### PR TITLE
Feature/mesh texture mapping

### DIFF
--- a/examples/graphics/meshTextureExample/CMakeLists.txt
+++ b/examples/graphics/meshTextureExample/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Default path (for TrussC repository)
+set(TRUSSC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../trussc")
+
+# Override with local config if exists
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.trussc")
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/.trussc" TRUSSC_DIR)
+    string(STRIP "${TRUSSC_DIR}" TRUSSC_DIR)
+endif()
+
+include(${TRUSSC_DIR}/cmake/trussc_app.cmake)
+
+trussc_app()
+

--- a/examples/graphics/meshTextureExample/CMakePresets.json
+++ b/examples/graphics/meshTextureExample/CMakePresets.json
@@ -1,0 +1,51 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "macos",
+      "displayName": "macOS",
+      "binaryDir": "${sourceDir}/build-macos",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "windows",
+      "displayName": "Windows",
+      "binaryDir": "${sourceDir}/build-windows",
+      "generator": "Visual Studio 17 2022"
+    },
+    {
+      "name": "linux",
+      "displayName": "Linux",
+      "binaryDir": "${sourceDir}/build-linux",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "web",
+      "displayName": "Web (Emscripten)",
+      "binaryDir": "${sourceDir}/build-web",
+      "generator": "Unix Makefiles",
+      "toolchainFile": "$env{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "macos",
+      "configurePreset": "macos",
+      "jobs": 4
+    },
+    {
+      "name": "windows",
+      "configurePreset": "windows"
+    },
+    {
+      "name": "linux",
+      "configurePreset": "linux",
+      "jobs": 4
+    },
+    {
+      "name": "web",
+      "configurePreset": "web",
+      "jobs": 4
+    }
+  ]
+}

--- a/examples/graphics/meshTextureExample/addons.make
+++ b/examples/graphics/meshTextureExample/addons.make
@@ -1,0 +1,2 @@
+# No addons required for this example
+

--- a/examples/graphics/meshTextureExample/src/main.cpp
+++ b/examples/graphics/meshTextureExample/src/main.cpp
@@ -1,0 +1,9 @@
+#include "tcApp.h"
+
+int main() {
+    WindowSettings settings;
+    settings.setSize(1280, 720);
+    settings.setTitle("Mesh Texture Mapping Example");
+    return runApp<tcApp>(settings);
+}
+

--- a/examples/graphics/meshTextureExample/src/tcApp.cpp
+++ b/examples/graphics/meshTextureExample/src/tcApp.cpp
@@ -1,0 +1,143 @@
+#include "tcApp.h"
+
+// ---------------------------------------------------------------------------
+// setup - Initialization
+// ---------------------------------------------------------------------------
+void tcApp::setup() {
+    tcLogNotice("tcApp") << "Mesh Texture Mapping Example";
+    tcLogNotice("tcApp") << "  - SPACE: Toggle texture";
+    tcLogNotice("tcApp") << "  - W: Toggle wireframe";
+    tcLogNotice("tcApp") << "  - ESC: Exit";
+    
+    // Create checkerboard texture
+    const int texSize = 256;
+    const int checkerSize = 32;
+    checkerTexture_.allocate(texSize, texSize, 4);
+    
+    for (int y = 0; y < texSize; y++) {
+        for (int x = 0; x < texSize; x++) {
+            int checkerX = x / checkerSize;
+            int checkerY = y / checkerSize;
+            bool isWhite = (checkerX + checkerY) % 2 == 0;
+            Color color = isWhite ? Color(1.0f, 1.0f, 1.0f, 1.0f) 
+                                  : Color(0.0f, 0.0f, 0.0f, 1.0f);
+            checkerTexture_.setColor(x, y, color);
+        }
+    }
+    // Note: update() will be called in draw() to ensure it's within a render pass
+    
+    // Create gradient texture
+    gradientTexture_.allocate(texSize, texSize, 4);
+    for (int y = 0; y < texSize; y++) {
+        for (int x = 0; x < texSize; x++) {
+            float u = (float)x / texSize;
+            float v = (float)y / texSize;
+            Color color = Color(u, v, 0.5f, 1.0f);
+            gradientTexture_.setColor(x, y, color);
+        }
+    }
+    // Note: update() will be called in draw() to ensure it's within a render pass
+    
+    // Create plane with texture coordinates
+    plane_ = createPlane(200, 200, 4, 4);
+    
+    // Create box with texture coordinates
+    box_ = createBox(150);
+    
+    // Create sphere with texture coordinates
+    sphere_ = createSphere(80, 16);
+}
+
+// ---------------------------------------------------------------------------
+// update - Update
+// ---------------------------------------------------------------------------
+void tcApp::update() {
+}
+
+// ---------------------------------------------------------------------------
+// draw - Drawing
+// ---------------------------------------------------------------------------
+void tcApp::draw() {
+    clear(0.1f, 0.1f, 0.12f);
+    
+    // Update textures on first draw (ensures it's called within a render pass)
+    static bool texturesUpdated = false;
+    if (!texturesUpdated) {
+        checkerTexture_.update();
+        gradientTexture_.update();
+        texturesUpdated = true;
+    }
+    
+    // Enable 3D drawing mode
+    enable3DPerspective(deg2rad(45.0f), 0.1f, 100.0f);
+    
+    float time = (float)getElapsedTime();
+    
+    // Camera rotation (like 3DPrimitivesExample)
+    float spinX = sin(time * 0.35f);
+    float spinY = cos(time * 0.075f);
+    
+    // Select texture
+    Image& currentTex = (currentTexture_ == 0) ? checkerTexture_ : gradientTexture_;
+    
+    // Draw plane (left, on ground)
+    pushMatrix();
+    translate(-3.0f, 0.0f, -8.0f);  // Left side, on ground level, in front of camera
+    rotateX(deg2rad(-90));  // Rotate to be horizontal (ground)
+    rotateY(spinX);
+    rotateX(spinY);
+    scale(0.01f, 0.01f, 0.01f);  // Scale down like 3DPrimitivesExample
+    if (showWireframe_) {
+        plane_.drawWireframe();
+    } else {
+        plane_.draw(currentTex);
+    }
+    popMatrix();
+    
+    // Draw box (center)
+    pushMatrix();
+    translate(0.0f, 1.5f, -8.0f);  // Center, above ground, in front of camera
+    rotateY(spinX);
+    rotateX(spinY);
+    scale(0.01f, 0.01f, 0.01f);
+    if (showWireframe_) {
+        box_.drawWireframe();
+    } else {
+        box_.draw(currentTex);
+    }
+    popMatrix();
+    
+    // Draw sphere (right)
+    pushMatrix();
+    translate(3.0f, 1.5f, -8.0f);  // Right side, above ground, in front of camera
+    rotateY(spinX);
+    rotateX(spinY);
+    scale(0.01f, 0.01f, 0.01f);
+    if (showWireframe_) {
+        sphere_.drawWireframe();
+    } else {
+        sphere_.draw(currentTex);
+    }
+    popMatrix();
+    
+    // Disable 3D mode
+    disable3D();
+    
+    // Draw info text
+    setColor(1.0f, 1.0f, 1.0f);
+    drawBitmapString("Mesh Texture Mapping Example", 10, 30);
+    drawBitmapString("SPACE: Toggle texture (" + string(currentTexture_ == 0 ? "Checker" : "Gradient") + ")", 10, 50);
+    drawBitmapString("W: Toggle wireframe (" + string(showWireframe_ ? "ON" : "OFF") + ")", 10, 70);
+}
+
+// ---------------------------------------------------------------------------
+// keyPressed
+// ---------------------------------------------------------------------------
+void tcApp::keyPressed(int key) {
+    if (key == ' ') {
+        currentTexture_ = (currentTexture_ + 1) % 2;
+    } else if (key == 'w' || key == 'W') {
+        showWireframe_ = !showWireframe_;
+    }
+}
+

--- a/examples/graphics/meshTextureExample/src/tcApp.h
+++ b/examples/graphics/meshTextureExample/src/tcApp.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <TrussC.h>
+using namespace std;
+using namespace tc;
+
+// =============================================================================
+// tcApp - Mesh Texture Mapping Example
+// Demonstrates texture mapping on Mesh using 3D primitives
+// =============================================================================
+
+class tcApp : public App {
+public:
+    // Lifecycle
+    void setup() override;
+    void update() override;
+    void draw() override;
+
+    // Input events
+    void keyPressed(int key) override;
+
+private:
+    // Meshes
+    Mesh plane_;
+    Mesh box_;
+    Mesh sphere_;
+    
+    // Textures
+    Image checkerTexture_;
+    Image gradientTexture_;
+    
+    // State
+    bool showWireframe_ = false;
+    int currentTexture_ = 0;  // 0: checker, 1: gradient
+};
+

--- a/trussc/include/TrussC.h
+++ b/trussc/include/TrussC.h
@@ -1974,23 +1974,23 @@ int runApp(const WindowSettings& settings = WindowSettings()) {
 #include "tc/3d/tcMaterial.h"
 #include "tc/3d/tcLight.h"
 
-// TrussC mesh
-#include "tc/graphics/tcMesh.h"
-
-// TrussC stroke mesh (thick line drawing)
-#include "tc/graphics/tcStrokeMesh.h"
-
 // TrussC pixel buffer
 #include "tc/graphics/tcPixels.h"
 
-// TrussC texture
+// TrussC texture (needed before tcMesh.h)
 #include "tc/gpu/tcTexture.h"
 
 // TrussC HasTexture interface
 #include "tc/gpu/tcHasTexture.h"
 
-// TrussC image
+// TrussC image (needed before tcMesh.h)
 #include "tc/graphics/tcImage.h"
+
+// TrussC mesh
+#include "tc/graphics/tcMesh.h"
+
+// TrussC stroke mesh (thick line drawing)
+#include "tc/graphics/tcStrokeMesh.h"
 #include "tc/graphics/tcFont.h"
 
 // TrussC FBO (offscreen rendering)

--- a/trussc/include/tc/3d/tcPrimitives.h
+++ b/trussc/include/tc/3d/tcPrimitives.h
@@ -54,40 +54,40 @@ inline Mesh createBox(float width, float height, float depth) {
 
     // 4 vertices per face (for flat shading)
     // Front face (Z+) - vertices 0-3
-    mesh.addVertex(-w, -h,  d); mesh.addNormal(0, 0, 1);
-    mesh.addVertex( w, -h,  d); mesh.addNormal(0, 0, 1);
-    mesh.addVertex( w,  h,  d); mesh.addNormal(0, 0, 1);
-    mesh.addVertex(-w,  h,  d); mesh.addNormal(0, 0, 1);
+    mesh.addVertex(-w, -h,  d); mesh.addNormal(0, 0, 1); mesh.addTexCoord(0, 1);
+    mesh.addVertex( w, -h,  d); mesh.addNormal(0, 0, 1); mesh.addTexCoord(1, 1);
+    mesh.addVertex( w,  h,  d); mesh.addNormal(0, 0, 1); mesh.addTexCoord(1, 0);
+    mesh.addVertex(-w,  h,  d); mesh.addNormal(0, 0, 1); mesh.addTexCoord(0, 0);
 
     // Back face (Z-) - vertices 4-7
-    mesh.addVertex( w, -h, -d); mesh.addNormal(0, 0, -1);
-    mesh.addVertex(-w, -h, -d); mesh.addNormal(0, 0, -1);
-    mesh.addVertex(-w,  h, -d); mesh.addNormal(0, 0, -1);
-    mesh.addVertex( w,  h, -d); mesh.addNormal(0, 0, -1);
+    mesh.addVertex( w, -h, -d); mesh.addNormal(0, 0, -1); mesh.addTexCoord(0, 1);
+    mesh.addVertex(-w, -h, -d); mesh.addNormal(0, 0, -1); mesh.addTexCoord(1, 1);
+    mesh.addVertex(-w,  h, -d); mesh.addNormal(0, 0, -1); mesh.addTexCoord(1, 0);
+    mesh.addVertex( w,  h, -d); mesh.addNormal(0, 0, -1); mesh.addTexCoord(0, 0);
 
     // Top face (Y+) - vertices 8-11
-    mesh.addVertex(-w,  h,  d); mesh.addNormal(0, 1, 0);
-    mesh.addVertex( w,  h,  d); mesh.addNormal(0, 1, 0);
-    mesh.addVertex( w,  h, -d); mesh.addNormal(0, 1, 0);
-    mesh.addVertex(-w,  h, -d); mesh.addNormal(0, 1, 0);
+    mesh.addVertex(-w,  h,  d); mesh.addNormal(0, 1, 0); mesh.addTexCoord(0, 1);
+    mesh.addVertex( w,  h,  d); mesh.addNormal(0, 1, 0); mesh.addTexCoord(1, 1);
+    mesh.addVertex( w,  h, -d); mesh.addNormal(0, 1, 0); mesh.addTexCoord(1, 0);
+    mesh.addVertex(-w,  h, -d); mesh.addNormal(0, 1, 0); mesh.addTexCoord(0, 0);
 
     // Bottom face (Y-) - vertices 12-15
-    mesh.addVertex(-w, -h, -d); mesh.addNormal(0, -1, 0);
-    mesh.addVertex( w, -h, -d); mesh.addNormal(0, -1, 0);
-    mesh.addVertex( w, -h,  d); mesh.addNormal(0, -1, 0);
-    mesh.addVertex(-w, -h,  d); mesh.addNormal(0, -1, 0);
+    mesh.addVertex(-w, -h, -d); mesh.addNormal(0, -1, 0); mesh.addTexCoord(0, 1);
+    mesh.addVertex( w, -h, -d); mesh.addNormal(0, -1, 0); mesh.addTexCoord(1, 1);
+    mesh.addVertex( w, -h,  d); mesh.addNormal(0, -1, 0); mesh.addTexCoord(1, 0);
+    mesh.addVertex(-w, -h,  d); mesh.addNormal(0, -1, 0); mesh.addTexCoord(0, 0);
 
     // Right face (X+) - vertices 16-19
-    mesh.addVertex( w, -h,  d); mesh.addNormal(1, 0, 0);
-    mesh.addVertex( w, -h, -d); mesh.addNormal(1, 0, 0);
-    mesh.addVertex( w,  h, -d); mesh.addNormal(1, 0, 0);
-    mesh.addVertex( w,  h,  d); mesh.addNormal(1, 0, 0);
+    mesh.addVertex( w, -h,  d); mesh.addNormal(1, 0, 0); mesh.addTexCoord(0, 1);
+    mesh.addVertex( w, -h, -d); mesh.addNormal(1, 0, 0); mesh.addTexCoord(1, 1);
+    mesh.addVertex( w,  h, -d); mesh.addNormal(1, 0, 0); mesh.addTexCoord(1, 0);
+    mesh.addVertex( w,  h,  d); mesh.addNormal(1, 0, 0); mesh.addTexCoord(0, 0);
 
     // Left face (X-) - vertices 20-23
-    mesh.addVertex(-w, -h, -d); mesh.addNormal(-1, 0, 0);
-    mesh.addVertex(-w, -h,  d); mesh.addNormal(-1, 0, 0);
-    mesh.addVertex(-w,  h,  d); mesh.addNormal(-1, 0, 0);
-    mesh.addVertex(-w,  h, -d); mesh.addNormal(-1, 0, 0);
+    mesh.addVertex(-w, -h, -d); mesh.addNormal(-1, 0, 0); mesh.addTexCoord(0, 1);
+    mesh.addVertex(-w, -h,  d); mesh.addNormal(-1, 0, 0); mesh.addTexCoord(1, 1);
+    mesh.addVertex(-w,  h,  d); mesh.addNormal(-1, 0, 0); mesh.addTexCoord(1, 0);
+    mesh.addVertex(-w,  h, -d); mesh.addNormal(-1, 0, 0); mesh.addTexCoord(0, 0);
 
     // Indices (2 triangles per face)
     for (int face = 0; face < 6; face++) {


### PR DESCRIPTION
Meshでテクスチャを書けるようにしてみました。
ふつうPRって「こんな風にしようと思ってますがどうでしょう？」みたいなのを経て出すものだと思ってはいるんですが、その方針がAIに聞くまで定まらず、聞くと一気に作っちゃえるのでいきなりPRになってしまいました。

修正も棄却もお気軽に！
下記、概要です。

## Meshクラスにテクスチャマッピング機能を追加

### 概要
Meshクラスにテクスチャマッピング機能を追加しました。`draw()`メソッドに`Texture`または`Image`を渡すことで、テクスチャを適用して描画できます。

### 変更内容

#### 1. インクルード順序の修正
- `TrussC.h`のインクルード順序を調整し、`tcTexture.h`と`tcImage.h`を`tcMesh.h`より前に配置
- 循環依存を解決

#### 2. Meshクラスへのテクスチャマッピング機能追加
- `Mesh::draw(const Texture& texture)` メソッドを追加
- `Mesh::draw(const Image& image)` メソッドを追加（便利メソッド）
- `hasValidTexCoords()` ヘルパーメソッドを追加
- `drawNoLightingWithTexture()` 内部実装を追加
- すべてのプリミティブモード（Triangles, TriangleStrip, TriangleFan, Lines, LineStrip, LineLoop, Points）に対応
- `sgl_v3f_t2f_c4f()` を使用して効率的な頂点送信を実現

#### 3. プリミティブ関数の更新
- `createBox()` にテクスチャ座標を追加（全6面）
- `createPlane()` と `createSphere()` は既にテクスチャ座標をサポート

#### 4. サンプルプロジェクトの追加
- `examples/graphics/meshTextureExample/` を追加
- Plane、Box、Sphereの3つのプリミティブでテクスチャマッピングをデモ
- チェッカーボードとグラデーションテクスチャの例を含む
- SPACEキーでテクスチャ切り替え、Wキーでワイヤフレーム表示の切り替え

### 使用例

// テクスチャを読み込む
Image texture;
texture.load("texture.png");

// Meshを作成（テクスチャ座標は自動的に設定される）
Mesh box = createBox(100);

// テクスチャを適用して描画
box.draw(texture);

### テスト
- `meshTextureExample` で動作確認済み
- チェッカーボードとグラデーションテクスチャが正常に表示されることを確認
- すべてのプリミティブモードでテクスチャマッピングが動作することを確認

### コミット履歴
- `fix: Fix include order in TrussC.h to resolve circular dependency`
- `feat: Add texture mapping support to Mesh class`
- `feat: Add texture coordinates to createBox() primitive`
- `feat: Add meshTextureExample demonstrating texture mapping`

### 関連
- tcxVboのexample-textureで得た知見を基に実装
- sokol_glを使用して既存のMesh描画システムと統合