### PR TITLE
add: Linux dependency install script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,29 +39,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-v2-
 
-      # Linux: Install dependencies
+      # Linux: Install dependencies using shared script
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libx11-dev \
-            libxcursor-dev \
-            libxi-dev \
-            libxrandr-dev \
-            libgl1-mesa-dev \
-            libasound2-dev \
-            libgtk-3-dev \
-            libavcodec-dev \
-            libavformat-dev \
-            libswscale-dev \
-            libavutil-dev \
-            libgstreamer1.0-dev \
-            libgstreamer-plugins-base1.0-dev \
-            gstreamer1.0-plugins-good \
-            gstreamer1.0-plugins-bad \
-            pkg-config \
-            libcurl4-openssl-dev
+          chmod +x projectGenerator/install_dependencies_linux.sh
+          ./projectGenerator/install_dependencies_linux.sh -y
 
       # Windows: Setup MSVC environment (provides cl.exe, ninja, etc. in PATH)
       - name: Setup MSVC (Windows)
@@ -125,13 +108,8 @@ jobs:
 
       - name: Install Linux dependencies (for ProjectGenerator)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libx11-dev libxcursor-dev libxi-dev libxrandr-dev libgl1-mesa-dev \
-            libasound2-dev libgtk-3-dev libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
-            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-            gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
-            pkg-config
+          chmod +x projectGenerator/install_dependencies_linux.sh
+          ./projectGenerator/install_dependencies_linux.sh -y
 
       - name: Build ProjectGenerator
         run: |

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -41,18 +41,19 @@ sudo apt install cmake
 
 ### Linux Dependencies
 
-Linux requires additional development packages:
+Linux requires additional development packages. A helper script is provided to check and install them:
 
 ```bash
-# Required: Core build dependencies
-sudo apt install build-essential libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libasound2-dev libgtk-3-dev pkg-config
-
-# Required: Video playback (FFmpeg)
-sudo apt install libavcodec-dev libavformat-dev libswscale-dev libavutil-dev
-
-# Required: AAC audio decoding (GStreamer)
-sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+./projectGenerator/install_dependencies_linux.sh
 ```
+
+This will list any missing packages and ask to install them. Use `-y` to skip the prompt:
+
+```bash
+./projectGenerator/install_dependencies_linux.sh -y
+```
+
+> **Note:** The build script (`buildProjectGenerator_linux.sh`) also runs this check automatically.
 
 ### Editor Setup
 
@@ -81,6 +82,8 @@ Build the project creation tool (first time only).
 **macOS:** Double-click `projectGenerator/buildProjectGenerator_mac.command`
 
 **Windows:** Double-click `projectGenerator/buildProjectGenerator_win.bat`
+
+**Linux:** Run `./projectGenerator/buildProjectGenerator_linux.sh` (dependencies are installed automatically)
 
 ---
 

--- a/docs/GET_STARTED_jp.md
+++ b/docs/GET_STARTED_jp.md
@@ -41,18 +41,19 @@ sudo apt install cmake
 
 ### Linux の依存パッケージ
 
-Linux では追加の開発パッケージが必要です:
+Linux では追加の開発パッケージが必要です。ヘルパースクリプトでチェック＆インストールできます:
 
 ```bash
-# 必須: コアビルド依存
-sudo apt install build-essential libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libasound2-dev libgtk-3-dev pkg-config
-
-# 必須: 動画再生 (FFmpeg)
-sudo apt install libavcodec-dev libavformat-dev libswscale-dev libavutil-dev
-
-# 必須: AAC 音声デコード (GStreamer)
-sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+./projectGenerator/install_dependencies_linux.sh
 ```
+
+不足パッケージを一覧表示し、インストールするか確認します。`-y` でプロンプトをスキップ:
+
+```bash
+./projectGenerator/install_dependencies_linux.sh -y
+```
+
+> **注意:** ビルドスクリプト（`buildProjectGenerator_linux.sh`）実行時にも自動でこのチェックが走ります。
 
 ### エディタのセットアップ
 
@@ -81,6 +82,8 @@ sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1
 **macOS:** `projectGenerator/buildProjectGenerator_mac.command` をダブルクリック
 
 **Windows:** `projectGenerator/buildProjectGenerator_win.bat` をダブルクリック
+
+**Linux:** `./projectGenerator/buildProjectGenerator_linux.sh` を実行（依存パッケージは自動でチェック・インストール）
 
 ---
 

--- a/projectGenerator/buildProjectGenerator_linux.sh
+++ b/projectGenerator/buildProjectGenerator_linux.sh
@@ -15,6 +15,14 @@ echo "  TrussC Project Generator Build Script"
 echo "=========================================="
 echo ""
 
+# Check and install dependencies
+"$SCRIPT_DIR/install_dependencies_linux.sh"
+if [ $? -ne 0 ]; then
+    echo "ERROR: Dependency check failed. Please install required packages."
+    exit 1
+fi
+echo ""
+
 # Source directory
 SOURCE_DIR="$SCRIPT_DIR/tools/projectGenerator"
 

--- a/projectGenerator/install_dependencies_linux.sh
+++ b/projectGenerator/install_dependencies_linux.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# =============================================================================
+# TrussC Linux Dependency Installer
+# =============================================================================
+# Checks for required packages and installs missing ones.
+# Usage:
+#   ./install_dependencies_linux.sh       # Interactive mode (asks before install)
+#   ./install_dependencies_linux.sh -y    # Auto-install without asking
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Required packages (keep in sync — this is the single source of truth)
+REQUIRED_PACKAGES=(
+    libx11-dev
+    libxcursor-dev
+    libxi-dev
+    libxrandr-dev
+    libgl1-mesa-dev
+    libasound2-dev
+    libgtk-3-dev
+    libavcodec-dev
+    libavformat-dev
+    libswscale-dev
+    libavutil-dev
+    libgstreamer1.0-dev
+    libgstreamer-plugins-base1.0-dev
+    gstreamer1.0-plugins-good
+    gstreamer1.0-plugins-bad
+    pkg-config
+    libcurl4-openssl-dev
+    cmake
+)
+
+AUTO_YES=false
+if [ "$1" = "-y" ]; then
+    AUTO_YES=true
+fi
+
+# Check which packages are missing
+MISSING=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    if ! dpkg -s "$pkg" &>/dev/null; then
+        MISSING+=("$pkg")
+    fi
+done
+
+if [ ${#MISSING[@]} -eq 0 ]; then
+    echo "All required packages are already installed."
+    exit 0
+fi
+
+echo "The following packages are missing:"
+echo ""
+for pkg in "${MISSING[@]}"; do
+    echo "  - $pkg"
+done
+echo ""
+
+if [ "$AUTO_YES" = true ]; then
+    echo "Installing (auto-yes mode)..."
+else
+    read -p "Install now? [Y/n] " answer
+    case "$answer" in
+        [nN]*)
+            echo "Skipped. You can install manually with:"
+            echo "  sudo apt-get install ${MISSING[*]}"
+            exit 1
+            ;;
+    esac
+fi
+
+sudo apt-get update
+sudo apt-get install -y "${MISSING[@]}"
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to install some packages."
+    exit 1
+fi
+
+echo "All dependencies installed successfully."


### PR DESCRIPTION
## Summary
- Add `install_dependencies_linux.sh` as a single source of truth for Linux package dependencies
- CI and local build scripts now use the same script instead of maintaining separate package lists
- GET_STARTED docs updated to reference the script and add Linux build instructions

## Test plan
- [ ] Linux CI passes (dependency install via script)
- [ ] macOS/Windows CI unaffected
- [ ] Web build CI passes (dependency install via script)