### PR TITLE
fix: Raspberry Pi support — modern detection, GLES3 backend, parallel builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Supports VSCode, Cursor, Xcode, and Visual Studio.
 # Build an example
 cd examples/graphics/graphicsExample
 cmake --preset macos      # or: windows, linux, web
-cmake --build build-macos
+cmake --build build-macos --parallel
 
 # Run (macOS)
 ./bin/graphicsExample.app/Contents/MacOS/graphicsExample

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -60,7 +60,7 @@ TrussC uses **CMake Presets** to ensure consistent build configurations across p
 **Native Build (macOS/Linux/Windows):**
 ```bash
 cmake --preset <os>   # e.g., macos, linux, windows
-cmake --build --preset <os>
+cmake --build --preset <os> --parallel
 ```
 
 **Web Build (WASM):**
@@ -74,7 +74,7 @@ Or manually using CMake:
 ```bash
 # Requires Emscripten SDK to be set up
 cmake --preset web
-cmake --build --preset web
+cmake --build --preset web --parallel
 ```
 
 ### Building All Examples
@@ -188,7 +188,7 @@ For most users, the default RelWithDebInfo is sufficient. If you need a full Deb
 
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Debug --preset macos
-cmake --build --preset macos
+cmake --build --preset macos --parallel
 ```
 
 > **Note:** Xcode and Visual Studio are multi-config generators and support switching between Debug/Release directly in the IDE without reconfiguring.

--- a/projectGenerator/buildProjectGenerator_linux.sh
+++ b/projectGenerator/buildProjectGenerator_linux.sh
@@ -48,10 +48,18 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Calculate parallel jobs based on available RAM (~1.5GiB per compile job)
+AVAIL_KB=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
+JOBS=$(awk "BEGIN { n = int($AVAIL_KB / 1572864); if (n < 1) n = 1; print n }")
+MAX_JOBS=$(( $(nproc) + 2 ))
+if [ "$JOBS" -gt "$MAX_JOBS" ]; then
+    JOBS=$MAX_JOBS
+fi
+
 # Build
 echo ""
-echo "Building..."
-cmake --build .
+echo "Building (parallel jobs: $JOBS)..."
+cmake --build . --parallel "$JOBS"
 if [ $? -ne 0 ]; then
     echo ""
     echo "ERROR: Build failed!"

--- a/projectGenerator/buildProjectGenerator_mac.command
+++ b/projectGenerator/buildProjectGenerator_mac.command
@@ -43,7 +43,7 @@ fi
 # Build
 echo ""
 echo "Building..."
-cmake --build .
+cmake --build . --parallel
 if [ $? -ne 0 ]; then
     echo ""
     echo "ERROR: Build failed!"

--- a/projectGenerator/buildProjectGenerator_win.bat
+++ b/projectGenerator/buildProjectGenerator_win.bat
@@ -44,7 +44,7 @@ if %ERRORLEVEL% neq 0 (
 REM Build
 echo.
 echo Building...
-cmake --build . --config Release
+cmake --build . --config Release --parallel
 if %ERRORLEVEL% neq 0 (
     echo.
     echo ERROR: Build failed!

--- a/projectGenerator/tools/projectGenerator/src/ProjectGenerator.cpp
+++ b/projectGenerator/tools/projectGenerator/src/ProjectGenerator.cpp
@@ -749,7 +749,7 @@ void ProjectGenerator::generateWebBuildFiles(const string& path) {
     file << "REM Configure and build using CMake presets\n";
     file << "cmake --preset web\n";
     file << "if errorlevel 1 exit /b 1\n\n";
-    file << "cmake --build --preset web\n";
+    file << "cmake --build --preset web --parallel\n";
     file << "if errorlevel 1 exit /b 1\n\n";
     file << "echo.\n";
     file << "echo Build complete! Output files are in bin\\\n";
@@ -775,7 +775,7 @@ void ProjectGenerator::generateWebBuildFiles(const string& path) {
     file << "fi\n\n";
     file << "# Configure and build using CMake presets\n";
     file << "cmake --preset web || exit 1\n";
-    file << "cmake --build --preset web || exit 1\n\n";
+    file << "cmake --build --preset web --parallel || exit 1\n\n";
     file << "echo \"\"\n";
     file << "echo \"Build complete! Output files are in bin/\"\n";
     file << "echo \"To test locally:\"\n";
@@ -801,7 +801,7 @@ void ProjectGenerator::generateWebBuildFiles(const string& path) {
     file << "fi\n\n";
     file << "# Configure and build using CMake presets\n";
     file << "cmake --preset web || exit 1\n";
-    file << "cmake --build --preset web || exit 1\n\n";
+    file << "cmake --build --preset web --parallel || exit 1\n\n";
     file << "echo \"\"\n";
     file << "echo \"Build complete! Output files are in bin/\"\n";
     file << "echo \"To test locally:\"\n";

--- a/projectGenerator/tools/projectGenerator/src/main.cpp
+++ b/projectGenerator/tools/projectGenerator/src/main.cpp
@@ -260,6 +260,18 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
+    #ifdef __linux__
+    const char* display = std::getenv("DISPLAY");
+    const char* wayland = std::getenv("WAYLAND_DISPLAY");
+    if ((!display || display[0] == '\0') && (!wayland || wayland[0] == '\0')) {
+        cerr << "Error: No display server found (DISPLAY and WAYLAND_DISPLAY are not set)." << endl;
+        cerr << "Please run this from a desktop environment (X11 or Wayland)." << endl;
+        cerr << "  - If using SSH, connect with: ssh -X user@host" << endl;
+        cerr << "  - For CLI usage, run with --help" << endl;
+        return 1;
+    }
+    #endif
+
     WindowSettings settings;
     settings.title = "TrussC Project Generator";
     settings.width = 500;

--- a/trussc/CMakeLists.txt
+++ b/trussc/CMakeLists.txt
@@ -35,10 +35,18 @@ elseif(WIN32)
     set(TC_GRAPHICS_BACKEND "D3D11")
     message(STATUS "[TrussC] Platform: Windows (D3D11)")
 elseif(UNIX)
-    if(EXISTS "/opt/vc/include/bcm_host.h")
+    # Raspberry Pi detection via Device Tree (works on all Pi OS versions)
+    set(_TC_IS_RASPI FALSE)
+    if(EXISTS "/proc/device-tree/model")
+        file(READ "/proc/device-tree/model" _TC_DEVICE_MODEL)
+        if(_TC_DEVICE_MODEL MATCHES "Raspberry Pi")
+            set(_TC_IS_RASPI TRUE)
+        endif()
+    endif()
+    if(_TC_IS_RASPI)
         set(TC_PLATFORM_RASPBIAN TRUE)
         set(TC_GRAPHICS_BACKEND "GLES3")
-        message(STATUS "[TrussC] Platform: Raspbian (GLES3)")
+        message(STATUS "[TrussC] Platform: Raspberry Pi (GLES3)")
     else()
         set(TC_PLATFORM_LINUX TRUE)
         set(TC_GRAPHICS_BACKEND "GLCORE")
@@ -69,7 +77,7 @@ elseif(TC_PLATFORM_MACOS)
     file(GLOB TC_PLATFORM_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/platform/mac/*.mm)
 elseif(TC_PLATFORM_WINDOWS)
     file(GLOB TC_PLATFORM_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/platform/win/*.cpp)
-elseif(TC_PLATFORM_LINUX)
+elseif(TC_PLATFORM_LINUX OR TC_PLATFORM_RASPBIAN)
     file(GLOB TC_PLATFORM_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/platform/linux/*.cpp)
 else()
     file(GLOB TC_PLATFORM_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/platform/linux/*.cpp)
@@ -177,12 +185,27 @@ elseif(TC_PLATFORM_LINUX)
 
 elseif(TC_PLATFORM_RASPBIAN)
     target_compile_definitions(TrussC PUBLIC SOKOL_GLES3)
-    target_include_directories(TrussC PUBLIC /opt/vc/include)
+    find_package(X11 REQUIRED)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+    pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libswscale libavutil)
+    pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-audio-1.0)
+    target_include_directories(TrussC PUBLIC
+        ${GTK3_INCLUDE_DIRS}
+        ${FFMPEG_INCLUDE_DIRS}
+        ${GSTREAMER_INCLUDE_DIRS}
+    )
     target_link_libraries(TrussC PUBLIC
+        ${X11_LIBRARIES}
+        ${X11_Xi_LIB}
+        ${X11_Xcursor_LIB}
         GLESv2
         EGL
-        bcm_host
+        ${GTK3_LIBRARIES}
+        ${FFMPEG_LIBRARIES}
+        ${GSTREAMER_LIBRARIES}
         pthread
+        dl
     )
 endif()
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                             
  - Replace legacy Pi detection (`/opt/vc/include/bcm_host.h`) with `/proc/device-tree/model` check (works on all Pi OS versions including 64-bit)                                                       
  - Use GLES3+EGL backend on Pi instead of GLCORE/GLX (which fails on Pi's Mesa V3D driver)                                                                                                              
  - Add RAM-based dynamic parallel job calculation for Linux build script (prevents OOM on memory-constrained devices)                                                                                   
  - Enable `--parallel` for all platform build scripts and documentation                                                                                                                                 
  - Show friendly error message on Linux when no display server is available instead of sokol panic
                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                           
  - [x] Build succeeds on Raspberry Pi 4 (aarch64, Debian 13 trixie)
  - [x] GUI launches via VNC (Raspberry Pi Connect) with Wayland/labwc                                                                                                                                   
  - [x] Friendly error message shown when DISPLAY is not set (SSH without X forwarding)
  - [ ] Verify GLCORE backend still works on regular Linux desktop   