### PR TITLE
feat: trussc-api.js generation, type mappings, missing API docs

### DIFF
--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -46,6 +46,26 @@ categories:
         sketch: true
         snippet: "void draw() {\n\t$0\n}"
 
+      - name: cleanup
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Called once before exit (optional user callback for cleanup)"
+        description_ja: "終了前に一度呼ばれる（オプショナルなクリーンアップコールバック）"
+        sketch: false
+        snippet: "void cleanup() {\n\t$0\n}"
+
+      - name: runApp
+        return: "int"
+        signatures:
+          - params: "const WindowSettings& settings = WindowSettings()"
+            params_simple: "settings"
+        description: "Start the application main loop. Called from main()"
+        description_ja: "アプリケーションのメインループを開始。main()から呼ぶ"
+        sketch: false
+        snippet: "runApp(${1:settings})"
+
   # ==========================================================================
   # Events
   # ==========================================================================
@@ -460,6 +480,27 @@ categories:
         sketch: true
         snippet: "drawBitmapString(${1:\"text\"}, ${2:x}, ${3:y})"
 
+      - name: drawBitmapStringHighlight
+        return: "void"
+        signatures:
+          - params: "const string& text, float x, float y, const Color& background = Color(0,0,0), const Color& foreground = Color(1,1,1)"
+            params_simple: "text, x, y, background, foreground"
+        description: "Draw text with background highlight"
+        description_ja: "背景ハイライト付きでテキストを描画"
+        of_equivalent: "ofDrawBitmapStringHighlight"
+        sketch: false
+        snippet: "drawBitmapStringHighlight(${1:\"text\"}, ${2:x}, ${3:y})"
+
+      - name: getBitmapStringBounds
+        return: "void"
+        signatures:
+          - params: "const string& text, float& width, float& height"
+            params_simple: "text, width, height"
+        description: "Get bitmap string bounding box size"
+        description_ja: "ビットマップ文字列のバウンディングボックスサイズを取得"
+        sketch: false
+        snippet: "getBitmapStringBounds(${1:\"text\"}, ${2:w}, ${3:h})"
+
       - name: setTextAlign
         return: "void"
         signatures:
@@ -735,6 +776,115 @@ categories:
         description_ja: "現在の塗りつぶし色を取得"
         sketch: true
         snippet: "getColor()"
+
+      # --- Scissor ---
+
+      - name: setScissor
+        return: "void"
+        signatures:
+          - params: "float x, float y, float w, float h"
+            params_simple: "x, y, w, h"
+        description: "Set scissor clipping rectangle. Also available via RectNode::setClipping(true)"
+        description_ja: "シザー（クリッピング）矩形を設定。RectNode::setClipping(true)でも使用可"
+        sketch: false
+        snippet: "setScissor(${1:x}, ${2:y}, ${3:w}, ${4:h})"
+
+      - name: resetScissor
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Reset (disable) scissor clipping"
+        description_ja: "シザー（クリッピング）を解除"
+        sketch: false
+        snippet: "resetScissor()"
+
+      - name: pushScissor
+        return: "void"
+        signatures:
+          - params: "float x, float y, float w, float h"
+            params_simple: "x, y, w, h"
+        description: "Push scissor clipping rectangle onto stack"
+        description_ja: "シザー矩形をスタックにプッシュ"
+        sketch: false
+        snippet: "pushScissor(${1:x}, ${2:y}, ${3:w}, ${4:h})"
+
+      - name: popScissor
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Pop scissor clipping rectangle from stack"
+        description_ja: "シザー矩形をスタックからポップ"
+        sketch: false
+        snippet: "popScissor()"
+
+      # --- Blend Mode ---
+
+      - name: setBlendMode
+        return: "void"
+        signatures:
+          - params: "BlendMode mode"
+            params_simple: "mode"
+        description: "Set blend mode. BlendMode::Alpha (default), Add, Multiply, Screen, Subtract, Disabled"
+        description_ja: "ブレンドモードを設定。BlendMode::Alpha（デフォルト）, Add, Multiply, Screen, Subtract, Disabled"
+        of_equivalent: "ofEnableBlendMode"
+        sketch: false
+        snippet: "setBlendMode(${1:BlendMode::Add})"
+
+      - name: getBlendMode
+        return: "BlendMode"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get current blend mode"
+        description_ja: "現在のブレンドモードを取得"
+        sketch: false
+        snippet: "getBlendMode()"
+
+      - name: resetBlendMode
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Reset blend mode to Alpha (default)"
+        description_ja: "ブレンドモードをAlpha（デフォルト）にリセット"
+        sketch: false
+        snippet: "resetBlendMode()"
+
+      # --- Style Stack ---
+
+      - name: pushStyle
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Push current style (color, fill, stroke, blend) onto stack"
+        description_ja: "現在のスタイル（色、塗り、ストローク、ブレンド）をスタックにプッシュ"
+        of_equivalent: "ofPushStyle"
+        sketch: false
+        snippet: "pushStyle()"
+
+      - name: popStyle
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Pop style from stack, restoring previous state"
+        description_ja: "スタイルをスタックからポップし、前の状態を復元"
+        of_equivalent: "ofPopStyle"
+        sketch: false
+        snippet: "popStyle()"
+
+      - name: resetStyle
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Reset all style settings to defaults"
+        description_ja: "全スタイル設定をデフォルトにリセット"
+        sketch: false
+        snippet: "resetStyle()"
 
   # ==========================================================================
   # Transform
@@ -1090,6 +1240,76 @@ categories:
         sketch: true
         snippet: "getGlobalMousePos()"
 
+      - name: getGlobalMouseX
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get global mouse X (screen coordinates, not window-relative)"
+        description_ja: "グローバルマウスX座標（スクリーン座標、ウィンドウ相対ではない）"
+        sketch: false
+        snippet: "getGlobalMouseX()"
+
+      - name: getGlobalMouseY
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get global mouse Y (screen coordinates, not window-relative)"
+        description_ja: "グローバルマウスY座標（スクリーン座標、ウィンドウ相対ではない）"
+        sketch: false
+        snippet: "getGlobalMouseY()"
+
+      - name: getGlobalPMouseX
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get previous frame global mouse X"
+        description_ja: "前フレームのグローバルマウスX座標"
+        sketch: false
+        snippet: "getGlobalPMouseX()"
+
+      - name: getGlobalPMouseY
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get previous frame global mouse Y"
+        description_ja: "前フレームのグローバルマウスY座標"
+        sketch: false
+        snippet: "getGlobalPMouseY()"
+
+      - name: getMouseButton
+        return: "int"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get currently pressed mouse button"
+        description_ja: "現在押されているマウスボタンを取得"
+        sketch: false
+        snippet: "getMouseButton()"
+
+      - name: setTouchAsMouse
+        return: "void"
+        signatures:
+          - params: "bool enabled"
+            params_simple: "enabled"
+        description: "Enable/disable touch events firing as mouse events (for Android/iOS)"
+        description_ja: "タッチイベントをマウスイベントとして発火させるか設定（Android/iOS用）"
+        sketch: false
+        snippet: "setTouchAsMouse(${1:true})"
+
+      - name: getTouchAsMouse
+        return: "bool"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get touchAsMouse state"
+        description_ja: "touchAsMouseの状態を取得"
+        sketch: false
+        snippet: "getTouchAsMouse()"
+
       - name: isMousePressed
         return: "bool"
         signatures:
@@ -1207,6 +1427,16 @@ categories:
         sketch: true
         snippet: "getFrameRate()"
 
+      - name: getFps
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get current FPS (alias for getFrameRate)"
+        description_ja: "現在のFPSを取得（getFrameRateのエイリアス）"
+        sketch: false
+        snippet: "getFps()"
+
       - name: getFrameCount
         return: "uint64_t"
         signatures:
@@ -1251,6 +1481,46 @@ categories:
         description_ja: "sokol_glのバッファを解放（次の描画時に自動再確保）"
         sketch: true
         snippet: "releaseSglBuffers()"
+
+      - name: getMemoryUsage
+        return: "size_t"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get process memory usage in bytes (platform-specific)"
+        description_ja: "プロセスのメモリ使用量をバイトで取得（プラットフォーム固有）"
+        sketch: false
+        snippet: "getMemoryUsage()"
+
+      - name: getFboCount
+        return: "size_t"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get number of active FBO objects"
+        description_ja: "アクティブなFBOオブジェクト数を取得"
+        sketch: false
+        snippet: "getFboCount()"
+
+      - name: getTextureCount
+        return: "size_t"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get number of active Texture objects"
+        description_ja: "アクティブなTextureオブジェクト数を取得"
+        sketch: false
+        snippet: "getTextureCount()"
+
+      - name: getNodeCount
+        return: "size_t"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get number of active Node objects in scene graph"
+        description_ja: "シーングラフ内のアクティブなNodeオブジェクト数を取得"
+        sketch: false
+        snippet: "getNodeCount()"
 
   # ==========================================================================
   # Time - Elapsed
@@ -1945,6 +2215,108 @@ categories:
         sketch: true
         snippet: "getClipboardString()"
 
+      - name: getDpiScale
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get display DPI scale factor (e.g. 2.0 for Retina)"
+        description_ja: "ディスプレイのDPIスケール係数を取得（Retinaなら2.0等）"
+        sketch: false
+        snippet: "getDpiScale()"
+
+      - name: getFramebufferWidth
+        return: "int"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get framebuffer width in pixels (window width * DPI scale)"
+        description_ja: "フレームバッファ幅をピクセルで取得（ウィンドウ幅 × DPIスケール）"
+        sketch: false
+        snippet: "getFramebufferWidth()"
+
+      - name: getFramebufferHeight
+        return: "int"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get framebuffer height in pixels (window height * DPI scale)"
+        description_ja: "フレームバッファ高さをピクセルで取得（ウィンドウ高さ × DPIスケール）"
+        sketch: false
+        snippet: "getFramebufferHeight()"
+
+      - name: getAspectRatio
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get window aspect ratio (width / height)"
+        description_ja: "ウィンドウのアスペクト比を取得（幅 / 高さ）"
+        sketch: false
+        snippet: "getAspectRatio()"
+
+      - name: setOrientation
+        return: "void"
+        signatures:
+          - params: "Orientation mask"
+            params_simple: "mask"
+        description: "Set allowed screen orientations (mobile). Values: Orientation::Portrait, Landscape, All"
+        description_ja: "画面の向きを設定（モバイル用）。Orientation::Portrait, Landscape, All"
+        sketch: false
+        snippet: "setOrientation(${1:Orientation::All})"
+
+      - name: setIndependentFps
+        return: "void"
+        signatures:
+          - params: "float updateFps, float drawFps"
+            params_simple: "updateFps, drawFps"
+        description: "Set independent update and draw frame rates"
+        description_ja: "updateとdrawのフレームレートを個別に設定"
+        sketch: false
+        snippet: "setIndependentFps(${1:60}, ${2:30})"
+
+      - name: grabScreen
+        return: "bool"
+        signatures:
+          - params: "Pixels& outPixels"
+            params_simple: "outPixels"
+        description: "Capture current screen to Pixels"
+        description_ja: "現在の画面をPixelsにキャプチャ"
+        sketch: false
+        snippet: "grabScreen(${1:pixels})"
+
+      - name: isFullscreen
+        return: "bool"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Check if window is fullscreen"
+        description_ja: "フルスクリーンかどうか確認"
+        of_equivalent: "ofGetWindowMode"
+        sketch: true
+        snippet: "isFullscreen()"
+
+      - name: setFullscreen
+        return: "void"
+        signatures:
+          - params: "bool fullscreen"
+            params_simple: "fullscreen"
+        description: "Set fullscreen mode"
+        description_ja: "フルスクリーンを設定"
+        of_equivalent: "ofSetFullscreen"
+        sketch: true
+        snippet: "setFullscreen(${1:true})"
+
+      - name: redraw
+        return: "void"
+        signatures:
+          - params: "int count = 1"
+            params_simple: "count"
+        description: "Request extra redraws (useful for event-driven rendering)"
+        description_ja: "追加の再描画を要求（イベント駆動レンダリング用）"
+        sketch: false
+        snippet: "redraw()"
+
   # ==========================================================================
   # Utility
   # ==========================================================================
@@ -2062,6 +2434,16 @@ categories:
         of_equivalent: "ofToUpper"
         sketch: true
         snippet: "toUpper(${1:str})"
+
+      - name: intersectRect
+        return: "void"
+        signatures:
+          - params: "float x1, float y1, float w1, float h1, float x2, float y2, float w2, float h2, float& ox, float& oy, float& ow, float& oh"
+            params_simple: "x1, y1, w1, h1, x2, y2, w2, h2, ox, oy, ow, oh"
+        description: "Compute intersection of two rectangles"
+        description_ja: "2つの矩形の交差部分を計算"
+        sketch: false
+        snippet: "intersectRect(${1:x1}, ${2:y1}, ${3:w1}, ${4:h1}, ${5:x2}, ${6:y2}, ${7:w2}, ${8:h2}, ${9:ox}, ${10:oy}, ${11:ow}, ${12:oh})"
 
   # ==========================================================================
   # File
@@ -3670,6 +4052,26 @@ categories:
         description_ja: "遠クリップ面を設定"
         sketch: true
         snippet: "setFarClip(${1:10000})"
+
+      - name: getNearClip
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get near clipping plane distance"
+        description_ja: "近クリップ面の距離を取得"
+        sketch: false
+        snippet: "getNearClip()"
+
+      - name: getFarClip
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get far clipping plane distance"
+        description_ja: "遠クリップ面の距離を取得"
+        sketch: false
+        snippet: "getFarClip()"
 
       - name: enableMouseInput
         return: "void"

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -8,8 +8,6 @@
 #   - TrussC_vs_openFrameworks.md mapping (future)
 #   - for-of-users.html tables (future)
 
-version: "0.0.2"
-
 categories:
   # ==========================================================================
   # Lifecycle

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -144,6 +144,7 @@ categories:
         description: "Clear screen. No args = transparent black (0,0,0,0)"
         description_ja: "画面をクリア。引数なし = 透明黒 (0,0,0,0)"
         of_equivalent: "ofClear / ofBackground"
+        of_signature_index: 1
         sketch: true
         snippet: "clear(${1:0.0})"
 
@@ -1545,6 +1546,19 @@ categories:
     name: "Math - Interpolation"
     name_ja: "数学 - 補間"
     functions:
+      - name: lerp
+        return: "float"
+        signatures:
+          - params: "float a, float b, float t"
+            params_simple: "a, b, t"
+        description: "Linear interpolation"
+        description_ja: "線形補間"
+        of_equivalent: "ofLerp"
+        of_notes: "std::lerp (C++20)"
+        of_notes_ja: "std::lerp (C++20)"
+        sketch: false
+        snippet: "lerp(${1:a}, ${2:b}, ${3:t})"
+
       - name: clamp
         return: "float"
         signatures:
@@ -5215,8 +5229,11 @@ keywords:
 # ==========================================================================
 types:
   - name: Vec2
-    description: "2D vector"
-    description_ja: "2Dベクトル"
+    description: "2D vector (x, y)"
+    description_ja: "2Dベクトル (x, y)"
+    description_ko: "2D 벡터 (x, y)"
+    of_equivalent: "glm::vec2 / ofVec2f"
+    of_type_category: "math-vector"
     sketch: true
     constructor:
       signatures:
@@ -5359,8 +5376,11 @@ types:
         snippet: "Vec2_fromAngle(${1:radians})"
 
   - name: Vec3
-    description: "3D vector"
-    description_ja: "3Dベクトル"
+    description: "3D vector (x, y, z)"
+    description_ja: "3Dベクトル (x, y, z)"
+    description_ko: "3D 벡터 (x, y, z)"
+    of_equivalent: "glm::vec3 / ofVec3f"
+    of_type_category: "math-vector"
     sketch: true
     constructor:
       signatures:
@@ -5476,8 +5496,11 @@ types:
         snippet: "xy()"
 
   - name: Color
-    description: "RGBA color (0.0-1.0)"
-    description_ja: "RGBAカラー (0.0-1.0)"
+    description: "RGBA color (0.0-1.0 range)"
+    description_ja: "RGBAカラー (0.0-1.0範囲)"
+    description_ko: "RGBA 색상 (0.0-1.0 범위)"
+    of_equivalent: "ofColor / ofFloatColor"
+    of_type_category: "color-types"
     sketch: true
     constructor:
       signatures:
@@ -5586,6 +5609,9 @@ types:
   - name: Rect
     description: "Rectangle (x, y, width, height)"
     description_ja: "矩形 (x, y, width, height)"
+    description_ko: "사각형 (x, y, width, height)"
+    of_equivalent: "ofRectangle"
+    of_type_category: "geometry-types"
     sketch: true
     constructor:
       signatures:
@@ -5663,6 +5689,9 @@ types:
   - name: Mat4
     description: "4x4 matrix for 3D transformations"
     description_ja: "3D変換用4x4行列"
+    description_ko: "3D 변환용 4x4 행렬"
+    of_equivalent: "glm::mat4 / ofMatrix4x4"
+    of_type_category: "math-vector"
     sketch: true
     constructor:
       signatures:
@@ -5687,6 +5716,9 @@ types:
   - name: Quaternion
     description: "Unit quaternion for 3D rotations"
     description_ja: "3D回転用単位クォータニオン"
+    description_ko: "3D 회전용 단위 쿼터니언"
+    of_equivalent: "glm::quat / ofQuaternion"
+    of_type_category: "math-vector"
     sketch: true
     constructor:
       signatures:
@@ -5757,6 +5789,9 @@ types:
   - name: Pixels
     description: "Pixel buffer for image manipulation"
     description_ja: "画像操作用ピクセルバッファ"
+    description_ko: "이미지 조작용 픽셀 버퍼"
+    of_equivalent: "ofPixels"
+    of_type_category: "image-texture-types"
     sketch: true
     constructor:
       signatures:
@@ -5880,6 +5915,9 @@ types:
   - name: Image
     description: "Image with CPU pixels and GPU texture"
     description_ja: "CPUピクセルとGPUテクスチャを持つ画像"
+    description_ko: "CPU 픽셀과 GPU 텍스처를 가진 이미지"
+    of_equivalent: "ofImage"
+    of_type_category: "image-texture-types"
     sketch: true
     static_methods:
       - name: createImage
@@ -6022,6 +6060,9 @@ types:
   - name: Texture
     description: "GPU texture for rendering"
     description_ja: "レンダリング用GPUテクスチャ"
+    description_ko: "렌더링용 GPU 텍스처"
+    of_equivalent: "ofTexture"
+    of_type_category: "image-texture-types"
     sketch: true
     constructor:
       signatures:
@@ -6209,7 +6250,10 @@ types:
 
   - name: Fbo
     description: "Framebuffer object for offscreen rendering"
-    description_ja: "オフスクリーンレンダリング用フレームバッファ"
+    description_ja: "オフスクリーンレンダリング用FBO"
+    description_ko: "오프스크린 렌더링용 프레임버퍼 객체"
+    of_equivalent: "ofFbo"
+    of_type_category: "image-texture-types"
     sketch: true
     constructor:
       signatures:
@@ -6315,9 +6359,163 @@ types:
         description_ja: "FBOの内容をImageにコピー"
         snippet: "copyTo(${1:image})"
 
+  - name: Path
+    description: "Path/Polyline for lines and curves"
+    description_ja: "線と曲線のパス/ポリライン"
+    description_ko: "선과 곡선을 위한 경로/폴리라인"
+    of_equivalent: "ofPath / ofPolyline"
+    of_type_category: "geometry-types"
+    sketch: true
+    constructor:
+      signatures:
+        - params: ""
+        - params: "vector<Vec2> verts"
+        - params: "vector<Vec3> verts"
+      snippet: "Path()"
+    methods:
+      - name: addVertex
+        return: "void"
+        signatures:
+          - params: "float x, float y"
+          - params: "float x, float y, float z"
+          - params: "Vec2 v"
+          - params: "Vec3 v"
+        description: "Add a vertex"
+        description_ja: "頂点を追加"
+        snippet: "addVertex(${1:x}, ${2:y})"
+      - name: addVertices
+        return: "Path@"
+        signatures:
+          - params: "array<Vec3>@ verts"
+            params_simple: "verts"
+          - params: "array<Vec2>@ verts"
+            params_simple: "verts"
+        description: "Add multiple vertices"
+        description_ja: "複数の頂点を追加"
+        snippet: "addVertices(${1:verts})"
+      - name: getVertices
+        sketch: false
+        return: "vector<Vec3>"
+        signatures:
+          - params: ""
+        description: "Get all vertices"
+        description_ja: "全頂点を取得"
+        snippet: "getVertices()"
+      - name: size
+        return: int
+        signatures:
+          - params: ""
+        description: "Get vertex count"
+        description_ja: "頂点数を取得"
+        snippet: "size()"
+      - name: empty
+        return: bool
+        signatures:
+          - params: ""
+        description: "Check if polyline is empty"
+        description_ja: "ポリラインが空か確認"
+        snippet: "empty()"
+      - name: clear
+        return: "void"
+        signatures:
+          - params: ""
+        description: "Clear all vertices"
+        description_ja: "全頂点をクリア"
+        snippet: "clear()"
+      - name: lineTo
+        return: "void"
+        signatures:
+          - params: "float x, float y"
+          - params: "float x, float y, float z"
+          - params: "Vec2 p"
+          - params: "Vec3 p"
+        description: "Add line segment to point"
+        description_ja: "点まで線を追加"
+        snippet: "lineTo(${1:x}, ${2:y})"
+      - name: bezierTo
+        return: "void"
+        signatures:
+          - params: "float cx1, float cy1, float cx2, float cy2, float x, float y"
+          - params: "Vec2 cp1, Vec2 cp2, Vec2 to"
+          - params: "Vec3 cp1, Vec3 cp2, Vec3 to"
+        description: "Add cubic bezier curve"
+        description_ja: "3次ベジェ曲線を追加"
+        snippet: "bezierTo(${1:cx1}, ${2:cy1}, ${3:cx2}, ${4:cy2}, ${5:x}, ${6:y})"
+      - name: quadBezierTo
+        return: "void"
+        signatures:
+          - params: "float cx, float cy, float x, float y"
+          - params: "Vec2 cp, Vec2 to"
+          - params: "Vec3 cp, Vec3 to"
+        description: "Add quadratic bezier curve"
+        description_ja: "2次ベジェ曲線を追加"
+        snippet: "quadBezierTo(${1:cx}, ${2:cy}, ${3:x}, ${4:y})"
+      - name: curveTo
+        return: "void"
+        signatures:
+          - params: "float x, float y"
+          - params: "Vec2 to"
+          - params: "Vec3 to"
+        description: "Add Catmull-Rom curve segment"
+        description_ja: "Catmull-Rom曲線を追加"
+        snippet: "curveTo(${1:x}, ${2:y})"
+      - name: arc
+        return: "void"
+        signatures:
+          - params: "float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd"
+          - params: "Vec2 center, float radiusX, float radiusY, float angleBegin, float angleEnd"
+        description: "Add an arc"
+        description_ja: "円弧を追加"
+        snippet: "arc(${1:x}, ${2:y}, ${3:radiusX}, ${4:radiusY}, ${5:0}, ${6:360})"
+      - name: close
+        return: "void"
+        signatures:
+          - params: ""
+        description: "Close the path"
+        description_ja: "パスを閉じる"
+        snippet: "close()"
+      - name: setClosed
+        return: "void"
+        signatures:
+          - params: "bool closed"
+        description: "Set closed state"
+        description_ja: "閉じた状態を設定"
+        snippet: "setClosed(${1:true})"
+      - name: isClosed
+        return: bool
+        signatures:
+          - params: ""
+        description: "Check if path is closed"
+        description_ja: "パスが閉じているか確認"
+        snippet: "isClosed()"
+      - name: draw
+        return: "void"
+        signatures:
+          - params: ""
+        description: "Draw the polyline"
+        description_ja: "ポリラインを描画"
+        snippet: "draw()"
+      - name: getBounds
+        return: "Rect"
+        signatures:
+          - params: ""
+        description: "Get bounding box as Rect"
+        description_ja: "バウンディングボックスをRectで取得"
+        snippet: "getBounds()"
+      - name: getPerimeter
+        return: float
+        signatures:
+          - params: ""
+        description: "Get total path length"
+        description_ja: "パスの全長を取得"
+        snippet: "getPerimeter()"
+
   - name: Mesh
-    description: "3D mesh with vertices, colors, normals, and indices"
-    description_ja: "頂点、色、法線、インデックスを持つ3Dメッシュ"
+    description: "3D mesh with vertices, colors, normals, indices"
+    description_ja: "頂点・色・法線・インデックスを持つ3Dメッシュ"
+    description_ko: "정점, 색상, 노멀, 인덱스를 가진 3D 메쉬"
+    of_equivalent: "ofMesh"
+    of_type_category: "geometry-types"
     sketch: true
     constructor:
       signatures:
@@ -6664,157 +6862,12 @@ types:
         description_ja: "ワイヤーフレームで描画"
         snippet: "drawWireframe()"
 
-  - name: Path
-    description: "Path/Polyline for drawing lines and curves"
-    description_ja: "線や曲線を描画するためのパス/ポリライン"
-    sketch: true
-    constructor:
-      signatures:
-        - params: ""
-        - params: "vector<Vec2> verts"
-        - params: "vector<Vec3> verts"
-      snippet: "Path()"
-    methods:
-      - name: addVertex
-        return: "void"
-        signatures:
-          - params: "float x, float y"
-          - params: "float x, float y, float z"
-          - params: "Vec2 v"
-          - params: "Vec3 v"
-        description: "Add a vertex"
-        description_ja: "頂点を追加"
-        snippet: "addVertex(${1:x}, ${2:y})"
-      - name: addVertices
-        return: "Path@"
-        signatures:
-          - params: "array<Vec3>@ verts"
-            params_simple: "verts"
-          - params: "array<Vec2>@ verts"
-            params_simple: "verts"
-        description: "Add multiple vertices"
-        description_ja: "複数の頂点を追加"
-        snippet: "addVertices(${1:verts})"
-      - name: getVertices
-        sketch: false
-        return: "vector<Vec3>"
-        signatures:
-          - params: ""
-        description: "Get all vertices"
-        description_ja: "全頂点を取得"
-        snippet: "getVertices()"
-      - name: size
-        return: int
-        signatures:
-          - params: ""
-        description: "Get vertex count"
-        description_ja: "頂点数を取得"
-        snippet: "size()"
-      - name: empty
-        return: bool
-        signatures:
-          - params: ""
-        description: "Check if polyline is empty"
-        description_ja: "ポリラインが空か確認"
-        snippet: "empty()"
-      - name: clear
-        return: "void"
-        signatures:
-          - params: ""
-        description: "Clear all vertices"
-        description_ja: "全頂点をクリア"
-        snippet: "clear()"
-      - name: lineTo
-        return: "void"
-        signatures:
-          - params: "float x, float y"
-          - params: "float x, float y, float z"
-          - params: "Vec2 p"
-          - params: "Vec3 p"
-        description: "Add line segment to point"
-        description_ja: "点まで線を追加"
-        snippet: "lineTo(${1:x}, ${2:y})"
-      - name: bezierTo
-        return: "void"
-        signatures:
-          - params: "float cx1, float cy1, float cx2, float cy2, float x, float y"
-          - params: "Vec2 cp1, Vec2 cp2, Vec2 to"
-          - params: "Vec3 cp1, Vec3 cp2, Vec3 to"
-        description: "Add cubic bezier curve"
-        description_ja: "3次ベジェ曲線を追加"
-        snippet: "bezierTo(${1:cx1}, ${2:cy1}, ${3:cx2}, ${4:cy2}, ${5:x}, ${6:y})"
-      - name: quadBezierTo
-        return: "void"
-        signatures:
-          - params: "float cx, float cy, float x, float y"
-          - params: "Vec2 cp, Vec2 to"
-          - params: "Vec3 cp, Vec3 to"
-        description: "Add quadratic bezier curve"
-        description_ja: "2次ベジェ曲線を追加"
-        snippet: "quadBezierTo(${1:cx}, ${2:cy}, ${3:x}, ${4:y})"
-      - name: curveTo
-        return: "void"
-        signatures:
-          - params: "float x, float y"
-          - params: "Vec2 to"
-          - params: "Vec3 to"
-        description: "Add Catmull-Rom curve segment"
-        description_ja: "Catmull-Rom曲線を追加"
-        snippet: "curveTo(${1:x}, ${2:y})"
-      - name: arc
-        return: "void"
-        signatures:
-          - params: "float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd"
-          - params: "Vec2 center, float radiusX, float radiusY, float angleBegin, float angleEnd"
-        description: "Add an arc"
-        description_ja: "円弧を追加"
-        snippet: "arc(${1:x}, ${2:y}, ${3:radiusX}, ${4:radiusY}, ${5:0}, ${6:360})"
-      - name: close
-        return: "void"
-        signatures:
-          - params: ""
-        description: "Close the path"
-        description_ja: "パスを閉じる"
-        snippet: "close()"
-      - name: setClosed
-        return: "void"
-        signatures:
-          - params: "bool closed"
-        description: "Set closed state"
-        description_ja: "閉じた状態を設定"
-        snippet: "setClosed(${1:true})"
-      - name: isClosed
-        return: bool
-        signatures:
-          - params: ""
-        description: "Check if path is closed"
-        description_ja: "パスが閉じているか確認"
-        snippet: "isClosed()"
-      - name: draw
-        return: "void"
-        signatures:
-          - params: ""
-        description: "Draw the polyline"
-        description_ja: "ポリラインを描画"
-        snippet: "draw()"
-      - name: getBounds
-        return: "Rect"
-        signatures:
-          - params: ""
-        description: "Get bounding box as Rect"
-        description_ja: "バウンディングボックスをRectで取得"
-        snippet: "getBounds()"
-      - name: getPerimeter
-        return: float
-        signatures:
-          - params: ""
-        description: "Get total path length"
-        description_ja: "パスの全長を取得"
-        snippet: "getPerimeter()"
-
   - name: Sound
     description: "Audio playback"
-    description_ja: "音声再生"
+    description_ja: "オーディオ再生"
+    description_ko: "오디오 재생"
+    of_equivalent: "ofSoundPlayer"
+    of_type_category: "audio-types"
     sketch: true
     constructor:
       signatures:
@@ -6943,7 +6996,10 @@ types:
 
   - name: Font
     description: "TrueType font for text rendering"
-    description_ja: "テキスト描画用TrueTypeフォント"
+    description_ja: "テキストレンダリング用TrueTypeフォント"
+    description_ko: "텍스트 렌더링용 트루타입 폰트"
+    of_equivalent: "ofTrueTypeFont"
+    of_type_category: "text-types"
     sketch: true
     constructor:
       signatures:
@@ -7035,6 +7091,8 @@ types:
   - name: FileWriter
     description: "Streaming file writer with immediate flush"
     description_ja: "即時フラッシュ付きストリーミングファイルライター"
+    description_ko: "즉시 플러시되는 스트리밍 파일 라이터"
+    of_type_category: "file-io-types"
     sketch: true
     constructor:
       signatures:
@@ -7091,6 +7149,8 @@ types:
   - name: FileReader
     description: "Streaming file reader for large files"
     description_ja: "大きなファイル用ストリーミングファイルリーダー"
+    description_ko: "대용량 파일용 스트리밍 파일 리더"
+    of_type_category: "file-io-types"
     sketch: true
     constructor:
       signatures:
@@ -7168,3 +7228,32 @@ types:
         description: "Get remaining bytes"
         description_ja: "残りバイト数を取得"
         snippet: "remaining()"
+
+  - name: ColorHSB
+    description: "HSB color space (H/S/B: 0-1)"
+    description_ja: "HSB色空間 (H/S/B: 0-1)"
+    description_ko: "HSB 색공간 (H/S/B: 0-1)"
+    of_type_category: "color-types"
+    sketch: false
+
+  - name: ColorOKLCH
+    description: "Perceptually uniform OKLCH color"
+    description_ja: "知覚均一なOKLCHカラー"
+    description_ko: "지각적 균일 OKLCH 색상"
+    of_type_category: "color-types"
+    sketch: false
+
+  - name: ChipSound
+    description: "Chip/synthesized sound generation"
+    description_ja: "チップ/合成サウンド生成"
+    description_ko: "칩/합성 사운드 생성"
+    of_type_category: "audio-types"
+    sketch: false
+
+  - name: EasyCam
+    description: "3D camera with mouse control"
+    description_ja: "マウス操作対応3Dカメラ"
+    description_ko: "마우스 조작 가능한 3D 카메라"
+    of_equivalent: "ofEasyCam"
+    of_type_category: "camera-types"
+    sketch: false

--- a/docs/scripts/generate-docs.js
+++ b/docs/scripts/generate-docs.js
@@ -25,7 +25,7 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { categoryMapping, ofOnlyEntries } = require('./of-category-mapping.js');
+const { categoryMapping, typeCategoryMapping, ofOnlyEntries } = require('./of-category-mapping.js');
 
 // Paths
 const API_YAML = path.join(__dirname, '../api-definition.yaml');
@@ -281,6 +281,7 @@ function generateOfMappingJson(api) {
                 id: displayId,
                 name: mapping.name,
                 name_ja: mapping.name_ja,
+                name_ko: mapping.name_ko || '',
                 order: mapping.order,
                 mappings: []
             };
@@ -289,13 +290,16 @@ function generateOfMappingJson(api) {
         // Add functions that have of_equivalent
         for (const fn of cat.functions) {
             if (fn.of_equivalent) {
-                // Use simple params for cleaner display
-                const params = fn.signatures[0]?.params_simple || '';
+                // Use of_signature_index to pick which overload to display (default: 0)
+                const sigIdx = fn.of_signature_index || 0;
+                const sig = fn.signatures[sigIdx] || fn.signatures[0];
+                const params = sig.params_simple || '';
                 categoryGroups[displayId].mappings.push({
                     of: fn.of_equivalent,
                     tc: fn.name + (params ? `(${params})` : '()'),
                     notes: fn.of_notes || '',
-                    notes_ja: fn.of_notes_ja || fn.of_notes || ''
+                    notes_ja: fn.of_notes_ja || fn.of_notes || '',
+                    notes_ko: fn.of_notes_ko || ''
                 });
             }
         }
@@ -308,6 +312,7 @@ function generateOfMappingJson(api) {
                 id: entry.category,
                 name: entry.name,
                 name_ja: entry.name_ja,
+                name_ko: entry.name_ko || '',
                 order: entry.order,
                 mappings: []
             };
@@ -317,17 +322,53 @@ function generateOfMappingJson(api) {
                 of: e.of,
                 tc: e.tc,
                 notes: e.notes || '',
-                notes_ja: e.notes_ja || e.notes || ''
+                notes_ja: e.notes_ja || e.notes || '',
+                notes_ko: e.notes_ko || ''
             });
         }
     }
 
     // Convert to sorted array
-    const categories = Object.values(categoryGroups)
+    const functions = Object.values(categoryGroups)
         .filter(cat => cat.mappings.length > 0)
         .sort((a, b) => a.order - b.order);
 
-    return JSON.stringify({ categories }, null, 2);
+    // Group types by of_type_category
+    const typeGroups = {};
+
+    if (api.types) {
+        for (const type of api.types) {
+            if (!type.of_type_category) continue;
+
+            const catDef = typeCategoryMapping[type.of_type_category];
+            if (!catDef) continue;
+
+            const catId = catDef.id;
+            if (!typeGroups[catId]) {
+                typeGroups[catId] = {
+                    id: catDef.id,
+                    name: catDef.name,
+                    name_ja: catDef.name_ja,
+                    name_ko: catDef.name_ko || '',
+                    order: catDef.order,
+                    mappings: []
+                };
+            }
+
+            typeGroups[catId].mappings.push({
+                of: type.of_equivalent || '-',
+                tc: type.name,
+                notes: type.description || '',
+                notes_ja: type.description_ja || type.description || '',
+                notes_ko: type.description_ko || ''
+            });
+        }
+    }
+
+    const types = Object.values(typeGroups)
+        .sort((a, b) => a.order - b.order);
+
+    return JSON.stringify({ functions, types }, null, 2);
 }
 
 // Generate oF comparison markdown (Section 5)

--- a/docs/scripts/generate-docs.js
+++ b/docs/scripts/generate-docs.js
@@ -5,6 +5,7 @@
  * Usage:
  *   node generate-docs.js                  # Generate all outputs
  *   node generate-docs.js --sketch         # Generate TrussSketch-related files only
+ *   node generate-docs.js --trussc-api     # Generate TrussC API JS (all APIs + version)
  *   node generate-docs.js --reference      # Generate REFERENCE.md only
  *   node generate-docs.js --of-mapping     # Generate oF mapping JSON for website
  *   node generate-docs.js --of-markdown    # Generate oF comparison markdown
@@ -12,10 +13,12 @@
  *
  * Outputs:
  *   --sketch:
- *     - ../trussc.org/sketch/trusssketch-api.js
+ *     - ../trussc.org/generated/trusssketch-api.js
  *     - ../TrussSketch/REFERENCE.md
+ *   --trussc-api:
+ *     - ../trussc.org/generated/trussc-api.js
  *   --of-mapping:
- *     - ../trussc.org/of-mapping.json
+ *     - ../trussc.org/generated/of-mapping.json
  *   --of-markdown:
  *     - ../TrussC_vs_openFrameworks.md (Section 5)
  *   --gemini:
@@ -25,14 +28,16 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const { execSync } = require('child_process');
 const { categoryMapping, typeCategoryMapping, ofOnlyEntries } = require('./of-category-mapping.js');
 
 // Paths
 const API_YAML = path.join(__dirname, '../api-definition.yaml');
-const SKETCH_API_JS = path.join(__dirname, '../../../trussc.org/sketch/trusssketch-api.js');
+const SKETCH_API_JS = path.join(__dirname, '../../../trussc.org/generated/trusssketch-api.js');
+const TRUSSC_API_JS = path.join(__dirname, '../../../trussc.org/generated/trussc-api.js');
 const REFERENCE_MD = path.join(__dirname, '../../../TrussSketch/REFERENCE.md');
 const REFERENCE_MD_DOCS = path.join(__dirname, '../REFERENCE.md');
-const OF_MAPPING_JSON = path.join(__dirname, '../../../trussc.org/of-mapping.json');
+const OF_MAPPING_JSON = path.join(__dirname, '../../../trussc.org/generated/of-mapping.json');
 const OF_COMPARISON_MD = path.join(__dirname, '../TrussC_vs_openFrameworks.md');
 const GEMINI_KNOWLEDGE_MD = path.join(__dirname, './trusssketch-knowledge.md');
 
@@ -40,6 +45,7 @@ const GEMINI_KNOWLEDGE_MD = path.join(__dirname, './trusssketch-knowledge.md');
 const args = process.argv.slice(2);
 const generateAll = args.length === 0;
 const generateSketch = generateAll || args.includes('--sketch');
+const generateTrussCApi = generateAll || args.includes('--trussc-api');
 const generateReference = generateAll || args.includes('--reference');
 const generateOfMapping = generateAll || args.includes('--of-mapping');
 const generateOfMarkdown = generateAll || args.includes('--of-markdown');
@@ -167,7 +173,120 @@ function generateSketchAPI(api) {
             
                 return js;
             }
-            
+
+// Get version from latest git tag
+function getVersion() {
+    try {
+        return execSync('git describe --tags --abbrev=0', { cwd: path.join(__dirname, '../..') })
+            .toString().trim();
+    } catch {
+        return 'unknown';
+    }
+}
+
+// Generate trussc-api.js (all APIs, no sketch filter)
+function generateTrussCApiJS(api) {
+    const version = getVersion();
+
+    const categories = [];
+    for (const cat of api.categories) {
+        const functions = [];
+        for (const fn of cat.functions) {
+            for (const sig of fn.signatures) {
+                functions.push({
+                    name: fn.name,
+                    params: sig.params_simple || sig.params || '',
+                    params_typed: sig.params || '',
+                    return_type: fn.return !== undefined ? fn.return : null,
+                    desc: fn.description,
+                    desc_ja: fn.description_ja || '',
+                    snippet: fn.snippet
+                });
+            }
+        }
+        if (functions.length === 0) continue;
+        categories.push({ name: cat.name, name_ja: cat.name_ja || '', functions });
+    }
+
+    const constants = (api.constants || []).map(c => ({
+        name: c.name,
+        value: c.value,
+        desc: c.description
+    }));
+
+    const types = [];
+    if (api.types) {
+        for (const type of api.types) {
+            const typeData = {
+                name: type.name,
+                desc: type.description,
+                desc_ja: type.description_ja || ''
+            };
+
+            if (type.constructor && type.constructor.signatures) {
+                typeData.constructor = {
+                    signatures: type.constructor.signatures.map(s => s.params || ''),
+                    snippet: type.constructor.snippet
+                };
+            }
+
+            if (type.properties) {
+                typeData.properties = type.properties.map(p => ({
+                    name: p.name,
+                    type: p.type,
+                    desc: p.description
+                }));
+            }
+
+            if (type.methods) {
+                typeData.methods = type.methods.map(m => ({
+                    name: m.name,
+                    return: m.return,
+                    signatures: m.signatures.map(s => s.params || ''),
+                    desc: m.description,
+                    snippet: m.snippet
+                }));
+            }
+
+            if (type.static_methods) {
+                typeData.static_methods = type.static_methods.map(m => ({
+                    name: m.name,
+                    return: m.return,
+                    signatures: m.signatures.map(s => s.params || ''),
+                    desc: m.description,
+                    snippet: m.snippet
+                }));
+            }
+
+            types.push(typeData);
+        }
+    }
+
+    const output = {
+        version: version,
+        categories: categories,
+        constants: constants,
+        keywords: api.keywords,
+        types: types
+    };
+
+    let js = `// TrussC API Definition
+// Complete C++ API reference (all functions, types, constants)
+//
+// AUTO-GENERATED from api-definition.yaml
+// Do not edit directly - edit api-definition.yaml instead
+
+const TrussCAPI = ${JSON.stringify(output, null, 4)};
+
+// Export for different environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = TrussCAPI;
+}
+`;
+
+    return js;
+}
+
             // Generate REFERENCE.md
             function generateReferenceMd(api) {
                 let md = `# TrussC API Reference
@@ -990,6 +1109,14 @@ function main() {
             fs.writeFileSync(REFERENCE_MD_DOCS, md);
             console.log(`  Written: ${REFERENCE_MD_DOCS}`);
         }
+    }
+
+    // Generate TrussC API JS
+    if (generateTrussCApi) {
+        console.log('\nGenerating trussc-api.js...');
+        const js = generateTrussCApiJS(api);
+        fs.writeFileSync(TRUSSC_API_JS, js);
+        console.log(`  Written: ${TRUSSC_API_JS}`);
     }
 
     // Generate oF mapping JSON

--- a/docs/scripts/of-category-mapping.js
+++ b/docs/scripts/of-category-mapping.js
@@ -7,61 +7,61 @@
 
 const categoryMapping = {
     // App Structure
-    "lifecycle": { id: "app", name: "App Structure", name_ja: "アプリ構造", order: 1 },
-    "events": { id: "app", name: "App Structure", name_ja: "アプリ構造", order: 1 },
-    "window_input": { id: "app", name: "App Structure", name_ja: "アプリ構造", order: 1 },
-    "window_system": { id: "app", name: "App Structure", name_ja: "アプリ構造", order: 1 },
+    "lifecycle": { id: "app", name: "App Structure", name_ja: "アプリ構造", name_ko: "앱 구조", order: 1 },
+    "events": { id: "app", name: "App Structure", name_ja: "アプリ構造", name_ko: "앱 구조", order: 1 },
+    "window_input": { id: "app", name: "App Structure", name_ja: "アプリ構造", name_ko: "앱 구조", order: 1 },
+    "window_system": { id: "app", name: "App Structure", name_ja: "アプリ構造", name_ko: "앱 구조", order: 1 },
 
     // Graphics
-    "graphics_color": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", order: 2 },
-    "graphics_shapes": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", order: 2 },
-    "graphics_style": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", order: 2 },
-    "graphics_advanced": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", order: 2 },
+    "graphics_color": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", name_ko: "그래픽스", order: 2 },
+    "graphics_shapes": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", name_ko: "그래픽스", order: 2 },
+    "graphics_style": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", name_ko: "그래픽스", order: 2 },
+    "graphics_advanced": { id: "graphics", name: "Graphics", name_ja: "グラフィックス", name_ko: "그래픽스", order: 2 },
 
     // Transform
-    "transform": { id: "transform", name: "Transform", name_ja: "変換", order: 3 },
+    "transform": { id: "transform", name: "Transform", name_ja: "変換", name_ko: "좌표변환", order: 3 },
 
     // Math
-    "math_random": { id: "math", name: "Math", name_ja: "数学", order: 4 },
-    "math_interpolation": { id: "math", name: "Math", name_ja: "数学", order: 4 },
-    "math_trig": { id: "math", name: "Math", name_ja: "数学", order: 4 },
-    "math_general": { id: "math", name: "Math", name_ja: "数学", order: 4 },
-    "math_geometry": { id: "math", name: "Math", name_ja: "数学", order: 4 },
-    "math_3d": { id: "math", name: "Math", name_ja: "数学", order: 4 },
+    "math_random": { id: "math", name: "Math", name_ja: "数学", name_ko: "수학", order: 4 },
+    "math_interpolation": { id: "math", name: "Math", name_ja: "数学", name_ko: "수학", order: 4 },
+    "math_trig": { id: "math", name: "Math", name_ja: "数学", name_ko: "수학", order: 4 },
+    "math_general": { id: "math", name: "Math", name_ja: "数学", name_ko: "수학", order: 4 },
+    "math_geometry": { id: "math", name: "Math", name_ja: "数学", name_ko: "수학", order: 4 },
+    "math_3d": { id: "math", name: "Math", name_ja: "数学", name_ko: "수학", order: 4 },
 
     // Types (Vec, Color, Rect)
-    "types_vec2": { id: "types", name: "Types", name_ja: "型", order: 5 },
-    "types_vec3": { id: "types", name: "Types", name_ja: "型", order: 5 },
-    "types_color": { id: "color", name: "Color", name_ja: "色", order: 6 },
-    "types_rect": { id: "types", name: "Types", name_ja: "型", order: 5 },
+    "types_vec2": { id: "types", name: "Types", name_ja: "型", name_ko: "타입", order: 5 },
+    "types_vec3": { id: "types", name: "Types", name_ja: "型", name_ko: "타입", order: 5 },
+    "types_color": { id: "color", name: "Color", name_ja: "色", name_ko: "색상", order: 6 },
+    "types_rect": { id: "types", name: "Types", name_ja: "型", name_ko: "타입", order: 5 },
 
     // Image & Texture
-    "graphics_texture": { id: "image", name: "Image", name_ja: "画像", order: 7 },
-    "graphics_pixels": { id: "image", name: "Image", name_ja: "画像", order: 7 },
+    "graphics_texture": { id: "image", name: "Image", name_ja: "画像", name_ko: "이미지", order: 7 },
+    "graphics_pixels": { id: "image", name: "Image", name_ja: "画像", name_ko: "이미지", order: 7 },
 
     // Font - no direct YAML category yet, will be added
 
     // FBO
-    "graphics_fbo": { id: "fbo", name: "FBO", name_ja: "FBO", order: 8 },
+    "graphics_fbo": { id: "fbo", name: "FBO", name_ja: "FBO", name_ko: "FBO", order: 8 },
 
     // Shader
-    "graphics_shader": { id: "shader", name: "Shader", name_ja: "シェーダー", order: 9 },
+    "graphics_shader": { id: "shader", name: "Shader", name_ja: "シェーダー", name_ko: "셰이더", order: 9 },
 
     // Mesh
-    "types_mesh": { id: "mesh", name: "Mesh", name_ja: "メッシュ", order: 10 },
-    "types_polyline": { id: "mesh", name: "Mesh", name_ja: "メッシュ", order: 10 },
-    "types_strokemesh": { id: "mesh", name: "Mesh", name_ja: "メッシュ", order: 10 },
+    "types_mesh": { id: "mesh", name: "Mesh", name_ja: "メッシュ", name_ko: "메쉬", order: 10 },
+    "types_polyline": { id: "mesh", name: "Mesh", name_ja: "メッシュ", name_ko: "메쉬", order: 10 },
+    "types_strokemesh": { id: "mesh", name: "Mesh", name_ja: "メッシュ", name_ko: "메쉬", order: 10 },
 
     // 3D Primitives
-    "graphics_3d_setup": { id: "3d-primitives", name: "3D Primitives", name_ja: "3Dプリミティブ", order: 11 },
+    "graphics_3d_setup": { id: "3d-primitives", name: "3D Primitives", name_ja: "3Dプリミティブ", name_ko: "3D Primitives", order: 11 },
 
     // 3D Camera
-    "graphics_camera": { id: "3d-camera", name: "3D Camera", name_ja: "3Dカメラ", order: 12 },
+    "graphics_camera": { id: "3d-camera", name: "3D Camera", name_ja: "3Dカメラ", name_ko: "3D 카메라", order: 12 },
 
     // Lighting (not yet in YAML)
 
     // Sound
-    "sound": { id: "sound", name: "Sound", name_ja: "サウンド", order: 13 },
+    "sound": { id: "sound", name: "Sound", name_ja: "サウンド", name_ko: "사운드", order: 13 },
 
     // Video (not yet in YAML)
 
@@ -72,7 +72,7 @@ const categoryMapping = {
     // Network (not yet in YAML)
 
     // Scene Graph
-    "scene_graph": { id: "scene", name: "Scene Graph", name_ja: "シーングラフ", order: 14 },
+    "scene_graph": { id: "scene", name: "Scene Graph", name_ja: "シーングラフ", name_ko: "씬 그래프", order: 14 },
 
     // Events (already in app)
 
@@ -83,74 +83,86 @@ const categoryMapping = {
     // Serial (not yet in YAML)
 
     // Timer
-    "animation": { id: "timer", name: "Timer", name_ja: "タイマー", order: 15 },
+    "animation": { id: "timer", name: "Timer", name_ja: "タイマー", name_ko: "타이머", order: 15 },
 
     // Time
-    "time_frame": { id: "time", name: "Time", name_ja: "時間", order: 16 },
-    "time_elapsed": { id: "time", name: "Time", name_ja: "時間", order: 16 },
-    "time_system": { id: "time", name: "Time", name_ja: "時間", order: 16 },
-    "time_current": { id: "time", name: "Time", name_ja: "時間", order: 16 },
+    "time_frame": { id: "time", name: "Time", name_ja: "時間", name_ko: "시간", order: 16 },
+    "time_elapsed": { id: "time", name: "Time", name_ja: "時間", name_ko: "시간", order: 16 },
+    "time_system": { id: "time", name: "Time", name_ja: "時間", name_ko: "시간", order: 16 },
+    "time_current": { id: "time", name: "Time", name_ja: "時間", name_ko: "시간", order: 16 },
 
     // Utility
-    "utility": { id: "utility", name: "Utility", name_ja: "ユーティリティ", order: 17 },
+    "utility": { id: "utility", name: "Utility", name_ja: "ユーティリティ", name_ko: "유틸리티", order: 17 },
 
     // Addons
-    "addon_tcxlut": { id: "addons", name: "Addons", name_ja: "アドオン", order: 99 },
+    "addon_tcxlut": { id: "addons", name: "Addons", name_ja: "アドオン", name_ko: "애드온", order: 99 },
+};
+
+// Type category mapping for of-mapping.json types section
+const typeCategoryMapping = {
+    "math-vector": { id: "math-vector", name: "Math / Vector", name_ja: "数学 / ベクトル", name_ko: "수학 / 벡터", order: 1 },
+    "color-types": { id: "color-types", name: "Color", name_ja: "カラー", name_ko: "색상", order: 2 },
+    "geometry-types": { id: "geometry-types", name: "Geometry", name_ja: "ジオメトリ", name_ko: "지오메트리", order: 3 },
+    "image-texture-types": { id: "image-texture-types", name: "Image / Texture", name_ja: "画像 / テクスチャ", name_ko: "이미지 / 텍스처", order: 4 },
+    "audio-types": { id: "audio-types", name: "Audio", name_ja: "オーディオ", name_ko: "오디오", order: 5 },
+    "text-types": { id: "text-types", name: "Text", name_ja: "テキスト", name_ko: "텍스트", order: 6 },
+    "file-io-types": { id: "file-io-types", name: "File I/O", name_ja: "ファイルI/O", name_ko: "파일 I/O", order: 7 },
+    "camera-types": { id: "camera-types", name: "3D Camera", name_ja: "3Dカメラ", name_ko: "3D 카메라", order: 8 },
 };
 
 // Additional entries that exist in oF but not yet in TrussC YAML
 // These will be added to the mapping JSON with of_equivalent but no tc equivalent
 const ofOnlyEntries = [
     // Font
-    { category: "font", name: "Font", name_ja: "フォント", order: 7.5, entries: [
-        { of: "ofTrueTypeFont", tc: "Font", notes: "" },
-        { of: "font.load(\"font.ttf\", size)", tc: "font.load(\"font.ttf\", size)", notes: "Same" },
-        { of: "font.drawString(text, x, y)", tc: "font.drawString(text, x, y)", notes: "Same" },
+    { category: "font", name: "Font", name_ja: "フォント", name_ko: "서체", order: 7.5, entries: [
+        { of: "ofTrueTypeFont", tc: "Font", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "font.load(\"font.ttf\", size)", tc: "font.load(\"font.ttf\", size)", notes: "Same", notes_ja: "Same", notes_ko: "" },
+        { of: "font.drawString(text, x, y)", tc: "font.drawString(text, x, y)", notes: "Same", notes_ja: "Same", notes_ko: "" },
     ]},
     // Video
-    { category: "video", name: "Video", name_ja: "ビデオ", order: 13.5, entries: [
-        { of: "ofVideoGrabber", tc: "VideoGrabber", notes: "" },
-        { of: "grabber.setup(w, h)", tc: "grabber.setup(w, h)", notes: "" },
-        { of: "grabber.update()", tc: "grabber.update()", notes: "" },
-        { of: "grabber.draw(x, y)", tc: "grabber.draw(x, y)", notes: "" },
-        { of: "grabber.isFrameNew()", tc: "grabber.isFrameNew()", notes: "" },
+    { category: "video", name: "Video", name_ja: "ビデオ", name_ko: "비디오", order: 13.5, entries: [
+        { of: "ofVideoGrabber", tc: "VideoGrabber", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "grabber.setup(w, h)", tc: "grabber.setup(w, h)", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "grabber.update()", tc: "grabber.update()", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "grabber.draw(x, y)", tc: "grabber.draw(x, y)", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "grabber.isFrameNew()", tc: "grabber.isFrameNew()", notes: "", notes_ja: "", notes_ko: "" },
     ]},
     // GUI
-    { category: "gui", name: "GUI", name_ja: "GUI", order: 18, entries: [
-        { of: "ofxGui / ofxImGui", tc: "ImGui (built-in)", notes: "Included by default" },
+    { category: "gui", name: "GUI", name_ja: "GUI", name_ko: "GUI", order: 18, entries: [
+        { of: "ofxGui / ofxImGui", tc: "ImGui (built-in)", notes: "Included by default", notes_ja: "Included by default", notes_ko: "" },
     ]},
     // I/O
-    { category: "io", name: "I/O", name_ja: "I/O", order: 19, entries: [
-        { of: "ofSystemLoadDialog()", tc: "systemLoadDialog()", notes: "" },
-        { of: "ofSystemSaveDialog()", tc: "systemSaveDialog()", notes: "" },
-        { of: "ofLoadJson(path)", tc: "loadJson(path)", notes: "nlohmann/json" },
-        { of: "-", tc: "loadXml(path)", notes: "pugixml" },
+    { category: "io", name: "I/O", name_ja: "I/O", name_ko: "I/O", order: 19, entries: [
+        { of: "ofSystemLoadDialog()", tc: "systemLoadDialog()", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "ofSystemSaveDialog()", tc: "systemSaveDialog()", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "ofLoadJson(path)", tc: "loadJson(path)", notes: "nlohmann/json", notes_ja: "nlohmann/json", notes_ko: "" },
+        { of: "-", tc: "loadXml(path)", notes: "pugixml", notes_ja: "pugixml", notes_ko: "" },
     ]},
     // Network
-    { category: "network", name: "Network", name_ja: "ネットワーク", order: 20, entries: [
-        { of: "ofxTCPClient", tc: "TcpClient", notes: "" },
-        { of: "ofxTCPServer", tc: "TcpServer", notes: "" },
-        { of: "ofxUDPManager", tc: "UdpSocket", notes: "" },
-        { of: "ofxOsc", tc: "OscReceiver / OscSender", notes: "" },
+    { category: "network", name: "Network", name_ja: "ネットワーク", name_ko: "네트워크", order: 20, entries: [
+        { of: "ofxTCPClient", tc: "TcpClient", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "ofxTCPServer", tc: "TcpServer", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "ofxUDPManager", tc: "UdpSocket", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "ofxOsc", tc: "OscReceiver / OscSender", notes: "", notes_ja: "", notes_ko: "" },
     ]},
     // Log
-    { category: "log", name: "Log", name_ja: "ログ", order: 21, entries: [
-        { of: "ofLog()", tc: "logNotice()", notes: "" },
-        { of: "ofLogWarning()", tc: "logWarning()", notes: "" },
-        { of: "ofLogError()", tc: "logError()", notes: "" },
+    { category: "log", name: "Log", name_ja: "ログ", name_ko: "로그", order: 21, entries: [
+        { of: "ofLog()", tc: "logNotice()", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "ofLogWarning()", tc: "logWarning()", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "ofLogError()", tc: "logError()", notes: "", notes_ja: "", notes_ko: "" },
     ]},
     // Thread
-    { category: "thread", name: "Thread", name_ja: "スレッド", order: 22, entries: [
-        { of: "ofThread", tc: "std::thread + MainThreadRunner", notes: "Safe sync" },
-        { of: "-", tc: "MainThreadRunner::run(func)", notes: "Execute on main thread" },
+    { category: "thread", name: "Thread", name_ja: "スレッド", name_ko: "스레드", order: 22, entries: [
+        { of: "ofThread", tc: "std::thread + MainThreadRunner", notes: "Safe sync", notes_ja: "Safe sync", notes_ko: "" },
+        { of: "-", tc: "MainThreadRunner::run(func)", notes: "Execute on main thread", notes_ja: "Execute on main thread", notes_ko: "" },
     ]},
     // Serial
-    { category: "serial", name: "Serial", name_ja: "シリアル", order: 23, entries: [
-        { of: "ofSerial", tc: "Serial", notes: "" },
-        { of: "serial.setup(port, baud)", tc: "serial.setup(port, baud)", notes: "Same" },
-        { of: "serial.readBytes(...)", tc: "serial.readBytes(...)", notes: "Same" },
-        { of: "serial.writeBytes(...)", tc: "serial.writeBytes(...)", notes: "Same" },
+    { category: "serial", name: "Serial", name_ja: "シリアル", name_ko: "시리얼통신", order: 23, entries: [
+        { of: "ofSerial", tc: "Serial", notes: "", notes_ja: "", notes_ko: "" },
+        { of: "serial.setup(port, baud)", tc: "serial.setup(port, baud)", notes: "Same", notes_ja: "Same", notes_ko: "" },
+        { of: "serial.readBytes(...)", tc: "serial.readBytes(...)", notes: "Same", notes_ja: "Same", notes_ko: "" },
+        { of: "serial.writeBytes(...)", tc: "serial.writeBytes(...)", notes: "Same", notes_ja: "Same", notes_ko: "" },
     ]},
 ];
 
-module.exports = { categoryMapping, ofOnlyEntries };
+module.exports = { categoryMapping, typeCategoryMapping, ofOnlyEntries };


### PR DESCRIPTION
## Summary
- Add `--trussc-api` option to generate-docs.js: generates complete C++ API JS with git tag version, for trussc.org/reference
- Add type mappings (of_equivalent, description_ko) to api-definition.yaml for auto-generating of-mapping.json types section
- Add ~30 missing public API functions to api-definition.yaml (scissor, blend mode, touch-as-mouse, global mouse, DPI, memory diagnostics, etc.)
- Update output paths to `trussc.org/generated/` directory
- Add Korean translations to of-category-mapping.js
- Remove stale `version: "0.0.2"` from yaml (version now from git tag)

## Test plan
- [ ] `node generate-docs.js` runs without error
- [ ] Generated trussc-api.js contains all APIs and correct version
- [ ] Generated of-mapping.json matches expected structure
- [ ] trussc.org/reference/ loads correctly with new trussc-api.js