### PR TITLE
feat: add isUsingHwAccel / getHwAccelName to VideoPlayerBase

### DIFF
--- a/trussc/include/tc/video/tcVideoPlayer.h
+++ b/trussc/include/tc/video/tcVideoPlayer.h
@@ -200,6 +200,13 @@ public:
     int getAudioSampleRate() const override { return getAudioSampleRatePlatform(); }
     int getAudioChannels() const override { return getAudioChannelsPlatform(); }
 
+    // =========================================================================
+    // Hardware acceleration info
+    // =========================================================================
+
+    bool isUsingHwAccel() const override { return isUsingHwAccelPlatform(); }
+    std::string getHwAccelName() const override { return getHwAccelNamePlatform(); }
+
 protected:
     // -------------------------------------------------------------------------
     // Implementation methods
@@ -320,6 +327,10 @@ private:
     std::vector<uint8_t> getAudioDataPlatform() const;
     int getAudioSampleRatePlatform() const;
     int getAudioChannelsPlatform() const;
+
+    // Hardware acceleration info
+    bool isUsingHwAccelPlatform() const;
+    std::string getHwAccelNamePlatform() const;
 
     // =========================================================================
     // Static utility — frame extraction (thread-safe, no GPU required)

--- a/trussc/include/tc/video/tcVideoPlayerBase.h
+++ b/trussc/include/tc/video/tcVideoPlayerBase.h
@@ -190,6 +190,22 @@ public:
     virtual int getAudioChannels() const { return 0; }
 
     // =========================================================================
+    // Hardware acceleration info
+    // =========================================================================
+
+    /// Returns true if hardware-accelerated decoding is currently active.
+    /// Concrete players that use HW decode should override this.
+    virtual bool isUsingHwAccel() const { return false; }
+
+    /// Returns the name of the active decode backend.
+    /// Possible values on the standard VideoPlayer:
+    ///   - macOS:   "videotoolbox", "software"
+    ///   - Windows: "mediafoundation", "software"
+    ///   - Linux:   "vaapi", "v4l2m2m", "drm", "cuda", "software"
+    /// Returns "none" when no video is loaded or the player has no HW path.
+    virtual std::string getHwAccelName() const { return "none"; }
+
+    // =========================================================================
     // HasTexture implementation
     // =========================================================================
 

--- a/trussc/platform/android/tcVideoPlayer_android.cpp
+++ b/trussc/platform/android/tcVideoPlayer_android.cpp
@@ -42,6 +42,10 @@ std::vector<uint8_t> VideoPlayer::getAudioDataPlatform() const { return {}; }
 int VideoPlayer::getAudioSampleRatePlatform() const { return 0; }
 int VideoPlayer::getAudioChannelsPlatform() const { return 0; }
 
+// Hardware acceleration info — Android VideoPlayer is currently a stub.
+bool VideoPlayer::isUsingHwAccelPlatform() const { return false; }
+std::string VideoPlayer::getHwAccelNamePlatform() const { return "none"; }
+
 bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
                                        float timeSec, float* outDuration) {
     (void)path; (void)outPixels; (void)timeSec; (void)outDuration;

--- a/trussc/platform/ios/tcVideoPlayer_ios.mm
+++ b/trussc/platform/ios/tcVideoPlayer_ios.mm
@@ -820,4 +820,13 @@ std::vector<uint8_t> VideoPlayer::getAudioDataPlatform() const {
     return result;
 }
 
+// Hardware acceleration info — iOS uses AVFoundation (VideoToolbox), same as macOS.
+bool VideoPlayer::isUsingHwAccelPlatform() const {
+    return platformHandle_ != nullptr;
+}
+
+std::string VideoPlayer::getHwAccelNamePlatform() const {
+    return platformHandle_ ? "videotoolbox" : "none";
+}
+
 } // namespace trussc

--- a/trussc/platform/linux/tcVideoPlayer_linux.cpp
+++ b/trussc/platform/linux/tcVideoPlayer_linux.cpp
@@ -742,6 +742,17 @@ int VideoPlayer::getAudioChannelsPlatform() const {
     return 0;
 }
 
+// Hardware acceleration info
+// Current Linux implementation is software-only; returns "software" when
+// a video is loaded. Will be replaced when tcxHwVideo is integrated.
+bool VideoPlayer::isUsingHwAccelPlatform() const {
+    return false;
+}
+
+std::string VideoPlayer::getHwAccelNamePlatform() const {
+    return platformHandle_ ? "software" : "none";
+}
+
 bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
                                        float timeSec, float* outDuration) {
     // TODO: implement frame extraction on Linux

--- a/trussc/platform/mac/tcVideoPlayer_mac.mm
+++ b/trussc/platform/mac/tcVideoPlayer_mac.mm
@@ -820,6 +820,22 @@ std::vector<uint8_t> VideoPlayer::getAudioDataPlatform() const {
 }
 
 // =============================================================================
+// Hardware acceleration info
+// =============================================================================
+// AVFoundation uses VideoToolbox for hardware decoding on all supported codecs
+// (H.264, HEVC, ProRes, etc.). There is no public AVPlayer API to query whether
+// a given asset is actually being HW-decoded, so we report "videotoolbox" for
+// any loaded video and trust the system to fall back internally if needed.
+
+bool VideoPlayer::isUsingHwAccelPlatform() const {
+    return platformHandle_ != nullptr;
+}
+
+std::string VideoPlayer::getHwAccelNamePlatform() const {
+    return platformHandle_ ? "videotoolbox" : "none";
+}
+
+// =============================================================================
 // Static frame extraction (thread-safe, no GPU)
 // =============================================================================
 

--- a/trussc/platform/web/tcVideoPlayer_web.cpp
+++ b/trussc/platform/web/tcVideoPlayer_web.cpp
@@ -380,6 +380,18 @@ int VideoPlayer::getAudioChannelsPlatform() const {
     return 0;
 }
 
+// Hardware acceleration info
+// HTML5 <video> delegates decoding to the browser, which uses the GPU
+// for mainstream codecs whenever available. We report "browser" to
+// indicate that the decode path is out of TrussC's direct control.
+bool VideoPlayer::isUsingHwAccelPlatform() const {
+    return platformHandle_ != nullptr;
+}
+
+std::string VideoPlayer::getHwAccelNamePlatform() const {
+    return platformHandle_ ? "browser" : "none";
+}
+
 } // namespace trussc
 
 #endif // __EMSCRIPTEN__

--- a/trussc/platform/win/tcVideoPlayer_win.cpp
+++ b/trussc/platform/win/tcVideoPlayer_win.cpp
@@ -1019,6 +1019,23 @@ std::vector<uint8_t> VideoPlayer::getAudioDataPlatform() const {
     return {};
 }
 
+// =============================================================================
+// Hardware acceleration info
+// =============================================================================
+// Media Foundation is configured with a DXGI device manager backed by a D3D11
+// device created with D3D11_CREATE_DEVICE_VIDEO_SUPPORT, so decoding runs on
+// the GPU via D3D11VA whenever the codec is supported. IMFMediaEngine does not
+// expose a direct "is HW active" query, so we report "mediafoundation" for any
+// successfully loaded video.
+
+bool VideoPlayer::isUsingHwAccelPlatform() const {
+    return platformHandle_ != nullptr;
+}
+
+std::string VideoPlayer::getHwAccelNamePlatform() const {
+    return platformHandle_ ? "mediafoundation" : "none";
+}
+
 bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
                                        float timeSec, float* outDuration) {
     // TODO: implement frame extraction on Windows


### PR DESCRIPTION
## Summary

Promotes the HW backend introspection API (originally defined in [icq4ever/tcxHwVideo](https://github.com/icq4ever/tcxHwVideo)) to the core `VideoPlayerBase` so any concrete player can report which decode path is active.

- `VideoPlayerBase` gains virtual `isUsingHwAccel()` / `getHwAccelName()` with defaults (`false` / `"none"`).
- `VideoPlayer` overrides both and dispatches to private platform hooks.
- **macOS**: `"videotoolbox"` when a video is loaded.
- **Windows**: `"mediafoundation"` when a video is loaded.
- **Linux**: `"software"` for now — will be replaced with HW backend detection (VAAPI / V4L2M2M / DRM / CUDA) when tcxHwVideo is integrated.

This is preparation for merging tcxHwVideo's Linux HW decode implementation into the core `tcVideoPlayer_linux.cpp`. The API is in place so the integration PR only needs to add the `isUsingHwAccelPlatform()` / `getHwAccelNamePlatform()` stubs alongside the backend logic.

## Test plan

- [x] macOS build passes (videoPlayerExample)
- [ ] Windows build (not verified locally, changes mirror mac pattern)
- [ ] Linux build (stub only, replaces existing SW path)