### PR TITLE
Add audio playback to Linux `VideoPlayer`

### DIFF
--- a/trussc/CMakeLists.txt
+++ b/trussc/CMakeLists.txt
@@ -214,9 +214,9 @@ elseif(TC_PLATFORM_LINUX)
     find_package(OpenGL REQUIRED)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
-    # FFmpeg for VideoPlayer
-    pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libswscale libavutil)
-    # GStreamer for AAC audio decoding
+    # FFmpeg for VideoPlayer and audio decoding
+    pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libswscale libavutil libswresample)
+    # GStreamer for AAC audio decoding (Sound)
     pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-audio-1.0)
     target_include_directories(TrussC PUBLIC
         ${GTK3_INCLUDE_DIRS}
@@ -249,7 +249,7 @@ elseif(TC_PLATFORM_RASPBIAN)
     find_package(X11 REQUIRED)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
-    pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libswscale libavutil)
+    pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libswscale libavutil libswresample)
     pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-audio-1.0)
     target_include_directories(TrussC PUBLIC
         ${GTK3_INCLUDE_DIRS}

--- a/trussc/platform/linux/tcVideoPlayer_linux.cpp
+++ b/trussc/platform/linux/tcVideoPlayer_linux.cpp
@@ -13,8 +13,10 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
+#include <libswresample/swresample.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/time.h>
+#include <libavutil/opt.h>
 }
 
 #include <thread>
@@ -65,7 +67,11 @@ public:
     int getAudioChannels() const { return audioChannels_; }
     std::vector<uint8_t> getAudioData() const;
 
+    Sound audioSound_;
+    std::shared_ptr<SoundBuffer> audioBuffer_;
+
 private:
+    bool loadAudioForPlayback();
     void decodeThread();
     bool decodeNextFrame();
     void seekToTime(double seconds);
@@ -284,6 +290,16 @@ bool TCVideoPlayerImpl::load(const std::string& path, VideoPlayer* player) {
     );
 
     isLoaded_ = true;
+
+    // Pre-decode audio for playback using FFmpeg (audio stream only)
+    if (hasAudio_) {
+        if (loadAudioForPlayback()) {
+            logNotice("VideoPlayer") << "Audio decoded and ready";
+        } else {
+            logWarning("VideoPlayer") << "Failed to decode audio";
+        }
+    }
+
     return true;
 }
 
@@ -347,6 +363,8 @@ void TCVideoPlayerImpl::close() {
     isFinished_ = false;
     width_ = 0;
     height_ = 0;
+    audioSound_.stop();
+    audioBuffer_.reset();
     hasAudio_ = false;
     audioStreamIndex_ = -1;
     audioCodec_ = 0;
@@ -376,11 +394,19 @@ void TCVideoPlayerImpl::play() {
     isPlaying_ = true;
     isPaused_ = false;
     cv_.notify_all();
+
+    if (audioBuffer_) {
+        audioSound_.play();
+        audioSound_.setPosition(static_cast<float>(currentPts_));
+        audioSound_.setVolume(volume_);
+    }
 }
 
 void TCVideoPlayerImpl::stop() {
     isPlaying_ = false;
     isPaused_ = false;
+
+    audioSound_.stop();
 
     // Seek to beginning
     seekToTime(0.0);
@@ -406,6 +432,11 @@ void TCVideoPlayerImpl::setPaused(bool paused) {
         playbackStartTime_ += pauseDuration;
         isPaused_ = false;
         cv_.notify_all();
+    }
+
+    if (audioBuffer_) {
+        if (paused) audioSound_.pause();
+        else audioSound_.resume();
     }
 }
 
@@ -555,6 +586,120 @@ bool TCVideoPlayerImpl::decodeNextFrame() {
     }
 }
 
+bool TCVideoPlayerImpl::loadAudioForPlayback() {
+    if (!hasAudio_ || filePath_.empty()) return false;
+
+    AVFormatContext* fmtCtx = nullptr;
+    if (avformat_open_input(&fmtCtx, filePath_.c_str(), nullptr, nullptr) < 0) return false;
+    if (avformat_find_stream_info(fmtCtx, nullptr) < 0) {
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+
+    // Find audio stream only
+    int audioIdx = -1;
+    for (unsigned int i = 0; i < fmtCtx->nb_streams; i++) {
+        if (fmtCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            audioIdx = i;
+            break;
+        }
+    }
+    if (audioIdx < 0) {
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+
+    // Open audio decoder
+    AVCodecParameters* par = fmtCtx->streams[audioIdx]->codecpar;
+    const AVCodec* codec = avcodec_find_decoder(par->codec_id);
+    if (!codec) {
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+    AVCodecContext* audioCtx = avcodec_alloc_context3(codec);
+    avcodec_parameters_to_context(audioCtx, par);
+    if (avcodec_open2(audioCtx, codec, nullptr) < 0) {
+        avcodec_free_context(&audioCtx);
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+
+    // Set up resampler: native → F32 interleaved stereo at AudioEngine::SAMPLE_RATE
+    SwrContext* swr = nullptr;
+    AVChannelLayout outLayout = AV_CHANNEL_LAYOUT_STEREO;
+    if (swr_alloc_set_opts2(&swr,
+            &outLayout,           AV_SAMPLE_FMT_FLT, AudioEngine::SAMPLE_RATE,
+            &audioCtx->ch_layout, audioCtx->sample_fmt, audioCtx->sample_rate,
+            0, nullptr) < 0 || swr_init(swr) < 0) {
+        if (swr) swr_free(&swr);
+        avcodec_free_context(&audioCtx);
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+
+    // Reserve estimated buffer space
+    std::vector<float> samples;
+    if (duration_ > 0)
+        samples.reserve((size_t)(duration_ * AudioEngine::SAMPLE_RATE * 2 * 1.05));
+
+    AVFrame* frame = av_frame_alloc();
+    AVPacket* pkt  = av_packet_alloc();
+
+    auto appendConverted = [&](int nbIn) {
+        int outN = av_rescale_rnd(
+            swr_get_delay(swr, audioCtx->sample_rate) + nbIn,
+            AudioEngine::SAMPLE_RATE, audioCtx->sample_rate, AV_ROUND_UP);
+        std::vector<float> buf(outN * 2);
+        uint8_t* outData[1] = { (uint8_t*)buf.data() };
+        int n = swr_convert(swr, outData, outN,
+                            nbIn > 0 ? (const uint8_t**)frame->data : nullptr, nbIn);
+        if (n > 0)
+            samples.insert(samples.end(), buf.begin(), buf.begin() + n * 2);
+    };
+
+    while (av_read_frame(fmtCtx, pkt) >= 0) {
+        if (pkt->stream_index == audioIdx) {
+            if (avcodec_send_packet(audioCtx, pkt) == 0) {
+                while (avcodec_receive_frame(audioCtx, frame) == 0) {
+                    appendConverted(frame->nb_samples);
+                    av_frame_unref(frame);
+                }
+            }
+        }
+        av_packet_unref(pkt);
+    }
+
+    // Flush decoder
+    avcodec_send_packet(audioCtx, nullptr);
+    while (avcodec_receive_frame(audioCtx, frame) == 0) {
+        appendConverted(frame->nb_samples);
+        av_frame_unref(frame);
+    }
+
+    // Flush resampler
+    appendConverted(0);
+
+    av_frame_free(&frame);
+    av_packet_free(&pkt);
+    swr_free(&swr);
+    avcodec_free_context(&audioCtx);
+    avformat_close_input(&fmtCtx);
+
+    if (samples.empty()) return false;
+
+    auto buf = std::make_shared<SoundBuffer>();
+    buf->samples   = std::move(samples);
+    buf->channels  = 2;
+    buf->sampleRate = AudioEngine::SAMPLE_RATE;
+    buf->numSamples = buf->samples.size() / 2;
+    audioBuffer_ = buf;
+    audioSound_.loadFromBuffer(audioBuffer_);
+
+    logNotice("VideoPlayer") << "Audio: " << buf->numSamples << " frames @ "
+                              << buf->sampleRate << " Hz";
+    return true;
+}
+
 // Helper: sample rate index for ADTS header
 static int adtsSampleRateIndex(int sampleRate) {
     static const int rates[] = {96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350};
@@ -640,6 +785,9 @@ void TCVideoPlayerImpl::setPosition(float pct) {
     double targetTime = pct * duration_;
     seekToTime(targetTime);
     playbackStartTime_ = av_gettime_relative() / 1000000.0 - targetTime;
+    if (audioBuffer_) {
+        audioSound_.setPosition(static_cast<float>(targetTime));
+    }
 }
 
 float TCVideoPlayerImpl::getDuration() const {
@@ -648,7 +796,7 @@ float TCVideoPlayerImpl::getDuration() const {
 
 void TCVideoPlayerImpl::setVolume(float vol) {
     volume_ = vol;
-    // Audio not implemented yet
+    audioSound_.setVolume(vol);
 }
 
 void TCVideoPlayerImpl::setSpeed(float speed) {

--- a/trussc/platform/linux/tcVideoPlayer_linux.cpp
+++ b/trussc/platform/linux/tcVideoPlayer_linux.cpp
@@ -59,6 +59,12 @@ public:
     int getWidth() const { return width_; }
     int getHeight() const { return height_; }
 
+    bool hasAudio() const { return hasAudio_; }
+    uint32_t getAudioCodec() const { return audioCodec_; }
+    int getAudioSampleRate() const { return audioSampleRate_; }
+    int getAudioChannels() const { return audioChannels_; }
+    std::vector<uint8_t> getAudioData() const;
+
 private:
     void decodeThread();
     bool decodeNextFrame();
@@ -73,6 +79,14 @@ private:
     AVPacket* packet_ = nullptr;
 
     int videoStreamIndex_ = -1;
+    int audioStreamIndex_ = -1;
+
+    // Audio properties
+    bool hasAudio_ = false;
+    uint32_t audioCodec_ = 0;
+    int audioSampleRate_ = 0;
+    int audioChannels_ = 0;
+    std::string filePath_;
 
     // Video properties
     int width_ = 0;
@@ -123,6 +137,8 @@ private:
 // =============================================================================
 
 bool TCVideoPlayerImpl::load(const std::string& path, VideoPlayer* player) {
+    filePath_ = path;
+
     // Open file
     if (avformat_open_input(&formatCtx_, path.c_str(), nullptr, nullptr) < 0) {
         logError("VideoPlayer") << "Failed to open file: " << path;
@@ -148,6 +164,31 @@ bool TCVideoPlayerImpl::load(const std::string& path, VideoPlayer* player) {
         logError("VideoPlayer") << "No video stream found";
         avformat_close_input(&formatCtx_);
         return false;
+    }
+
+    // Find audio stream
+    for (unsigned int i = 0; i < formatCtx_->nb_streams; i++) {
+        if (formatCtx_->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            audioStreamIndex_ = i;
+            break;
+        }
+    }
+
+    if (audioStreamIndex_ >= 0) {
+        AVCodecParameters* audioPar = formatCtx_->streams[audioStreamIndex_]->codecpar;
+        hasAudio_ = true;
+        audioSampleRate_ = audioPar->sample_rate;
+        audioChannels_ = audioPar->ch_layout.nb_channels;
+
+        if (audioPar->codec_id == AV_CODEC_ID_AAC) {
+            audioCodec_ = 0x61616320; // 'aac '
+        } else if (audioPar->codec_id == AV_CODEC_ID_MP3) {
+            audioCodec_ = 0x6D703320; // 'mp3 '
+        } else {
+            audioCodec_ = audioPar->codec_tag;
+        }
+
+        logNotice("VideoPlayer") << "Audio: " << audioChannels_ << "ch, " << audioSampleRate_ << "Hz";
     }
 
     AVStream* videoStream = formatCtx_->streams[videoStreamIndex_];
@@ -306,6 +347,12 @@ void TCVideoPlayerImpl::close() {
     isFinished_ = false;
     width_ = 0;
     height_ = 0;
+    hasAudio_ = false;
+    audioStreamIndex_ = -1;
+    audioCodec_ = 0;
+    audioSampleRate_ = 0;
+    audioChannels_ = 0;
+    filePath_.clear();
 }
 
 void TCVideoPlayerImpl::play() {
@@ -506,6 +553,76 @@ bool TCVideoPlayerImpl::decodeNextFrame() {
         av_frame_unref(frame_);
         return true;
     }
+}
+
+// Helper: sample rate index for ADTS header
+static int adtsSampleRateIndex(int sampleRate) {
+    static const int rates[] = {96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350};
+    for (int i = 0; i < 13; i++) {
+        if (rates[i] == sampleRate) return i;
+    }
+    return 4; // default: 44100
+}
+
+// Helper: create 7-byte ADTS header
+static void createADTSHeader(uint8_t* hdr, int frameSize, int sampleRate, int channels) {
+    int srIdx = adtsSampleRateIndex(sampleRate);
+    int fullLen = frameSize + 7;
+    // AAC-LC profile (adtsProfile=1)
+    hdr[0] = 0xFF;
+    hdr[1] = 0xF1;
+    hdr[2] = (1 << 6) | ((srIdx & 0x0F) << 2) | ((channels >> 2) & 0x01);
+    hdr[3] = ((channels & 0x03) << 6) | ((fullLen >> 11) & 0x03);
+    hdr[4] = (fullLen >> 3) & 0xFF;
+    hdr[5] = ((fullLen & 0x07) << 5) | 0x1F;
+    hdr[6] = 0xFC;
+}
+
+std::vector<uint8_t> TCVideoPlayerImpl::getAudioData() const {
+    if (!hasAudio_ || filePath_.empty()) return {};
+
+    AVFormatContext* fmtCtx = nullptr;
+    if (avformat_open_input(&fmtCtx, filePath_.c_str(), nullptr, nullptr) < 0) return {};
+    if (avformat_find_stream_info(fmtCtx, nullptr) < 0) {
+        avformat_close_input(&fmtCtx);
+        return {};
+    }
+
+    int audioIdx = -1;
+    for (unsigned int i = 0; i < fmtCtx->nb_streams; i++) {
+        if (fmtCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            audioIdx = i;
+            break;
+        }
+    }
+
+    if (audioIdx < 0) {
+        avformat_close_input(&fmtCtx);
+        return {};
+    }
+
+    bool isAAC = (fmtCtx->streams[audioIdx]->codecpar->codec_id == AV_CODEC_ID_AAC);
+
+    std::vector<uint8_t> audioData;
+    AVPacket* pkt = av_packet_alloc();
+
+    while (av_read_frame(fmtCtx, pkt) >= 0) {
+        if (pkt->stream_index == audioIdx) {
+            if (isAAC) {
+                uint8_t adtsHdr[7];
+                createADTSHeader(adtsHdr, pkt->size, audioSampleRate_, audioChannels_);
+                audioData.insert(audioData.end(), adtsHdr, adtsHdr + 7);
+            }
+            audioData.insert(audioData.end(), pkt->data, pkt->data + pkt->size);
+        }
+        av_packet_unref(pkt);
+    }
+
+    av_packet_free(&pkt);
+    avformat_close_input(&fmtCtx);
+
+    logNotice("VideoPlayer") << "Extracted audio: " << audioData.size() << " bytes";
+    return audioData;
 }
 
 void TCVideoPlayerImpl::seekToTime(double seconds) {
@@ -721,24 +838,34 @@ void VideoPlayer::previousFramePlatform() {
     }
 }
 
-// Audio access (not yet implemented for Linux FFmpeg)
+// Audio access
 bool VideoPlayer::hasAudioPlatform() const {
+    if (platformHandle_)
+        return static_cast<TCVideoPlayerImpl*>(platformHandle_)->hasAudio();
     return false;
 }
 
 uint32_t VideoPlayer::getAudioCodecPlatform() const {
+    if (platformHandle_)
+        return static_cast<TCVideoPlayerImpl*>(platformHandle_)->getAudioCodec();
     return 0;
 }
 
 std::vector<uint8_t> VideoPlayer::getAudioDataPlatform() const {
+    if (platformHandle_)
+        return static_cast<TCVideoPlayerImpl*>(platformHandle_)->getAudioData();
     return {};
 }
 
 int VideoPlayer::getAudioSampleRatePlatform() const {
+    if (platformHandle_)
+        return static_cast<TCVideoPlayerImpl*>(platformHandle_)->getAudioSampleRate();
     return 0;
 }
 
 int VideoPlayer::getAudioChannelsPlatform() const {
+    if (platformHandle_)
+        return static_cast<TCVideoPlayerImpl*>(platformHandle_)->getAudioChannels();
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Add audio playback to Linux `VideoPlayer` using FFmpeg + libswresample
- Pre-decodes audio into `SoundBuffer` at load time for stable A/V sync
- Also exposes `getAudioData()` returning raw AAC with ADTS headers (encoding workflow)

## Implementation
- `load()`: detect audio stream, store codec / sampleRate / channels
- `loadAudioForPlayback()`: avcodec decode + libswresample resample → F32 stereo @ `AudioEngine::SAMPLE_RATE` → `SoundBuffer` → `Sound`
- Wire `play` / `stop` / `pause` / `resume` / `seek` / `volume` to control the audio track alongside video
- `CMakeLists.txt`: add `libswresample` to FFmpeg deps (LGPL 2.1+, part of the FFmpeg package)

## Notes
Pre-loading the full audio buffer works well for videos up to ~10 minutes. A streaming approach for longer content is left as future work.

## Test plan
- [ ] Play H.264/H.265 + AAC video — verify audio plays in sync
- [ ] Seek, pause/resume, volume, speed control all affect audio correctly
- [ ] Video without audio still plays (no audio init)
- [ ] `getAudioData()` returns raw AAC + ADTS for AAC inputs
