### PR TITLE
fix(video): AV sync on Linux VideoPlayer (audio-master clock + hard re-sync)

### DIFF
--- a/trussc/include/tc/video/tcVideoPlayerBase.h
+++ b/trussc/include/tc/video/tcVideoPlayerBase.h
@@ -206,6 +206,20 @@ public:
     virtual std::string getHwAccelName() const { return "none"; }
 
     // =========================================================================
+    // AV sync control
+    // =========================================================================
+
+    /// Set the maximum allowed video/audio drift (in seconds) before a hard
+    /// re-sync (video seeks to the audio position). Set to 0 or negative to
+    /// disable. Primarily affects the Linux (FFmpeg) backend — other
+    /// platforms delegate sync to their native framework.
+    /// Default: 0.5s
+    virtual void setResyncThreshold(float seconds) { resyncThreshold_ = seconds; }
+
+    /// Get the current resync threshold in seconds.
+    virtual float getResyncThreshold() const { return resyncThreshold_; }
+
+    // =========================================================================
     // HasTexture implementation
     // =========================================================================
 
@@ -228,6 +242,7 @@ protected:
     float volume_ = 1.0f;
     float speed_ = 1.0f;
     float pan_ = 0.0f;
+    float resyncThreshold_ = 0.5f;
 
     // Thread synchronization
     mutable std::mutex mutex_;

--- a/trussc/platform/linux/tcVideoPlayer_linux.cpp
+++ b/trussc/platform/linux/tcVideoPlayer_linux.cpp
@@ -445,9 +445,15 @@ void TCVideoPlayerImpl::update(VideoPlayer* player) {
 
     if (!isLoaded_ || !isPlaying_ || isPaused_) return;
 
-    // Calculate target PTS based on elapsed time
-    double elapsed = av_gettime_relative() / 1000000.0 - playbackStartTime_;
-    double targetPts = elapsed * speed_;
+    // Target PTS: use audio as master clock when available (no drift).
+    // Fall back to wall clock for audio-less videos.
+    double targetPts;
+    if (audioBuffer_) {
+        targetPts = audioSound_.getPosition();
+    } else {
+        double elapsed = av_gettime_relative() / 1000000.0 - playbackStartTime_;
+        targetPts = elapsed * speed_;
+    }
 
     // Get frame from queue if available and PTS is right
     std::lock_guard<std::mutex> lock(mutex_);

--- a/trussc/platform/linux/tcVideoPlayer_linux.cpp
+++ b/trussc/platform/linux/tcVideoPlayer_linux.cpp
@@ -455,6 +455,19 @@ void TCVideoPlayerImpl::update(VideoPlayer* player) {
         targetPts = elapsed * speed_;
     }
 
+    // Hard re-sync if drift exceeds threshold (e.g. window backgrounded on
+    // Wayland — compositor throttles frame callbacks while audio keeps
+    // playing; CPU spikes; decode stalls). Seeking is far cheaper than
+    // decoding every intermediate frame to catch up.
+    // Threshold configurable via VideoPlayer::setResyncThreshold();
+    // <= 0 disables the check.
+    float resyncThreshold = player ? player->getResyncThreshold() : 0.5f;
+    if (resyncThreshold > 0.0f &&
+        std::abs(targetPts - currentPts_) > resyncThreshold) {
+        seekToTime(targetPts);
+        return;  // next update() will pick up freshly decoded frames
+    }
+
     // Get frame from queue if available and PTS is right
     std::lock_guard<std::mutex> lock(mutex_);
 


### PR DESCRIPTION
## Summary

Follow-up to #29. Fixes AV sync drift on Linux `VideoPlayer` with two complementary mechanisms:

1. **Audio-master clock** — `update()` uses `audioSound_.getPosition()` as the reference instead of `av_gettime_relative()`. Eliminates cumulative drift between the video clock (system monotonic) and audio clock (audio hardware). Falls back to wall-clock for audio-less videos.

2. **Hard re-sync on large drift** — when the video–audio drift grows beyond a threshold (default **0.5s**), the video decoder is seeked to match the current audio position instead of catching up frame-by-frame. This handles cases where the decode/update loop cannot catch up:
   - Wayland compositor pausing `wl_surface.frame` callbacks to a backgrounded / occluded surface (confirmed not reproducing on X11)
   - CPU spikes / transient decoder stalls

Matches the standard audio-master + resync approach used by mpv / VLC / ffplay.

## API

```cpp
video.setResyncThreshold(0.5f);   // seconds, default 0.5
video.setResyncThreshold(0.0f);   // disable hard re-sync
```

`setResyncThreshold` / `getResyncThreshold` are added to `VideoPlayerBase` (virtual). The Linux backend consults the value in `update()`; other platforms store it but delegate sync to their native framework.

## Discussion points

Happy to change any of these — pinging reviewers because these are judgment calls:

1. **Threshold API shape** — currently a single setter where `0` disables. Alternatives considered:
   - Separate `setResyncEnabled(bool)` + `setResyncThreshold(float)` (two knobs, more discoverable)
   - Keep as-is (single setter, one-knob = less surface)
2. **Default value (0.5s)** — based on drift observations in #29. Too aggressive? Too permissive?
3. **API placement** — kept on `VideoPlayerBase` for cross-platform consistency (follows the `isUsingHwAccel()` pattern introduced in #26). Effectively no-op on macOS/Windows. Acceptable, or move to `VideoPlayer` only?

## Testing

Drift measured on 1920x1080 60fps HEVC (audio-master only, no hard re-sync):

| Scenario | Drift |
|----------|-------|
| Normal playback | ±10–20ms steady |
| Initial catch-up | up to -300ms then converges |
| Wayland, window backgrounded ~30s | grows to -2+ seconds |
| X11, window backgrounded ~30s | stays bounded (≈ normal) |

With hard re-sync at 0.5s threshold: drift stays within ±~500ms under all scenarios including Wayland backgrounded.

## Prior art / reference

This approach mirrors what established FFmpeg-based players do:

**mpv** ([docs](https://mpv.io/manual/master/#options-video-sync))
- Audio is the default master clock (`--video-sync=audio`)
- Has a drift threshold before mpv falls back to different sync strategies (`--video-sync-max-video-change`, default 1s)
- Frame drop / duplicate layer for small drift before escalating to resync

**ffplay** ([source](https://github.com/FFmpeg/FFmpeg/blob/master/fftools/ffplay.c))
- Audio-master clock (`av_sync_type=AV_SYNC_AUDIO_MASTER` by default)
- Multiple thresholds hard-coded in source:
  - `AV_SYNC_THRESHOLD_MIN = 0.04s` — below this, do nothing
  - `AV_SYNC_THRESHOLD_MAX = 0.1s` — above this, drop / duplicate frames
  - `AV_NOSYNC_THRESHOLD = 10.0s` — above this, give up syncing
- Frame drop / duplicate layer between "small" and "too large"

Our implementation is a simplified two-level version:
- **Small drift** — natural catch-up via the frame queue / PTS matching (no explicit drop/duplicate layer)
- **Large drift (> threshold, default 0.5s)** — hard seek to audio position

The intermediate "drop / duplicate individual frames" layer is something we can add later if needed. Current data suggests the two-level approach is sufficient for TrussC's use case.


## Test plan

- [ ] H.264 + AAC video — no drift, no audible glitches
- [ ] HEVC + AAC video — same
- [ ] Background window for 30s+ on Wayland → returns in sync within 1 update
- [ ] `setResyncThreshold(0.0f)` → no seek triggered; drift behaves as audio-master only
- [ ] `setResyncThreshold(0.2f)` → more aggressive re-sync
- [ ] Seek / pause / resume / speed change still work correctly
