### PR TITLE
fix(video): minor improvements from #32 (HW transfer drop logging + NV12 fast path)

### DIFF
--- a/trussc/platform/linux/tcVideoPlayer_linux.cpp
+++ b/trussc/platform/linux/tcVideoPlayer_linux.cpp
@@ -649,6 +649,7 @@ bool TCVideoPlayerImpl::decodeNextFrame() {
             swFrame = av_frame_alloc();
             swFrame->format = AV_PIX_FMT_YUV420P;
             if (av_hwframe_transfer_data(swFrame, frame_, 0) < 0) {
+                logWarning("VideoPlayer") << "HW frame transfer failed, dropping frame";
                 av_frame_free(&swFrame);
                 av_frame_unref(frame_);
                 continue;

--- a/trussc/platform/linux/tcVideoPlayer_linux.cpp
+++ b/trussc/platform/linux/tcVideoPlayer_linux.cpp
@@ -647,7 +647,10 @@ bool TCVideoPlayerImpl::decodeNextFrame() {
         AVFrame* swFrame  = nullptr;
         if (hwType_ != AV_HWDEVICE_TYPE_NONE && frame_->hw_frames_ctx) {
             swFrame = av_frame_alloc();
-            swFrame->format = AV_PIX_FMT_YUV420P;
+            // Use the HW backend's native format (e.g. NV12 on VAAPI) to
+            // avoid an extra pixel-format conversion during transfer. The
+            // scaler is rebuilt lazily on format change (lastScalerFmt_).
+            swFrame->format = AV_PIX_FMT_NONE;
             if (av_hwframe_transfer_data(swFrame, frame_, 0) < 0) {
                 logWarning("VideoPlayer") << "HW frame transfer failed, dropping frame";
                 av_frame_free(&swFrame);


### PR DESCRIPTION
Implements both items from #32.

## 1. Log warning on HW frame transfer failure

Previously `av_hwframe_transfer_data` failures silently dropped the frame, which made GPU memory / driver issues hard to diagnose. Now emits a `logWarning` so dropped frames are visible.

## 2. Skip unnecessary pixel-format conversion on HW transfer

HW backends like VAAPI produce **NV12** natively. Requesting `AV_PIX_FMT_YUV420P` during transfer forced an extra conversion inside FFmpeg, only for `sws_scale` to convert to RGBA afterwards (NV12 → YUV420P → RGBA).

Setting the transfer format to `AV_PIX_FMT_NONE` lets the backend yield its native format. The dynamic scaler rebuild (`lastScalerFmt_`) already adapts when the source format changes, so `sws_scale` picks up the native format directly on the first frame (NV12 → RGBA).

Saves one full-frame pixel-format conversion per decoded frame.

## Test plan

- [ ] Play HEVC + AAC video with VAAPI HW decode — verify still plays correctly
- [ ] Check logs: no `HW frame transfer failed` spam under normal operation
- [ ] (RPi) Confirm improvement on high-resolution playback
