### PR TITLE
fix(linux): setLoop() does not work when video has audio

### DIFF
--- a/core/platform/linux/tcVideoPlayer_linux.cpp
+++ b/core/platform/linux/tcVideoPlayer_linux.cpp
@@ -560,6 +560,9 @@ void TCVideoPlayerImpl::update(VideoPlayer* player) {
     // Check if finished
     if (frameQueue_.empty() && isFinished_) {
         if (isLoop_) {
+            if (audioBuffer_) {
+                audioSound_.setPosition(0.0f);
+            }
             seekToTime(0.0);
             playbackStartTime_ = av_gettime_relative() / 1000000.0;
             isFinished_ = false;


### PR DESCRIPTION
When a video with audio loops, audioSound_ was not reset to the beginning. 

Since audio is the master clock on Linux, the next update() saw targetPts at end-of-video while `currentPts_` was `0`, triggering an immediate resync seek back to the end — effectively preventing the loop from working.

Only affects Linux/FFmpeg backend; macOS, iOS, and Windows use native APIs that handle audio reset automatically.

Closes #42