### PR TITLE
fix: PBR D3D11クラッシュ���Ninja+MSVCビルドエラーを修正

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -192,6 +192,15 @@ elseif(TC_PLATFORM_WINDOWS)
         NOMINMAX
         _USE_MATH_DEFINES
     )
+    # configure時のINCLUDE/LIB環境変数パスをビルドシステムに焼き込む。
+    # Ninja+MSVC環境では、cmake --build <dir>（preset経由でない）実行時に
+    # 環境変数が未設定になりヘッダやライブラリが見つからないエラーが起きるため。
+    if(DEFINED ENV{INCLUDE})
+        target_include_directories(TrussC SYSTEM PUBLIC $ENV{INCLUDE})
+    endif()
+    if(DEFINED ENV{LIB})
+        target_link_directories(TrussC PUBLIC $ENV{LIB})
+    endif()
     target_link_libraries(TrussC PUBLIC
         d3d11
         dxgi

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -312,6 +312,9 @@ namespace internal {
 
     // Color pixel format of the current FBO pass (for PBR pipeline format matching)
     inline sg_pixel_format currentFboColorFormat = SG_PIXELFORMAT_RGBA8;
+
+    // MSAAサンプルカウント（FBOパス中のPBRパイプライン用）
+    inline int currentFboSampleCount = 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/core/include/tc/3d/tcEnvironment.h
+++ b/core/include/tc/3d/tcEnvironment.h
@@ -213,6 +213,7 @@ private:
             pd.depth.pixel_format = SG_PIXELFORMAT_NONE;  // no depth attachment
             pd.colors[0].pixel_format = colorFmt;
             pd.colors[0].blend.enabled = false;
+            pd.sample_count = 1;  // オフスクリーンベイク用（MSAA不要）
             pd.label = "tc_ibl_bake_pipeline";
             return sg_make_pipeline(&pd);
         };

--- a/core/include/tc/3d/tcMeshPbrPipeline.h
+++ b/core/include/tc/3d/tcMeshPbrPipeline.h
@@ -41,9 +41,10 @@ public:
         initialized_ = true;
     }
 
-    // Get or create a pipeline for the given color pixel format.
-    sg_pipeline getPipeline(sg_pixel_format colorFormat) {
-        int key = static_cast<int>(colorFormat);
+    // Get or create a pipeline for the given color pixel format and sample count.
+    sg_pipeline getPipeline(sg_pixel_format colorFormat, int sampleCount) {
+        // キャッシュキー: colorFormat(下位16bit) + sampleCount(上位16bit)
+        int key = static_cast<int>(colorFormat) | (sampleCount << 16);
         auto it = pipelineCache_.find(key);
         if (it != pipelineCache_.end()) return it->second;
 
@@ -63,6 +64,7 @@ public:
         pd.colors[0].pixel_format = colorFormat;
         pd.colors[0].blend.enabled = false;
 
+        pd.sample_count = sampleCount;
         pd.index_type = SG_INDEXTYPE_UINT32;
         pd.label = "tc_mesh_pbr_pipeline";
 
@@ -76,12 +78,18 @@ public:
     void drawMesh(const Mesh& mesh) {
         ensureInit();
 
-        // Determine color format for current render target.
-        // _SG_PIXELFORMAT_DEFAULT (0) = use sokol environment default (swapchain).
-        // Note: SG_PIXELFORMAT_NONE (1) means "no color attachment" — don't use it.
-        sg_pixel_format colorFmt = internal::inFboPass
-            ? internal::currentFboColorFormat
-            : _SG_PIXELFORMAT_DEFAULT;
+        // 現在のレンダーターゲットのカラーフォーマットとサンプルカウントを取得
+        // _SG_PIXELFORMAT_DEFAULT (0) = sokol環境デフォルト（スワップチェーン）
+        // SG_PIXELFORMAT_NONE (1) は「カラーアタッチメントなし」なので使わない
+        sg_pixel_format colorFmt;
+        int sampleCount;
+        if (internal::inFboPass) {
+            colorFmt = internal::currentFboColorFormat;
+            sampleCount = internal::currentFboSampleCount;
+        } else {
+            colorFmt = _SG_PIXELFORMAT_DEFAULT;
+            sampleCount = sapp_sample_count();
+        }
 
         // Ensure we are inside a render pass
         if (!internal::inFboPass) {
@@ -93,7 +101,7 @@ public:
         // where the first drawBox should appear beneath the PBR mesh.
         sgl_draw();
 
-        sg_apply_pipeline(getPipeline(colorFmt));
+        sg_apply_pipeline(getPipeline(colorFmt, sampleCount));
 
         // --- Bindings -------------------------------------------------------
         sg_bindings bind = {};
@@ -352,38 +360,32 @@ private:
         if (fallbackInitialized_) return;
 
         // 1x1x6 RGBA8 cubemap, all zeros
+        // D3D11はdynamic cubemapを作れない（ArraySize=1制限）のでimmutableで作成
+        uint8_t zero[4 * 6] = {0};
         sg_image_desc cube_desc = {};
         cube_desc.type = SG_IMAGETYPE_CUBE;
         cube_desc.width = 1;
         cube_desc.height = 1;
         cube_desc.pixel_format = SG_PIXELFORMAT_RGBA8;
-        cube_desc.usage.dynamic_update = true;
+        cube_desc.data.mip_levels[0].ptr = zero;
+        cube_desc.data.mip_levels[0].size = sizeof(zero);
         cube_desc.label = "tc_pbr_fallback_cube";
         fallbackCube_ = sg_make_image(&cube_desc);
-        // Zero-init all 6 faces
-        uint8_t zero[4 * 6] = {0};
-        sg_image_data cube_data = {};
-        cube_data.mip_levels[0].ptr = zero;
-        cube_data.mip_levels[0].size = sizeof(zero);
-        sg_update_image(fallbackCube_, &cube_data);
         sg_view_desc cube_view_desc = {};
         cube_view_desc.texture.image = fallbackCube_;
         fallbackCubeView_ = sg_make_view(&cube_view_desc);
 
         // 1x1 RG16F 2D texture
+        uint16_t zero2d[2] = {0, 0};
         sg_image_desc tex_desc = {};
         tex_desc.type = SG_IMAGETYPE_2D;
         tex_desc.width = 1;
         tex_desc.height = 1;
         tex_desc.pixel_format = SG_PIXELFORMAT_RG16F;
-        tex_desc.usage.dynamic_update = true;
+        tex_desc.data.mip_levels[0].ptr = zero2d;
+        tex_desc.data.mip_levels[0].size = sizeof(zero2d);
         tex_desc.label = "tc_pbr_fallback_2d";
         fallback2d_ = sg_make_image(&tex_desc);
-        uint16_t zero2d[2] = {0, 0};
-        sg_image_data tex_data = {};
-        tex_data.mip_levels[0].ptr = zero2d;
-        tex_data.mip_levels[0].size = sizeof(zero2d);
-        sg_update_image(fallback2d_, &tex_data);
         sg_view_desc tex_view_desc = {};
         tex_view_desc.texture.image = fallback2d_;
         fallback2dView_ = sg_make_view(&tex_view_desc);

--- a/core/include/tc/gpu/tcFbo.h
+++ b/core/include/tc/gpu/tcFbo.h
@@ -217,6 +217,7 @@ public:
         internal::currentFboBlendPipeline = {};
         internal::currentFbo = nullptr;
         internal::currentFboColorFormat = SG_PIXELFORMAT_RGBA8;
+        internal::currentFboSampleCount = 1;
         internal::fboClearColorFunc = nullptr;
 
         // Resume swapchain pass (if we were in one before)
@@ -443,6 +444,7 @@ private:
         internal::currentFboBlendPipeline = shared.pipelineBlend;
         internal::currentFbo = this;
         internal::currentFboColorFormat = toSokolFormat(format_);
+        internal::currentFboSampleCount = sampleCount_;
         internal::fboClearColorFunc = _fboClearColorHelper;
     }
 


### PR DESCRIPTION
## Summary
- PBRパイプラインのMSAAサンプルカウント不一致によるD3D11バリデーションエラーを修正
- IBLベイクパイプラ��ンのsample_count未指定を修正
- fallbackテクスチャをdynamic→immutableに変更（D3D11はdynamic cubemap非対応）
- Ninja+MSVC環境で`cmake --build <dir>`（preset経由でない）実行時のビルドエラーを修正

## 変更内容

| ファイル | 修正 |
|---------|------|
| `core/CMakeLists.txt` | configure時の`INCLUDE`/`LIB`環境変数をビルドシステムに焼き込み |
| `core/include/TrussC.h` | `currentFboSampleCount` internal変数を追加 |
| `core/include/tc/3d/tcMeshPbrPipeline.h` | `getPipeline`にsampleCount引数追加、fallbackテクスチャをimmutable化 |
| `core/include/tc/3d/tcEnvironment.h` | IBLベイクパイプラインに`sample_count=1`を明示指定 |
| `core/include/tc/gpu/tcFbo.h` | FBO begin/endで`currentFboSampleCount`を設定/リセット |

## クロスプラットフォーム確認チェックリスト

### Windows (確認済み)
- [x] `pbrSpheresExample` ビルド成功
- [x] 実行時にsokol_gfxの`[error]`/`[panic]`が出ない
- [x] `cmake --build build-windows`（preset経由でない）でもビルド成功

### macOS
- [x] `pbrSpheresExample` ビルド成功
- [x] 起動直後にsokol_gfxの`[error]`/`[panic]`が出ない
- [x] 5x5の球体グリッドが表示される
- [x] 球体に環境反射が映る（IBLベイク成功の確認）
- [x] ドラッグでカメラ回転しても落ちない

### Linux
- [x] `pbrSpheresExample` ビルド成功
- [x] ��動直後にsokol_gfxの`[error]`/`[panic]`が出��い
- [x] 5x5の球体グ��ッドが表示さ���る
- [x] 球体に環境��射が映��（IBLベイク成功の確認）
- [x] ドラッグでカメラ回転しても落ちない