### PR TITLE
feat(video): GPU NV12 path for Linux HW decoders (NVDEC/VAAPI)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -611,7 +611,7 @@ if(TC_SHADER_SOURCES)
     set(_TC_SHADER_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/tc/gpu/shaders")
     file(MAKE_DIRECTORY "${_TC_SHADER_OUTPUT_DIR}")
 
-    set(_TC_SOKOL_SLANG "metal_macos:metal_ios:hlsl5:glsl300es:wgsl")
+    set(_TC_SOKOL_SLANG "metal_macos:metal_ios:hlsl5:glsl300es:glsl430:wgsl")
 
     set(_TC_SHADER_OUTPUTS "")
     foreach(_shader_src ${TC_SHADER_SOURCES})

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -68,6 +68,15 @@ public:
             if (nv12Mode_) {
                 textureY_.allocate(width_,     height_,     1,                  TextureUsage::Stream);
                 textureUV_.allocate(width_ / 2, height_ / 2, TextureFormat::RG8, TextureUsage::Stream);
+                // Prime the textures with the neutral-chroma CPU buffers
+                // (Y=0, UV=128) set up in loadPlatform(). Without this, the
+                // GPU textures contain uninitialized data and the BT.601
+                // shader renders a green flash on the first frame (Y=0,
+                // U=0, V=0 → RGB (0, 135, 0)).
+                if (pixelsY_ && pixelsUV_) {
+                    textureY_.loadData(pixelsY_,  width_,     height_,     1);
+                    textureUV_.loadData(pixelsUV_, width_ / 2, height_ / 2, 2);
+                }
             } else {
                 texture_.allocate(width_, height_, 4, TextureUsage::Stream);
                 clearTexture();

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -63,10 +63,15 @@ public:
             return false;
         }
 
-        // Create texture (Stream mode: for per-frame updates)
+        // Create texture(s) for per-frame updates
         if (width_ > 0 && height_ > 0) {
-            texture_.allocate(width_, height_, 4, TextureUsage::Stream);
-            clearTexture();
+            if (nv12Mode_) {
+                textureY_.allocate(width_,     height_,     1,                  TextureUsage::Stream);
+                textureUV_.allocate(width_ / 2, height_ / 2, TextureFormat::RG8, TextureUsage::Stream);
+            } else {
+                texture_.allocate(width_, height_, 4, TextureUsage::Stream);
+                clearTexture();
+            }
         }
 
         initialized_ = true;
@@ -80,11 +85,14 @@ public:
         closePlatform();
 
         texture_.clear();
+        textureY_.clear();
+        textureUV_.clear();
 
-        if (pixels_) {
-            delete[] pixels_;
-            pixels_ = nullptr;
-        }
+        if (pixels_)  { delete[] pixels_;  pixels_  = nullptr; }
+        if (pixelsY_) { delete[] pixelsY_; pixelsY_ = nullptr; }
+        if (pixelsUV_){ delete[] pixelsUV_; pixelsUV_ = nullptr; }
+        nv12Mode_ = false;
+        nv12ShaderHandle_ = nullptr;  // deleted in closePlatform()
 
         initialized_ = false;
         playing_ = false;
@@ -110,11 +118,18 @@ public:
 
         // Check for new frame from platform
         if (hasNewFramePlatform()) {
-            // Update texture from pixel buffer
             std::lock_guard<std::mutex> lock(mutex_);
-            if (pixels_ && width_ > 0 && height_ > 0) {
-                texture_.loadData(pixels_, width_, height_, 4);
-                markFrameNew();
+            if (nv12Mode_) {
+                if (pixelsY_ && pixelsUV_ && width_ > 0 && height_ > 0) {
+                    textureY_.loadData(pixelsY_,  width_,     height_,     1);
+                    textureUV_.loadData(pixelsUV_, width_ / 2, height_ / 2, 2);
+                    markFrameNew();
+                }
+            } else {
+                if (pixels_ && width_ > 0 && height_ > 0) {
+                    texture_.loadData(pixels_, width_, height_, 4);
+                    markFrameNew();
+                }
             }
         }
 
@@ -122,6 +137,24 @@ public:
         if (playing_ && !paused_ && isFinishedPlatform()) {
             markDone();
         }
+    }
+
+    // =========================================================================
+    // Draw (NV12 path uses shader; RGBA path uses default HasTexture::draw)
+    // =========================================================================
+
+    void draw(float x, float y) const override {
+        draw(x, y, (float)width_, (float)height_);
+    }
+
+    void draw(float x, float y, float w, float h) const override {
+#ifdef __linux__
+        if (nv12Mode_ && nv12ShaderHandle_) {
+            drawNV12Platform(x, y, w, h);
+            return;
+        }
+#endif
+        if (texture_.isAllocated()) texture_.draw(x, y, w, h);
     }
 
     // =========================================================================
@@ -207,6 +240,9 @@ public:
     unsigned char* getPixels() override { return pixels_; }
     const unsigned char* getPixels() const override { return pixels_; }
 
+    unsigned char* getPixelsY()  { return pixelsY_; }
+    unsigned char* getPixelsUV() { return pixelsUV_; }
+
     // =========================================================================
     // Audio access
     // =========================================================================
@@ -267,7 +303,15 @@ protected:
 private:
     // Pixel data (RGBA)
     unsigned char* pixels_ = nullptr;
-    
+
+    // NV12 (CUDA HW decode) planes — Linux only, non-null when nv12Mode_ is set
+    unsigned char* pixelsY_  = nullptr;
+    unsigned char* pixelsUV_ = nullptr;
+    Texture textureY_;
+    Texture textureUV_;
+    bool  nv12Mode_       = false;
+    void* nv12ShaderHandle_ = nullptr;  // NV12VideoShader* on Linux/CUDA
+
     // Gamma correction (1.0 = none)
     float gammaCorrection_ = 1.0f;
 
@@ -293,15 +337,24 @@ private:
         loop_ = other.loop_;
         volume_ = other.volume_;
         speed_ = other.speed_;
-        pixels_ = other.pixels_;
-        texture_ = std::move(other.texture_);
-        platformHandle_ = other.platformHandle_;
+        pixels_    = other.pixels_;
+        pixelsY_   = other.pixelsY_;
+        pixelsUV_  = other.pixelsUV_;
+        texture_   = std::move(other.texture_);
+        textureY_  = std::move(other.textureY_);
+        textureUV_ = std::move(other.textureUV_);
+        nv12Mode_        = other.nv12Mode_;
+        nv12ShaderHandle_ = other.nv12ShaderHandle_;
+        platformHandle_  = other.platformHandle_;
 
-        // Invalidate source
-        other.pixels_ = nullptr;
-        other.initialized_ = false;
-        other.platformHandle_ = nullptr;
-        other.width_ = 0;
+        other.pixels_    = nullptr;
+        other.pixelsY_   = nullptr;
+        other.pixelsUV_  = nullptr;
+        other.nv12Mode_        = false;
+        other.nv12ShaderHandle_ = nullptr;
+        other.initialized_     = false;
+        other.platformHandle_  = nullptr;
+        other.width_  = 0;
         other.height_ = 0;
     }
 
@@ -373,6 +426,10 @@ private:
 
     // Allow platform implementations to access internals
     friend class VideoPlayerPlatformAccess;
+
+#ifdef __linux__
+    void drawNV12Platform(float x, float y, float w, float h) const;
+#endif
 };
 
 // Helper class for platform implementations to access protected members

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -157,7 +157,7 @@ public:
     }
 
     void draw(float x, float y, float w, float h) const override {
-#ifdef __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
         if (nv12Mode_ && nv12ShaderHandle_) {
             drawNV12Platform(x, y, w, h);
             return;
@@ -436,7 +436,7 @@ private:
     // Allow platform implementations to access internals
     friend class VideoPlayerPlatformAccess;
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
     void drawNV12Platform(float x, float y, float w, float h) const;
 #endif
 };

--- a/core/platform/linux/tcVideoPlayer_linux.cpp
+++ b/core/platform/linux/tcVideoPlayer_linux.cpp
@@ -1142,7 +1142,7 @@ bool VideoPlayer::loadPlatform(const std::string& path) {
             pixelsY_   = new unsigned char[width_ * height_];
             pixelsUV_  = new unsigned char[width_ * height_ / 2];
             std::memset(pixelsY_,  0, width_ * height_);
-            std::memset(pixelsUV_, 0, width_ * height_ / 2);
+            std::memset(pixelsUV_, 128, width_ * height_ / 2);  // 128 = neutral chroma in NV12
 
             auto* shader = new NV12VideoShader();
             shader->loadShader();

--- a/core/platform/linux/tcVideoPlayer_linux.cpp
+++ b/core/platform/linux/tcVideoPlayer_linux.cpp
@@ -1147,9 +1147,16 @@ public:
 
         sg_apply_pipeline(pipeline);
 
+        // x/y/w/h come in logical coordinates (same space tcApp draws in),
+        // but sapp_width()/sapp_height() are physical framebuffer pixels.
+        // Divide by DPI scale so the shader's viewport matches its inputs.
+        const float dpiScale = sapp_dpi_scale();
+        const float vpW = (float)sapp_width()  / dpiScale;
+        const float vpH = (float)sapp_height() / dpiScale;
+
         struct VsParams { float v[8]; } p = {{
-            (float)sapp_width(), (float)sapp_height(), x, y,
-            w, h, 0.0f, 0.0f
+            vpW, vpH, x, y,
+            w,   h,   0.0f, 0.0f
         }};
         sg_range range = { &p, sizeof(p) };
         sg_apply_uniforms(0, &range);
@@ -1168,7 +1175,7 @@ public:
         sg_reset_state_cache();
         sgl_defaults();
         sgl_matrix_mode_projection();
-        sgl_ortho(0.0f, (float)sapp_width(), (float)sapp_height(), 0.0f, -10000.0f, 10000.0f);
+        sgl_ortho(0.0f, vpW, vpH, 0.0f, -10000.0f, 10000.0f);
         sgl_matrix_mode_modelview();
         sgl_load_identity();
     }

--- a/core/platform/linux/tcVideoPlayer_linux.cpp
+++ b/core/platform/linux/tcVideoPlayer_linux.cpp
@@ -161,7 +161,9 @@ private:
 
     // Frame queue
     struct FrameData {
-        std::vector<uint8_t> pixels;
+        std::vector<uint8_t> pixels;    // RGBA, or NV12 Y-plane when isNV12
+        std::vector<uint8_t> pixelsUV;  // NV12 UV-plane (empty when !isNV12)
+        bool isNV12 = false;
         double pts;
     };
     std::queue<FrameData> frameQueue_;
@@ -175,6 +177,10 @@ private:
     // Pixel buffer
     uint8_t* rgbaBuffer_ = nullptr;
     int rgbaBufferSize_ = 0;
+
+public:
+    bool nv12Mode_ = false;  // set by loadPlatform() when CUDA is active
+    bool isNV12Capable() const { return hwType_ == AV_HWDEVICE_TYPE_CUDA; }
 };
 
 // =============================================================================
@@ -545,18 +551,28 @@ void TCVideoPlayerImpl::update(VideoPlayer* player) {
         FrameData& front = frameQueue_.front();
 
         if (front.pts <= targetPts) {
-            // Copy pixels to VideoPlayer's buffer
             if (player) {
-                unsigned char* playerPixels = player->getPixels();
-                if (playerPixels && front.pixels.size() == (size_t)(width_ * height_ * 4)) {
-                    memcpy(playerPixels, front.pixels.data(), front.pixels.size());
-                    hasNewFrame_ = true;
-                    currentPts_ = front.pts;
+                if (front.isNV12) {
+                    unsigned char* yBuf  = player->getPixelsY();
+                    unsigned char* uvBuf = player->getPixelsUV();
+                    if (yBuf  && front.pixels.size()   == (size_t)(width_ * height_) &&
+                        uvBuf && front.pixelsUV.size() == (size_t)(width_ * height_ / 2)) {
+                        memcpy(yBuf,  front.pixels.data(),   front.pixels.size());
+                        memcpy(uvBuf, front.pixelsUV.data(), front.pixelsUV.size());
+                        hasNewFrame_ = true;
+                        currentPts_  = front.pts;
+                    }
+                } else {
+                    unsigned char* playerPixels = player->getPixels();
+                    if (playerPixels && front.pixels.size() == (size_t)(width_ * height_ * 4)) {
+                        memcpy(playerPixels, front.pixels.data(), front.pixels.size());
+                        hasNewFrame_ = true;
+                        currentPts_  = front.pts;
+                    }
                 }
             }
             frameQueue_.pop();
         } else {
-            // Frame is in the future, wait
             break;
         }
     }
@@ -708,8 +724,40 @@ bool TCVideoPlayerImpl::decodeNextFrame() {
             srcFrame = swFrame;
         }
 
-        // Recreate scaler if source pixel format changed (HW transfer may
-        // produce NV12 / YUV420P depending on backend).
+        // Calculate PTS (frame_->pts before any av_frame_unref)
+        double pts = 0.0;
+        if (frame_->pts != AV_NOPTS_VALUE)
+            pts = frame_->pts * av_q2d(timeBase_);
+
+        // NV12 fast path: copy Y+UV planes directly, skip sws_scale entirely
+        if (nv12Mode_ && srcFrame->format == AV_PIX_FMT_NV12) {
+            FrameData data;
+            data.isNV12 = true;
+            data.pts    = pts;
+
+            data.pixels.resize(width_ * height_);
+            for (int row = 0; row < height_; ++row)
+                std::memcpy(data.pixels.data()  + row * width_,
+                            srcFrame->data[0]   + row * srcFrame->linesize[0],
+                            width_);
+
+            const int uvRows     = height_ / 2;
+            const int uvRowBytes = width_;      // (width/2 pairs) * 2 bytes = width
+            data.pixelsUV.resize(uvRows * uvRowBytes);
+            for (int row = 0; row < uvRows; ++row)
+                std::memcpy(data.pixelsUV.data() + row * uvRowBytes,
+                            srcFrame->data[1]    + row * srcFrame->linesize[1],
+                            uvRowBytes);
+
+            if (swFrame) av_frame_free(&swFrame);
+            av_frame_unref(frame_);
+
+            std::lock_guard<std::mutex> lock(mutex_);
+            frameQueue_.push(std::move(data));
+            return true;
+        }
+
+        // RGBA fallback: sws_scale for non-CUDA or non-NV12
         AVPixelFormat srcFmt = (AVPixelFormat)srcFrame->format;
         if (srcFmt != lastScalerFmt_ && srcFmt != AV_PIX_FMT_NONE) {
             if (swsCtx_) sws_freeContext(swsCtx_);
@@ -730,13 +778,6 @@ bool TCVideoPlayerImpl::decodeNextFrame() {
 
         if (swFrame) av_frame_free(&swFrame);
 
-        // Calculate PTS
-        double pts = 0.0;
-        if (frame_->pts != AV_NOPTS_VALUE) {
-            pts = frame_->pts * av_q2d(timeBase_);
-        }
-
-        // Add to queue
         {
             std::lock_guard<std::mutex> lock(mutex_);
             FrameData data;
@@ -1012,6 +1053,74 @@ void TCVideoPlayerImpl::previousFrame() {
 // VideoPlayer platform methods (Linux implementation)
 // =============================================================================
 
+#include "tc/gpu/shaders/videoNV12.glsl.h"
+
+// NV12 immediate-draw shader (immutable unit-quad, uniform-based positioning)
+class NV12VideoShader : public Shader {
+public:
+    void loadShader() { load(tc_video_nv12_nv12_shader_desc); }
+
+    void draw(float x, float y, float w, float h,
+              const Texture& texY, const Texture& texUV) {
+        if (!loaded) return;
+
+        ensureSwapchainPass();
+        sgl_draw();
+
+        sg_apply_pipeline(pipeline);
+
+        struct VsParams { float v[8]; } p = {{
+            (float)sapp_width(), (float)sapp_height(), x, y,
+            w, h, 0.0f, 0.0f
+        }};
+        sg_range range = { &p, sizeof(p) };
+        sg_apply_uniforms(0, &range);
+
+        sg_bindings bind = {};
+        bind.vertex_buffers[0] = vertexBuffer;
+        bind.index_buffer      = indexBuffer;
+        bind.views[0]    = texY.getView();
+        bind.samplers[0] = texY.getSampler();
+        bind.views[1]    = texUV.getView();
+        bind.samplers[1] = texUV.getSampler();
+        sg_apply_bindings(&bind);
+
+        sg_draw(0, 6, 1);
+
+        sg_reset_state_cache();
+        sgl_defaults();
+        sgl_matrix_mode_projection();
+        sgl_ortho(0.0f, (float)sapp_width(), (float)sapp_height(), 0.0f, -10000.0f, 10000.0f);
+        sgl_matrix_mode_modelview();
+        sgl_load_identity();
+    }
+
+protected:
+    sg_pipeline_desc createPipelineDesc() override {
+        sg_pipeline_desc desc = {};
+        desc.layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
+        desc.colors[0].blend.enabled = false;
+        desc.index_type = SG_INDEXTYPE_UINT16;
+        desc.label = "tc_nv12_pipeline";
+        return desc;
+    }
+
+    void createVertexBuffer() override {
+        float verts[] = { 0.f,0.f, 1.f,0.f, 1.f,1.f, 0.f,1.f };
+        sg_buffer_desc vd = {};
+        vd.data  = SG_RANGE(verts);
+        vd.label = "tc_nv12_verts";
+        vertexBuffer = sg_make_buffer(&vd);
+
+        uint16_t idx[] = { 0, 1, 2, 0, 2, 3 };
+        sg_buffer_desc id = {};
+        id.usage.index_buffer = true;
+        id.data  = SG_RANGE(idx);
+        id.label = "tc_nv12_idx";
+        indexBuffer = sg_make_buffer(&id);
+    }
+};
+
 namespace trussc {
 
 bool VideoPlayer::loadPlatform(const std::string& path) {
@@ -1023,24 +1132,44 @@ bool VideoPlayer::loadPlatform(const std::string& path) {
     }
 
     platformHandle_ = impl;
-    width_ = impl->getWidth();
+    width_  = impl->getWidth();
     height_ = impl->getHeight();
 
-    // Allocate pixel buffer
     if (width_ > 0 && height_ > 0) {
-        pixels_ = new unsigned char[width_ * height_ * 4];
-        std::memset(pixels_, 0, width_ * height_ * 4);
+        if (impl->isNV12Capable()) {
+            impl->nv12Mode_ = true;
+            nv12Mode_  = true;
+            pixelsY_   = new unsigned char[width_ * height_];
+            pixelsUV_  = new unsigned char[width_ * height_ / 2];
+            std::memset(pixelsY_,  0, width_ * height_);
+            std::memset(pixelsUV_, 0, width_ * height_ / 2);
+
+            auto* shader = new NV12VideoShader();
+            shader->loadShader();
+            nv12ShaderHandle_ = shader;
+        } else {
+            pixels_ = new unsigned char[width_ * height_ * 4];
+            std::memset(pixels_, 0, width_ * height_ * 4);
+        }
     }
 
     return true;
 }
 
 void VideoPlayer::closePlatform() {
+    if (nv12ShaderHandle_) {
+        delete static_cast<NV12VideoShader*>(nv12ShaderHandle_);
+        nv12ShaderHandle_ = nullptr;
+    }
     if (platformHandle_) {
         auto impl = static_cast<TCVideoPlayerImpl*>(platformHandle_);
         delete impl;
         platformHandle_ = nullptr;
     }
+}
+
+void VideoPlayer::drawNV12Platform(float x, float y, float w, float h) const {
+    static_cast<NV12VideoShader*>(nv12ShaderHandle_)->draw(x, y, w, h, textureY_, textureUV_);
 }
 
 void VideoPlayer::playPlatform() {

--- a/core/platform/linux/tcVideoPlayer_linux.cpp
+++ b/core/platform/linux/tcVideoPlayer_linux.cpp
@@ -107,6 +107,7 @@ private:
     void decodeThread();
     bool decodeNextFrame();
     void seekToTime(double seconds);
+    void probeHwOutputFormat();
 
     // FFmpeg context
     AVFormatContext* formatCtx_ = nullptr;
@@ -122,6 +123,11 @@ private:
     AVBufferRef*   hwDeviceCtx_   = nullptr;
     AVHWDeviceType hwType_        = AV_HWDEVICE_TYPE_NONE;
     AVPixelFormat  lastScalerFmt_ = AV_PIX_FMT_NONE;
+    // Filled by probeHwOutputFormat() after opening the codec. For HW decode
+    // this is the format the first transferred frame actually produced (e.g.
+    // NV12 on most VAAPI/NVDEC paths, P010 for 10-bit, YUV420P for some
+    // V4L2M2M). AV_PIX_FMT_NONE if no HW or probe failed.
+    AVPixelFormat  probedFormat_  = AV_PIX_FMT_NONE;
 
     int videoStreamIndex_ = -1;
     int audioStreamIndex_ = -1;
@@ -179,8 +185,14 @@ private:
     int rgbaBufferSize_ = 0;
 
 public:
-    bool nv12Mode_ = false;  // set by loadPlatform() when CUDA is active
-    bool isNV12Capable() const { return hwType_ == AV_HWDEVICE_TYPE_CUDA; }
+    bool nv12Mode_ = false;  // set by loadPlatform() when HW decode produces NV12
+    // Runtime check: HW backend is active AND the first probed frame came
+    // out as NV12 after hwframe_transfer. Different backends / codecs /
+    // bit-depths can produce P010, YUV420P, etc. — those fall back to RGBA.
+    bool isNV12Capable() const {
+        return hwType_ != AV_HWDEVICE_TYPE_NONE
+            && probedFormat_ == AV_PIX_FMT_NV12;
+    }
 };
 
 // =============================================================================
@@ -368,6 +380,10 @@ bool TCVideoPlayerImpl::load(const std::string& path, VideoPlayer* player) {
             logWarning("VideoPlayer") << "Failed to decode audio";
         }
     }
+
+    // Probe the first decoded frame so callers can see the post-transfer
+    // pixel format and pick NV12 fast path vs RGBA fallback accurately.
+    probeHwOutputFormat();
 
     return true;
 }
@@ -640,6 +656,68 @@ void TCVideoPlayerImpl::decodeThread() {
         if (!decodeNextFrame()) {
             isFinished_ = true;
         }
+    }
+}
+
+// Decodes a single frame up-front to learn the actual post-transfer pixel
+// format (e.g. NV12 on VAAPI/NVDEC, P010 for 10-bit, YUV420P on some
+// V4L2M2M). The format only becomes knowable after av_hwframe_transfer_data
+// runs, so we cannot decide it from hwType_ alone. The demuxer is rewound
+// and the codec flushed afterwards so playback starts cleanly from frame 0.
+void TCVideoPlayerImpl::probeHwOutputFormat() {
+    probedFormat_ = AV_PIX_FMT_NONE;
+    if (hwType_ == AV_HWDEVICE_TYPE_NONE) return;  // SW decode: nothing to probe
+
+    AVFrame* probeFrame = av_frame_alloc();
+    bool captured = false;
+    constexpr int kMaxPackets = 64;  // keep probe bounded
+
+    for (int i = 0; i < kMaxPackets && !captured; ++i) {
+        int ret = av_read_frame(formatCtx_, packet_);
+        if (ret < 0) break;
+        if (packet_->stream_index != videoStreamIndex_) {
+            av_packet_unref(packet_);
+            continue;
+        }
+
+        ret = avcodec_send_packet(codecCtx_, packet_);
+        av_packet_unref(packet_);
+        if (ret < 0 && ret != AVERROR(EAGAIN)) continue;
+
+        while (!captured) {
+            ret = avcodec_receive_frame(codecCtx_, frame_);
+            if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) break;
+            if (ret < 0) { captured = false; break; }
+
+            if (frame_->hw_frames_ctx) {
+                probeFrame->format = AV_PIX_FMT_NONE;
+                if (av_hwframe_transfer_data(probeFrame, frame_, 0) >= 0) {
+                    probedFormat_ = (AVPixelFormat)probeFrame->format;
+                    captured = true;
+                }
+                av_frame_unref(probeFrame);
+            } else {
+                probedFormat_ = (AVPixelFormat)frame_->format;
+                captured = true;
+            }
+            av_frame_unref(frame_);
+        }
+    }
+
+    av_frame_free(&probeFrame);
+    av_frame_unref(frame_);
+
+    // Reset demuxer + codec state so the decode thread starts from frame 0.
+    av_seek_frame(formatCtx_, videoStreamIndex_, 0, AVSEEK_FLAG_BACKWARD);
+    avcodec_flush_buffers(codecCtx_);
+    packetPending_ = false;
+
+    if (captured) {
+        const char* name = av_get_pix_fmt_name(probedFormat_);
+        logNotice("VideoPlayer") << "HW transfer format: "
+                                  << (name ? name : "unknown");
+    } else {
+        logWarning("VideoPlayer") << "HW format probe failed; using RGBA fallback";
     }
 }
 

--- a/core/shaders/videoNV12.glsl
+++ b/core/shaders/videoNV12.glsl
@@ -1,0 +1,52 @@
+@module tc_video_nv12
+// NV12 (NVDEC output) → RGB shader for VideoPlayer on Linux/CUDA.
+// Eliminates CPU-side sws_scale() by doing YUV→RGB in the fragment shader.
+// Y plane:  R8  texture, full resolution
+// UV plane: RG8 texture, half resolution (chroma subsampling)
+
+@vs vs_nv12
+layout(binding=0) uniform vs_params {
+    vec4 screenSizePos;  // xy = screen size (pixels), zw = draw origin (pixels)
+    vec4 sizePad;        // xy = draw size (pixels), zw = unused (padding)
+};
+
+in vec2 position;   // unit quad: (0,0) → (1,1)
+out vec2 v_uv;
+
+void main() {
+    v_uv = position;
+    vec2 pixelPos = screenSizePos.zw + position * sizePad.xy;
+    vec2 ndc = (pixelPos / screenSizePos.xy) * 2.0 - 1.0;
+    ndc.y = -ndc.y;
+    gl_Position = vec4(ndc, 0.0, 1.0);
+}
+@end
+
+@fs fs_nv12
+layout(binding=0) uniform texture2D texY;
+layout(binding=0) uniform sampler smpY;
+layout(binding=1) uniform texture2D texUV;
+layout(binding=1) uniform sampler smpUV;
+
+in vec2 v_uv;
+out vec4 frag_color;
+
+void main() {
+    float y  = texture(sampler2D(texY,  smpY),  v_uv).r;
+    vec2  uv = texture(sampler2D(texUV, smpUV), v_uv).rg;
+
+    // BT.601 limited-range YCbCr → RGB
+    float yy = (y  - 16.0 / 255.0) * (255.0 / 219.0);
+    float u  = (uv.r - 0.5) * (255.0 / 224.0);
+    float v  = (uv.g - 0.5) * (255.0 / 224.0);
+
+    frag_color = vec4(
+        clamp(yy + 1.402   * v,               0.0, 1.0),
+        clamp(yy - 0.34414 * u - 0.71414 * v, 0.0, 1.0),
+        clamp(yy + 1.772   * u,               0.0, 1.0),
+        1.0
+    );
+}
+@end
+
+@program nv12 vs_nv12 fs_nv12


### PR DESCRIPTION
Closes #41

## Summary

Adds a GPU-side NV12 → RGB path for Linux HW-decoded video, eliminating the CPU-bound `sws_scale()` stage. On Nvidia P1000 / FHD 60fps HEVC: **CPU ~116% → ~46%** with smooth playback even under concurrent CPU load.

Pipeline change:

```
before:  HW decode → hwframe_transfer → sws_scale [CPU] → memcpy×2 → glTex
after:   HW decode → hwframe_transfer → memcpy×1 (Y+UV)  → shader [GPU]
```


## What's included

- **NV12 fast path + shader** — Upload Y(R8) + UV(RG8) planes, convert in fragment shader (BT.601)
- **Runtime format probe** — Decode one frame at load and inspect post-transfer format; NV12 fast path enabled only when HW is active AND the frame actually comes out as NV12. Safely falls back to RGBA for P010 (10-bit), YUV420P, and other formats — no hardcoded backend allowlist
- **glsl430 target** — sokol-shdc was missing this, causing custom shaders to silently fail on Linux GLCORE
- **DPI scale fix** — Shader was passing physical `sapp_width/height` while x/y/w/h come in logical coords; video rendered at half size on non-1.0 DPI systems. Also fixed the subsequent `sgl_ortho` reset (was leaving sgl in physical-pixel space, breaking 2D UI drawn afterwards)
- **Initial texture prime** — Freshly allocated NV12 textures contained uninitialized data; BT.601 decodes (Y=0, U=0, V=0) as (0, 135, 0) — a green flash on the first frame. Primed with neutral CPU buffers at load, mirroring the RGBA path's `clearTexture()`

## Tested

| Backend | GPU | Codec | Result |
|---------|-----|-------|--------|
| CUDA/NVDEC | Nvidia P1000 (lenovo p340 tiny) | HEVC 1080p60 | CPU 116% → 46%, smooth |
| VAAPI | Intel iGPU (lenovo thinkpad x1 Nano) | HEVC 1080p60 | smooth |

## Test plan

- [x] NV12 path engages on both CUDA and VAAPI
- [x] DPI scale — video fills window correctly on HiDPI display
- [x] No green flash on first frame
- [x] 2D UI (progress bar, overlays) drawn after video is positioned correctly
- [x] RGBA fallback still works when probe returns non-NV12
- [ ] 10-bit HEVC (P010) — expected to fall back to RGBA, untested
