### PR TITLE
fix: --session x11 works end-to-end on Raspberry Pi 5 (headless / SSH) + document update 

### DIFF
--- a/docs/GET_STARTED_CONSOLE_MODE.md
+++ b/docs/GET_STARTED_CONSOLE_MODE.md
@@ -108,11 +108,9 @@ sudo apt install twm        # Debian / Raspbian
 sudo pacman -S xorg-twm     # Arch
 ```
 
-> **Raspberry Pi 5 troubleshooting** — Pi 5 has no legacy `/dev/fb0`. Modern
-> Xorg auto-selects the `modesetting` driver for the V3D KMS device, but if
-> Xorg aborts with `(EE) Cannot run in framebuffer mode. Please specify busIDs
-> for all framebuffer devices`, force `modesetting` by creating
-> `/etc/X11/xorg.conf.d/99-vc4.conf`:
+> **Raspberry Pi 5 only** — Pi 5 has no legacy `/dev/fb0`, so Xorg falls back
+> to `fbdev` and fails with "Cannot run in framebuffer mode". Force the
+> `modesetting` driver by creating `/etc/X11/xorg.conf.d/99-vc4.conf`:
 >
 > ```bash
 > sudo tee /etc/X11/xorg.conf.d/99-vc4.conf > /dev/null << 'EOF'

--- a/docs/GET_STARTED_CONSOLE_MODE.md
+++ b/docs/GET_STARTED_CONSOLE_MODE.md
@@ -90,10 +90,32 @@ The simplest option. Works well and avoids Wayland-specific issues (e.g., surfac
 **Install X11:**
 ```bash
 # Debian / Raspbian / Ubuntu
-sudo apt install xserver-xorg xinit
+sudo apt install xserver-xorg xinit libgl1-mesa-dri
 
 # Arch
-sudo pacman -S xorg-server xorg-xinit
+sudo pacman -S xorg-server xorg-xinit mesa
+```
+
+> **Raspberry Pi 5 only** — Pi 5 has no legacy `/dev/fb0`, so Xorg falls back
+> to `fbdev` and fails with "Cannot run in framebuffer mode". Force the
+> `modesetting` driver by creating `/etc/X11/xorg.conf.d/99-vc4.conf`:
+>
+> ```bash
+> sudo tee /etc/X11/xorg.conf.d/99-vc4.conf > /dev/null << 'EOF'
+> Section "OutputClass"
+>     Identifier "vc4"
+>     MatchDriver "vc4"
+>     Driver "modesetting"
+>     Option "PrimaryGPU" "true"
+> EndSection
+> EOF
+> ```
+
+**Permissions** — add yourself to the video / render groups so the X
+server can access the GPU:
+```bash
+sudo usermod -aG video,render $USER
+# Log out and back in for changes to take effect
 ```
 
 **Run:**

--- a/docs/GET_STARTED_CONSOLE_MODE.md
+++ b/docs/GET_STARTED_CONSOLE_MODE.md
@@ -90,10 +90,22 @@ The simplest option. Works well and avoids Wayland-specific issues (e.g., surfac
 **Install X11:**
 ```bash
 # Debian / Raspbian / Ubuntu
-sudo apt install xserver-xorg xinit libgl1-mesa-dri
+sudo apt install xserver-xorg xinit libgl1-mesa-dri x11-xserver-utils
 
 # Arch
-sudo pacman -S xorg-server xorg-xinit mesa
+sudo pacman -S xorg-server xorg-xinit mesa xorg-xhost
+```
+
+`x11-xserver-utils` (Arch: `xorg-xhost`) provides `xhost`, which
+`trusscli run --session x11` uses to authorize the local user.
+
+**Optional — window manager for multi-window apps:**
+Single-window apps run fine without a WM. If your app opens file
+dialogs, popups, or extra windows, install a minimal WM (`trusscli`
+auto-detects and uses it):
+```bash
+sudo apt install twm        # Debian / Raspbian
+sudo pacman -S xorg-twm     # Arch
 ```
 
 > **Raspberry Pi 5 only** — Pi 5 has no legacy `/dev/fb0`, so Xorg falls back

--- a/docs/GET_STARTED_CONSOLE_MODE.md
+++ b/docs/GET_STARTED_CONSOLE_MODE.md
@@ -279,6 +279,20 @@ sudo pacman -S mesa
 
 This is expected — labwc creates a Wayland session without a physical display. The app runs in the background. Connect a monitor to see the output, or use MCP mode (`TRUSSC_MCP=1`) for headless interaction.
 
+### Monitor goes to sleep / screen blanks during long runs
+
+For installations and kiosk setups you typically want the display always on. X11 has its own screensaver and DPMS (power management) that blank the screen after a few minutes of no input.
+
+Disable them inside the X session — easiest is to add the commands to `~/.xprofile` (sourced when X starts) or run them once after launch:
+
+```bash
+xset s off       # disable screensaver
+xset -dpms       # disable display power management
+xset s noblank   # don't blank the screen
+```
+
+For the Linux console framebuffer (non-X), add `consoleblank=0` to `/boot/firmware/cmdline.txt` and reboot.
+
 ---
 
 ## See Also

--- a/docs/GET_STARTED_CONSOLE_MODE.md
+++ b/docs/GET_STARTED_CONSOLE_MODE.md
@@ -108,9 +108,11 @@ sudo apt install twm        # Debian / Raspbian
 sudo pacman -S xorg-twm     # Arch
 ```
 
-> **Raspberry Pi 5 only** — Pi 5 has no legacy `/dev/fb0`, so Xorg falls back
-> to `fbdev` and fails with "Cannot run in framebuffer mode". Force the
-> `modesetting` driver by creating `/etc/X11/xorg.conf.d/99-vc4.conf`:
+> **Raspberry Pi 5 troubleshooting** — Pi 5 has no legacy `/dev/fb0`. Modern
+> Xorg auto-selects the `modesetting` driver for the V3D KMS device, but if
+> Xorg aborts with `(EE) Cannot run in framebuffer mode. Please specify busIDs
+> for all framebuffer devices`, force `modesetting` by creating
+> `/etc/X11/xorg.conf.d/99-vc4.conf`:
 >
 > ```bash
 > sudo tee /etc/X11/xorg.conf.d/99-vc4.conf > /dev/null << 'EOF'

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -2308,11 +2308,23 @@ static int cmdRun(const vector<string>& args) {
             //   6. Tear xinit down when the app exits
             cout << "Launching via xinit (X11 session) on vt7 ...\n";
 
-            // 1. Write minimal xinitrc that keeps a WM alive without xterm.
+            // 1. Write minimal xinitrc. Single-window apps work fine with
+            // no WM (verified on Pi 5), so we don't make a WM a hard dep.
+            // If twm or openbox happens to be installed though, prefer it
+            // — it helps with multi-window scenarios such as file dialogs,
+            // popups, or apps that open additional windows. Otherwise just
+            // keep the X session alive with sleep infinity.
             string xinitrcPath = "/tmp/trusscli-x11-" + to_string(getpid()) + ".sh";
             {
                 ofstream f(xinitrcPath);
-                f << "#!/bin/sh\nexec twm\n";
+                f << "#!/bin/sh\n"
+                  << "if command -v twm >/dev/null 2>&1; then\n"
+                  << "    exec twm\n"
+                  << "elif command -v openbox >/dev/null 2>&1; then\n"
+                  << "    exec openbox\n"
+                  << "else\n"
+                  << "    exec sleep infinity\n"
+                  << "fi\n";
             }
             chmod(xinitrcPath.c_str(), 0755);
 

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -13,6 +13,7 @@
 #include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <signal.h>
 #else
 #include <process.h>
 #endif
@@ -2292,19 +2293,62 @@ static int cmdRun(const vector<string>& args) {
             return runProcess({"labwc", "-s", binPath});
         }
         if (session == "x11") {
-            // Put Xorg on the currently-active VT so output is visible on
-            // the attached monitor. Without this, xinit can allocate an
-            // inactive VT (common when launched over SSH) and the app
-            // renders off-screen while the monitor keeps showing tty1.
-            string vt = "vt7";  // Debian/Raspbian traditional fallback
-            ifstream activeTty("/sys/class/tty/tty0/active");
-            string line;
-            if (activeTty && getline(activeTty, line)) {
-                auto pos = line.find_first_of("0123456789");
-                if (pos != string::npos) vt = "vt" + line.substr(pos);
+            // On Pi 5 (modesetting + V3D), running the binary directly as
+            // xinit's client races with driver init and the app renders
+            // invisibly. The reliable path is:
+            //   1. Start xinit in the background with the default xinitrc
+            //      (pulls up twm / resources so the X session is stable)
+            //   2. Wait for the X socket to exist
+            //   3. Authorize the local user via xhost
+            //   4. Run the binary as a separate X client with DISPLAY=:0
+            //   5. Tear xinit down when the app exits
+            // xinit is pinned to vt7 so the monitor follows the kernel's VT
+            // switch (without explicit vt, xinit can pick an inactive VT).
+            cout << "Launching via xinit (X11 session) on vt7 ...\n";
+
+            extern char** environ;
+            vector<char*> xinitArgv = {
+                (char*)"xinit", (char*)"--", (char*)":0", (char*)"vt7", nullptr
+            };
+            pid_t xinitPid = 0;
+            if (posix_spawnp(&xinitPid, "xinit", nullptr, nullptr,
+                             xinitArgv.data(), environ) != 0) {
+                cerr << "Error: failed to spawn xinit (is xserver-xorg installed?)\n";
+                return -1;
             }
-            cout << "Launching via xinit (X11 session) on " << vt << " ...\n";
-            return runProcess({"xinit", binPath, "--", ":0", vt});
+
+            // Poll for the X socket (<=6s). Socket appears as soon as Xorg
+            // starts listening; that's enough for xhost to work. A small
+            // extra sleep lets xinitrc (twm etc.) settle.
+            bool xReady = false;
+            for (int i = 0; i < 30; ++i) {
+                if (access("/tmp/.X11-unix/X0", F_OK) == 0) { xReady = true; break; }
+                usleep(200000);
+            }
+            if (!xReady) {
+                cerr << "Error: X server did not start within 6 seconds\n";
+                kill(xinitPid, SIGTERM);
+                waitpid(xinitPid, nullptr, 0);
+                return -1;
+            }
+            sleep(1);  // let WM / xinitrc finish coming up
+
+            setenv("DISPLAY", ":0", 1);
+
+            // Authorize this user so DISPLAY=:0 connects without needing
+            // the server's XAUTHORITY file (which xinit keeps private).
+            const char* user = getenv("USER");
+            if (user && *user) {
+                runProcess({"xhost", string("+SI:localuser:") + user});
+            }
+
+            // Run the app (blocks until it exits).
+            int rc = runProcess({binPath});
+
+            // Tear down the X session.
+            kill(xinitPid, SIGTERM);
+            waitpid(xinitPid, nullptr, 0);
+            return rc;
         }
         cout << "Launching " << projectName << " ...\n";
         return runProcess({binPath});

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -2292,8 +2292,19 @@ static int cmdRun(const vector<string>& args) {
             return runProcess({"labwc", "-s", binPath});
         }
         if (session == "x11") {
-            cout << "Launching via xinit (X11 session) ...\n";
-            return runProcess({"xinit", binPath});
+            // Put Xorg on the currently-active VT so output is visible on
+            // the attached monitor. Without this, xinit can allocate an
+            // inactive VT (common when launched over SSH) and the app
+            // renders off-screen while the monitor keeps showing tty1.
+            string vt = "vt7";  // Debian/Raspbian traditional fallback
+            ifstream activeTty("/sys/class/tty/tty0/active");
+            string line;
+            if (activeTty && getline(activeTty, line)) {
+                auto pos = line.find_first_of("0123456789");
+                if (pos != string::npos) vt = "vt" + line.substr(pos);
+            }
+            cout << "Launching via xinit (X11 session) on " << vt << " ...\n";
+            return runProcess({"xinit", binPath, "--", ":0", vt});
         }
         cout << "Launching " << projectName << " ...\n";
         return runProcess({binPath});

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -2295,31 +2295,42 @@ static int cmdRun(const vector<string>& args) {
         if (session == "x11") {
             // On Pi 5 (modesetting + V3D), running the binary directly as
             // xinit's client races with driver init and the app renders
-            // invisibly. The reliable path is:
-            //   1. Start xinit in the background with the default xinitrc
-            //      (pulls up twm / resources so the X session is stable)
-            //   2. Wait for the X socket to exist
-            //   3. Authorize the local user via xhost
-            //   4. Run the binary as a separate X client with DISPLAY=:0
-            //   5. Tear xinit down when the app exits
-            // xinit is pinned to vt7 so the monitor follows the kernel's VT
-            // switch (without explicit vt, xinit can pick an inactive VT).
+            // invisibly. A window manager must be running before our GL
+            // client connects, but the default xinitrc also spawns xterm
+            // and friends which flash on screen. Use a minimal custom
+            // xinitrc that only runs twm, then run the binary as a
+            // separate X client with DISPLAY=:0:
+            //   1. Write a temp xinitrc: `exec twm`
+            //   2. Spawn xinit on vt7 with that script as the client
+            //   3. Wait for the X socket
+            //   4. Authorize the local user via xhost
+            //   5. Run the binary
+            //   6. Tear xinit down when the app exits
             cout << "Launching via xinit (X11 session) on vt7 ...\n";
+
+            // 1. Write minimal xinitrc that keeps a WM alive without xterm.
+            string xinitrcPath = "/tmp/trusscli-x11-" + to_string(getpid()) + ".sh";
+            {
+                ofstream f(xinitrcPath);
+                f << "#!/bin/sh\nexec twm\n";
+            }
+            chmod(xinitrcPath.c_str(), 0755);
 
             extern char** environ;
             vector<char*> xinitArgv = {
-                (char*)"xinit", (char*)"--", (char*)":0", (char*)"vt7", nullptr
+                (char*)"xinit",
+                (char*)xinitrcPath.c_str(),
+                (char*)"--", (char*)":0", (char*)"vt7", nullptr
             };
             pid_t xinitPid = 0;
             if (posix_spawnp(&xinitPid, "xinit", nullptr, nullptr,
                              xinitArgv.data(), environ) != 0) {
                 cerr << "Error: failed to spawn xinit (is xserver-xorg installed?)\n";
+                std::remove(xinitrcPath.c_str());
                 return -1;
             }
 
-            // Poll for the X socket (<=6s). Socket appears as soon as Xorg
-            // starts listening; that's enough for xhost to work. A small
-            // extra sleep lets xinitrc (twm etc.) settle.
+            // 2. Poll for the X socket (<=6s).
             bool xReady = false;
             for (int i = 0; i < 30; ++i) {
                 if (access("/tmp/.X11-unix/X0", F_OK) == 0) { xReady = true; break; }
@@ -2329,25 +2340,27 @@ static int cmdRun(const vector<string>& args) {
                 cerr << "Error: X server did not start within 6 seconds\n";
                 kill(xinitPid, SIGTERM);
                 waitpid(xinitPid, nullptr, 0);
+                std::remove(xinitrcPath.c_str());
                 return -1;
             }
-            sleep(1);  // let WM / xinitrc finish coming up
+            sleep(1);  // let twm settle
 
             setenv("DISPLAY", ":0", 1);
 
-            // Authorize this user so DISPLAY=:0 connects without needing
+            // 3. Authorize this user so DISPLAY=:0 connects without needing
             // the server's XAUTHORITY file (which xinit keeps private).
             const char* user = getenv("USER");
             if (user && *user) {
                 runProcess({"xhost", string("+SI:localuser:") + user});
             }
 
-            // Run the app (blocks until it exits).
+            // 4. Run the app (blocks until it exits).
             int rc = runProcess({binPath});
 
-            // Tear down the X session.
+            // 5. Tear down the X session.
             kill(xinitPid, SIGTERM);
             waitpid(xinitPid, nullptr, 0);
+            std::remove(xinitrcPath.c_str());
             return rc;
         }
         cout << "Launching " << projectName << " ...\n";


### PR DESCRIPTION
## Problem

`trusscli run --session x11` from `main` does not work on Raspberry Pi 5 in headless / SSH environments. 

Symptoms:

- App appears to launch but the monitor shows a black screen indefinitely
- No visible error — sokol's setup proceeds, X server starts, but no rendering ever appears
- `--session labwc` (Wayland) works fine, but X11 path is broken

This PR makes `--session x11` work end-to-end on Pi 5 and documents the prerequisites.

## Root causes (multiple, layered)

1. **xinit picks an inactive VT** — without an explicit `vt N` argument, xinit allocates a VT that may not be the one the monitor is showing (especially over SSH). Xorg starts but renders to an off-screen VT.
2. **Direct-client launch races driver init** — running the binary as xinit's foreground client (`xinit binary -- :0 vt7`) on Pi 5 modesetting + V3D causes the app to render invisibly even when X is visible. A 2-session arrangement (xinit + separate X client) avoids the race.
3. **Mesa DRI driver** — `libgl1-mesa-dri` is not always pulled automatically on minimal Pi OS Lite installs.
4. **(Conditional) Xorg fbdev fallback** — on some installs Xorg picks the legacy `fbdev` driver instead of `modesetting`, aborting because Pi 5 has no `/dev/fb0`. Documented as a troubleshooting fallback; modern Xorg usually auto-selects modesetting.

## Changes

| Commit | What |
|---|---|
| `55fffcb` | trusscli: pin xinit to vt7 (was picking inactive VT over SSH) |
| `56a87f9` | docs: Pi 5 X11 prerequisites |
| `a0fc36e` | trusscli: 2-session approach (background xinit + separate client) |
| `24a4620` | trusscli: minimal xinitrc (twm only) — no xterm flash |
| `e98dfaa` | trusscli: WM optional (auto-detect twm/openbox, fallback sleep) |
| `63ff9ce` | docs: clarify x11-xserver-utils required, WM optional |
| `f5393e4` | docs: demote 99-vc4.conf to fallback |

## Why the 2-session approach

The reliable path verified on Pi 5:

1. Spawn xinit in the background with a minimal xinitrc
2. Wait for `/tmp/.X11-unix/X0` (X server listening)
3. Authorize the local user via `xhost`
4. Run the binary as a separate X client with `DISPLAY=:0`
5. Tear xinit down when the app exits

xinit is pinned to `vt7` so the kernel auto-switches the active VT to where the X server is running.

## Tested

- Raspberry Pi 5 8GB / Pi OS Lite (Debian 13 Trixie, aarch64) over SSH
- `examples/3d/3DPrimitivesExample` — single-window app
- Without twm installed → auto-fallback to `sleep infinity`, app visible
- With twm installed → auto-detected and used, app visible
- `main` (before this PR) on the same hardware → confirmed black-screen issue

## Future considerations

- **Multi-window apps** (GTK file dialogs, popups, secondary windows) benefit from a real WM — docs recommend `apt install twm` for those cases. trusscli already auto-detects twm/openbox if installed.
- **`vt7` is hardcoded** (Debian/Raspbian convention). Could add a `--vt N` flag later if conflicts arise on systems running parallel graphical sessions.
- **Pi 4** should also benefit but wasn't tested in this PR — community confirmation welcome.

## Test plan

- [x] Pi 5 + minimal install, single-window app
- [x] Pi 5 with optional twm, same app
- [x] Verified `main` reproduces the issue
- [ ] Pi 4 (regression check — likely fine, would appreciate community confirmation)
- [ ] x86 Linux desktop — unaffected (no Pi-specific behavior in changed paths)
