### PR TITLE
test(ci): add tcxLua to AllFeaturesExample for CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,18 @@ jobs:
       # binding usertypes via tcxLua). Pin to r29 to match the local dev
       # baseline and Fumiya's verified setup.
       - name: Set up Android NDK r29
+        id: setup-ndk
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r29
+
+      # Force ANDROID_NDK_HOME to the freshly-installed r29; the runner image
+      # pre-sets this env var to its bundled (older) NDK, which otherwise wins
+      # over what setup-ndk would export.
+      - name: Force ANDROID_NDK_HOME to r29
+        run: |
+          echo "ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
 
       - name: Cache Android build
         uses: actions/cache@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,14 +91,23 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # The NDK shipped with ubuntu-latest runners is too old for sol2's
+      # libc++ trait checks (causes "substitution failure" errors when
+      # binding usertypes via tcxLua). Pin to r29 to match the local dev
+      # baseline and Fumiya's verified setup.
+      - name: Set up Android NDK r29
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r29
+
       - name: Cache Android build
         uses: actions/cache@v5
         with:
           path: |
             core/build-android
             tools/build
-          key: android-build-v3-${{ hashFiles('core/**/*.h', 'core/**/*.cpp') }}
-          restore-keys: android-build-v3-
+          key: android-build-v4-${{ hashFiles('core/**/*.h', 'core/**/*.cpp') }}
+          restore-keys: android-build-v4-
 
       - name: Install Linux dependencies (for trusscli)
         run: |

--- a/examples/tests/AllFeaturesExample/addons.make
+++ b/examples/tests/AllFeaturesExample/addons.make
@@ -1,5 +1,6 @@
 # TrussC addons - one addon per line
 tcxBox2d
+tcxLua
 tcxLut
 tcxOsc
 tcxTls


### PR DESCRIPTION
## Summary

Adds `tcxLua` to `examples/tests/AllFeaturesExample/addons.make` so the addon's compile is exercised by the existing CI matrix on every push.

This was held back as part of #53 (close condition: tcxLua included in AllFeaturesExample with green CI).

## Local verification

Built successfully on this machine for:

| Platform | Result |
|---|---|
| macOS | ✅ |
| Web (Emscripten) | ✅ (verified earlier on PR #58 base) |
| Android (NDK r29) | ✅ — including APK packaging via `trussc_app()` auto-detect |

Combined with @funatsufumiya's earlier verification on Windows and Linux, all 5 platforms now pass locally with `tcxLua` in the addon set.

The earlier CI Android failure (the sol2 template substitution error in `tcxLua.cpp:230`) does **not** reproduce locally with NDK r29, supporting the hypothesis that it was CI-environment-specific (likely an older NDK / libc++ trait mismatch) or transient.

## Test plan

- [ ] CI matrix passes on macOS / Linux / Windows / Web / Android
- [ ] If green: closes #53

If Android still fails on CI, we revert and re-investigate the NDK / libc++ delta.

Closes #53