### PR TITLE
fix(Fbo): correct vertical flip on OpenGL/GLES backends (#69)

### DIFF
--- a/core/include/tc/gpu/tcFbo.h
+++ b/core/include/tc/gpu/tcFbo.h
@@ -272,7 +272,26 @@ public:
     Texture& getTexture() override { return colorTexture_; }
     const Texture& getTexture() const override { return colorTexture_; }
 
-    // draw() uses HasTexture's default implementation
+    // GL backends store FBO color textures bottom-to-top in memory
+    // (unlike Metal/D3D11 which are top-to-bottom). Override draw to
+    // flip V on GL so the displayed image matches user-space top-left coords.
+    void draw(float x, float y) const override {
+        if (!hasTexture()) return;
+        if (needsGlYFlip()) {
+            colorTexture_.drawFlippedY(x, y, (float)width_, (float)height_);
+        } else {
+            colorTexture_.draw(x, y);
+        }
+    }
+
+    void draw(float x, float y, float w, float h) const override {
+        if (!hasTexture()) return;
+        if (needsGlYFlip()) {
+            colorTexture_.drawFlippedY(x, y, w, h);
+        } else {
+            colorTexture_.draw(x, y, w, h);
+        }
+    }
 
     // save() override - Save FBO contents to file
     bool save(const fs::path& path) const override {
@@ -289,6 +308,11 @@ public:
     sg_sampler getSampler() const { return colorTexture_.getSampler(); }
 
 private:
+    static bool needsGlYFlip() {
+        sg_backend be = sg_query_backend();
+        return be == SG_BACKEND_GLCORE || be == SG_BACKEND_GLES3;
+    }
+
     int width_ = 0;
     int height_ = 0;
     int sampleCount_ = 1;

--- a/core/include/tc/gpu/tcTexture.h
+++ b/core/include/tc/gpu/tcTexture.h
@@ -465,6 +465,14 @@ public:
         }
     }
 
+    // Draw with vertical flip (v swapped). Used by Fbo on GL backends
+    // where framebuffer textures are stored bottom-to-top in memory.
+    void drawFlippedY(float x, float y, float w, float h) const {
+        if (allocated_) {
+            drawInternal(x, y, w, h, 0.0f, 1.0f, 1.0f, 0.0f);
+        }
+    }
+
     // Partial draw (for sprite sheets)
     void drawSubsection(float x, float y, float w, float h,
                         float sx, float sy, float sw, float sh) const {


### PR DESCRIPTION
GL framebuffer attachment textures are stored bottom-to-top in memory (row 0 = NDC y=-1), unlike Metal/D3D11 which are top-to-bottom. Texture::draw samples v=0 from row 0, which placed the FBO's bottom row at the top of the destination on GL — making fbo.draw() appear upside-down on Linux/Android/Web (GL fallback).

readPixels already handled this via flipY=true in tcFbo_linux.cpp; this commit applies the same correction to the display path.

- Add Texture::drawFlippedY for v-swapped sampling
- Override Fbo::draw to dispatch via a private needsGlYFlip() check (true only for SG_BACKEND_GLCORE / SG_BACKEND_GLES3)

Metal/D3D11/WGPU paths are unchanged. Apps that previously worked around this with translate(0,h)/scale(1,-1) on GL must remove the workaround.

Closes #69