### PR TITLE
fix: hot reload reconfigure check skips unsupported platforms

### DIFF
--- a/core/cmake/trussc_app.cmake
+++ b/core/cmake/trussc_app.cmake
@@ -152,6 +152,15 @@ macro(trussc_app)
     # triggers reconfig if the result changed. Using a CMake script (rather
     # than a shell script) keeps this cross-platform — Windows doesn't ship
     # `sh` by default.
+    #
+    # Hot-reload-unsupported platforms (Android / Emscripten / iOS) force
+    # _TC_HOT_RELOAD off above regardless of the source scan, so the runtime
+    # check must agree — otherwise it spots TC_HOT_RELOAD in .cpp, decides
+    # CURRENT="ON", and fails the build forever with "state changed".
+    set(_TC_HR_PLATFORM_SUPPORTED "TRUE")
+    if(EMSCRIPTEN OR ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
+        set(_TC_HR_PLATFORM_SUPPORTED "FALSE")
+    endif()
     set(_TC_HR_CHECK_SCRIPT "${CMAKE_BINARY_DIR}/_tc_check_hot_reload.cmake")
     set(_TC_HR_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
     set(_TC_HR_CMAKELISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
@@ -160,6 +169,13 @@ macro(trussc_app)
 set(STATE_FILE \"${_TC_HR_STATE_FILE}\")
 set(SRC_DIR    \"${_TC_HR_SRC_DIR}\")
 set(CMAKELISTS \"${_TC_HR_CMAKELISTS}\")
+set(PLATFORM_SUPPORTED ${_TC_HR_PLATFORM_SUPPORTED})
+
+# Hot reload is unavailable on this platform — TC_HOT_RELOAD in source is
+# treated as a no-op, so just confirm OFF without scanning.
+if(NOT PLATFORM_SUPPORTED)
+    return()
+endif()
 
 set(PREV \"\")
 if(EXISTS \"\${STATE_FILE}\")


### PR DESCRIPTION
## Summary

Android (and Emscripten / iOS) builds of any app that opts into hot reload — e.g. \`SONY_XP_Attendant\` with \`TC_HOT_RELOAD(tcApp)\` in its source — were failing at the pre-build hot-reload-state check:

\`\`\`
[HotReload] TC_HOT_RELOAD detected.
CMake Error at _tc_check_hot_reload.cmake:40 (message):
  hot reload state changed -- reconfigure required
\`\`\`

The configure-time detection in \`trussc_app.cmake\` forces \`_TC_HOT_RELOAD\` off on those platforms (line 127), but the auto-generated re-scan script didn't share the same gate — it always scanned \`*.cpp\` and reported \`CURRENT=ON\` whenever the macro was present, mismatching the saved state.

Bake the platform decision into the generated script and \`return()\` early on platforms that don't support hot reload.

## Why CI didn't catch this

\`HotReloadExample\` (the only example with \`TC_HOT_RELOAD\` in source) is only built on the desktop matrix. The Android/Web jobs only build \`AllFeaturesExample\`, which doesn't set the macro, so the mismatch path was never exercised. Adding \`HotReloadExample\` to the Android/Web jobs as a hot-reload-disabled fallback build would close that gap — tracked under the existing CI hot-reload TODO.

## Test plan
- [x] \`trusscli build --android -p apps/sony-xp/SONY_XP_Attendant\` → APK builds cleanly with \`TC_HOT_RELOAD(tcApp)\` in source
- [ ] CI: existing matrix still passes (no behavior change on hot-reload-supported platforms)