### PR TITLE
Android manifest plumbing + nav-bar hiding on API 30+

### DIFF
--- a/core/cmake/trussc_app.cmake
+++ b/core/cmake/trussc_app.cmake
@@ -665,7 +665,20 @@ message(\"  [HotReload] Generated \${DEF_FILE} with \${SYM_COUNT} symbols\")
         string(REGEX REPLACE "^([^a-zA-Z])" "app\\1" _TC_SAFE_NAME "${PROJECT_NAME}")
         set(TC_APP_PACKAGE "com.trussc.${_TC_SAFE_NAME}")
         set(TC_APP_LIB_NAME "${PROJECT_NAME}")
-        set(_TC_MANIFEST_TEMPLATE "${TRUSSC_DIR}/resources/android/AndroidManifest.xml.in")
+        # Allow projects to ship their own manifest under android/. If
+        # AndroidManifest.xml.in is present, it's run through configure_file
+        # (so @TC_APP_PACKAGE@ / @TC_APP_LIB_NAME@ still expand); a plain
+        # AndroidManifest.xml is copied as-is. Falls back to the framework
+        # default, which carries every permission the core APIs might need.
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/android/AndroidManifest.xml.in")
+            set(_TC_MANIFEST_TEMPLATE "${CMAKE_CURRENT_SOURCE_DIR}/android/AndroidManifest.xml.in")
+            message(STATUS "[${PROJECT_NAME}] Using project-local android/AndroidManifest.xml.in")
+        elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/android/AndroidManifest.xml")
+            set(_TC_MANIFEST_TEMPLATE "${CMAKE_CURRENT_SOURCE_DIR}/android/AndroidManifest.xml")
+            message(STATUS "[${PROJECT_NAME}] Using project-local android/AndroidManifest.xml")
+        else()
+            set(_TC_MANIFEST_TEMPLATE "${TRUSSC_DIR}/resources/android/AndroidManifest.xml.in")
+        endif()
         set(_TC_MANIFEST_OUT "${CMAKE_CURRENT_BINARY_DIR}/AndroidManifest.xml")
         configure_file("${_TC_MANIFEST_TEMPLATE}" "${_TC_MANIFEST_OUT}" @ONLY)
 

--- a/core/platform/android/tcPlatform_android.cpp
+++ b/core/platform/android/tcPlatform_android.cpp
@@ -30,15 +30,85 @@ void setImmersiveMode(bool enabled) {
     auto* activity = (ANativeActivity*)sapp_android_get_native_activity();
     if (!activity) return;
 
-    // ANativeActivity_setWindowFlags is thread-safe (posts to UI thread internally).
-    // FLAG_FULLSCREEN (0x0400) hides the status bar.
-    // Navigation bar hiding requires View.setSystemUiVisibility on UI thread (JNI + Runnable),
-    // which is complex from pure NDK. For now, hide status bar only.
+    // Status bar: FLAG_FULLSCREEN (0x0400). ANativeActivity_setWindowFlags
+    // is thread-safe (the framework posts it to the UI thread internally).
     if (enabled) {
-        ANativeActivity_setWindowFlags(activity, 0x00000400 /*FLAG_FULLSCREEN*/, 0);
+        ANativeActivity_setWindowFlags(activity, 0x00000400, 0);
     } else {
-        ANativeActivity_setWindowFlags(activity, 0, 0x00000400 /*FLAG_FULLSCREEN*/);
+        ANativeActivity_setWindowFlags(activity, 0, 0x00000400);
     }
+
+    // Navigation bar: WindowInsetsController (API 30+). The older
+    // View.setSystemUiVisibility() flags are deprecated as of API 30 and
+    // were observed to be effectively no-ops on API 36 (Android 16) — the
+    // bar stayed visible even with IMMERSIVE_STICKY set. We target API 30+
+    // here; earlier devices keep the status-bar-only behavior above.
+    //
+    // BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE = 2: hidden bars temporarily
+    // re-appear when the user swipes from the edge and auto-hide again
+    // after a moment, so a kiosk operator can't accidentally trigger Back
+    // by brushing the bottom of the screen.
+    //
+    // Type bitmask values (WindowInsets.Type):
+    //   statusBars()     = 0x1
+    //   navigationBars() = 0x2
+    //   captionBar()     = 0x4   (kept in mask for cleanliness)
+    JNIEnv* env;
+    bool attached = false;
+    if (activity->vm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+        activity->vm->AttachCurrentThread(&env, nullptr);
+        attached = true;
+    }
+
+    jclass actCls = env->GetObjectClass(activity->clazz);
+    jmethodID getWindow = env->GetMethodID(actCls, "getWindow",
+        "()Landroid/view/Window;");
+    jobject window = env->CallObjectMethod(activity->clazz, getWindow);
+    if (window) {
+        jclass winCls = env->GetObjectClass(window);
+
+        // Window.setDecorFitsSystemWindows(false) is the API 30+ pre-req
+        // for letting the app draw under the system bars at all.
+        jmethodID setDecorFits = env->GetMethodID(winCls,
+            "setDecorFitsSystemWindows", "(Z)V");
+        if (setDecorFits) {
+            env->CallVoidMethod(window, setDecorFits, enabled ? JNI_FALSE : JNI_TRUE);
+            if (env->ExceptionCheck()) env->ExceptionClear();
+        }
+
+        jmethodID getController = env->GetMethodID(winCls,
+            "getInsetsController", "()Landroid/view/WindowInsetsController;");
+        if (getController) {
+            jobject ctrl = env->CallObjectMethod(window, getController);
+            if (ctrl) {
+                jclass ctrlCls = env->GetObjectClass(ctrl);
+                jmethodID setBehavior = env->GetMethodID(ctrlCls,
+                    "setSystemBarsBehavior", "(I)V");
+                if (setBehavior) {
+                    env->CallVoidMethod(ctrl, setBehavior, 2);
+                    if (env->ExceptionCheck()) env->ExceptionClear();
+                }
+
+                jmethodID hide = env->GetMethodID(ctrlCls, "hide", "(I)V");
+                jmethodID show = env->GetMethodID(ctrlCls, "show", "(I)V");
+                jint types = 0x1 | 0x2 | 0x4;
+                if (enabled && hide) {
+                    env->CallVoidMethod(ctrl, hide, types);
+                } else if (!enabled && show) {
+                    env->CallVoidMethod(ctrl, show, types);
+                }
+                if (env->ExceptionCheck()) env->ExceptionClear();
+
+                env->DeleteLocalRef(ctrlCls);
+                env->DeleteLocalRef(ctrl);
+            }
+        }
+        env->DeleteLocalRef(winCls);
+        env->DeleteLocalRef(window);
+    }
+    env->DeleteLocalRef(actCls);
+
+    if (attached) activity->vm->DetachCurrentThread();
 }
 
 bool getImmersiveMode() {

--- a/core/resources/android/AndroidManifest.xml.in
+++ b/core/resources/android/AndroidManifest.xml.in
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
 
     <application

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -109,6 +109,27 @@ Notes:
 - Data files: Use `adb push` to transfer assets to the app's internal storage.
 - **If `cmake --preset android` fails after trusscli update**, try running the command manually from the terminal.
 
+**Custom AndroidManifest.xml:**
+
+By default the build uses TrussC's bundled manifest, which declares every
+permission the core APIs (`acquireWifiLock`, `acquireMulticastLock`,
+`vibrate`, etc.) might need. This is convenient for local development but
+not ideal for store-published apps or MDM-managed devices, where requesting
+unused permissions can cause review pushback or policy rejection.
+
+To override, drop your own manifest into the project at one of:
+
+- `android/AndroidManifest.xml.in` — run through `configure_file` so
+  `@TC_APP_PACKAGE@` and `@TC_APP_LIB_NAME@` still expand. Recommended.
+- `android/AndroidManifest.xml` — copied verbatim (you fill in the
+  `package` and `lib_name` yourself).
+
+If neither file exists, the bundled "everything" manifest at
+`core/resources/android/AndroidManifest.xml.in` is used unchanged.
+
+Suggested workflow: copy the bundled manifest into `android/` and strip
+out the `<uses-permission>` lines you don't actually need.
+
 **iOS Build (beta):**
 
 Requires:


### PR DESCRIPTION
## Summary

- **Project-local AndroidManifest override**: drop `android/AndroidManifest.xml.in` (or `.xml`) into a project to replace the bundled "all permissions" manifest. Falls back to the framework default when absent. Lets store-published / MDM-managed apps trim down to only the permissions they actually use.
- **`setImmersiveMode` now hides the navigation bar on API 30+** (Android 16 included). The old `View.setSystemUiVisibility` path is fully deprecated on API 30+ and was confirmed to be a no-op on API 36 — switched to `WindowInsetsController.hide(...)` with `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` so the bar reappears transiently on edge-swipe and auto-hides again.
- **WAKE_LOCK permission** added to the bundled manifest — required by `acquireWifiLock()` (which started SecurityException'ing without it on real devices).

## Test plan

- [x] Verified on real device (Sony Xperia, Android 16 / API 36): nav bar stays hidden, swipe-from-edge brings it back transiently
- [x] Verified the project-local manifest override path: a minimal manifest with no permissions crashes at startup with SecurityException (as expected), the bundled full manifest works as before
- [x] CI passes