### PR TITLE
fix(captureWindow): allow CPU read from Metal drawable (issue #56)

### DIFF
--- a/core/include/sokol/sokol_app.h
+++ b/core/include/sokol/sokol_app.h
@@ -5190,7 +5190,7 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_init(void) {
     _sapp.macos.mtl.layer.magnificationFilter = kCAFilterNearest;
     _sapp.macos.mtl.layer.opaque = true;
     _sapp.macos.mtl.layer.pixelFormat = MTLPixelFormatRGB10A2Unorm  /* Modified by tettou771 for TrussC: 10-bit color */;
-    _sapp.macos.mtl.layer.framebufferOnly = true;
+    _sapp.macos.mtl.layer.framebufferOnly = false  /* Modified for TrussC: enable captureWindow() reads (issue #56) */;
     //NOTE: default is 3: _sapp.macos.mtl.layer.maximumDrawableCount = 2;
     // FIXME: _sapp.macos.mtl.layer.colorspace = ...;
     _sapp.macos.view = [[_sapp_macos_view alloc] init];
@@ -6458,7 +6458,7 @@ _SOKOL_PRIVATE void _sapp_ios_mtl_init(UIWindowScene* windowScene) {
     _sapp.ios.mtl.layer = [CAMetalLayer layer];
     _sapp.ios.mtl.layer.device = _sapp.ios.mtl.device;
     _sapp.ios.mtl.layer.opaque = true;
-    _sapp.ios.mtl.layer.framebufferOnly = true;
+    _sapp.ios.mtl.layer.framebufferOnly = false  /* Modified for TrussC: enable captureWindow() reads (issue #56) */;
     _sapp.ios.mtl.layer.pixelFormat = MTLPixelFormatRGB10A2Unorm  /* Modified by tettou771 for TrussC: 10-bit color */;
     _sapp.ios.mtl.layer.frame = _sapp.ios.view.layer.frame;
 

--- a/core/platform/mac/tcPlatform_mac.mm
+++ b/core/platform/mac/tcPlatform_mac.mm
@@ -160,25 +160,61 @@ bool captureWindow(Pixels& outPixels) {
         return false;
     }
 
-    id<MTLTexture> texture = drawable.texture;
-    if (!texture) {
+    id<MTLTexture> srcTexture = drawable.texture;
+    if (!srcTexture) {
         logError() << "[Screenshot] Metal テクスチャが取得できません";
         return false;
     }
 
-    NSUInteger width = texture.width;
-    NSUInteger height = texture.height;
-    MTLPixelFormat pixelFormat = texture.pixelFormat;
+    NSUInteger width = srcTexture.width;
+    NSUInteger height = srcTexture.height;
+    MTLPixelFormat pixelFormat = srcTexture.pixelFormat;
 
-    // Read raw pixel data from Metal texture
+    // sokol が CAMetalLayer に framebufferOnly=YES をセットしているため、
+    // drawable.texture から直接 getBytes するとアサートする (Metal validation 有効時)。
+    // shared-storage の staging texture に blit してから読み出す。
+    id<MTLDevice> device = srcTexture.device;
+    MTLTextureDescriptor* desc =
+        [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
+                                                           width:width
+                                                          height:height
+                                                       mipmapped:NO];
+    desc.usage = MTLTextureUsageShaderRead;
+    desc.storageMode = MTLStorageModeShared;
+    id<MTLTexture> stagingTexture = [device newTextureWithDescriptor:desc];
+    if (!stagingTexture) {
+        logError() << "[Screenshot] staging texture の作成に失敗しました";
+        return false;
+    }
+
+    static id<MTLCommandQueue> s_blitQueue = nil;
+    if (!s_blitQueue || s_blitQueue.device != device) {
+        s_blitQueue = [device newCommandQueue];
+    }
+
+    id<MTLCommandBuffer>      cmdBuf  = [s_blitQueue commandBuffer];
+    id<MTLBlitCommandEncoder> blitEnc = [cmdBuf blitCommandEncoder];
+    [blitEnc copyFromTexture:srcTexture
+                 sourceSlice:0
+                 sourceLevel:0
+                sourceOrigin:MTLOriginMake(0, 0, 0)
+                  sourceSize:MTLSizeMake(width, height, 1)
+                   toTexture:stagingTexture
+            destinationSlice:0
+            destinationLevel:0
+           destinationOrigin:MTLOriginMake(0, 0, 0)];
+    [blitEnc endEncoding];
+    [cmdBuf commit];
+    [cmdBuf waitUntilCompleted];
+
     MTLRegion region = MTLRegionMake2D(0, 0, width, height);
     NSUInteger bytesPerRow = width * 4;
     std::vector<uint8_t> rawData(bytesPerRow * height);
 
-    [texture getBytes:rawData.data()
-          bytesPerRow:bytesPerRow
-           fromRegion:region
-          mipmapLevel:0];
+    [stagingTexture getBytes:rawData.data()
+                 bytesPerRow:bytesPerRow
+                  fromRegion:region
+                 mipmapLevel:0];
 
     // Allocate output pixels (always RGBA8)
     outPixels.allocate((int)width, (int)height, 4);


### PR DESCRIPTION
## Summary

Fixes #56 — `saveScreenshot()` / `captureWindow()` triggers a Metal API Validation assertion on macOS Tahoe:

```
_validateGetBytes:75: failed assertion `Get Bytes Validation
texture must not be a framebufferOnly texture.
```

### Root cause
- `sokol_app.h` sets `CAMetalLayer.framebufferOnly = YES` (mac & iOS), so drawable textures cannot be sampled, blit-copied, or read via `getBytes` — those operations are spec-violations regardless of GPU model.
- `captureWindow()` in `tcPlatform_mac.mm` was calling `[texture getBytes:]` directly on the drawable texture, which asserts when Metal API Validation is on (Xcode default for Debug schemes) and is undefined otherwise.
- This is OS/GPU-independent — newer macOS / Xcode just made the existing latent bug visible by tightening validation.

### Fix
1. Flip `framebufferOnly = false` on the macOS and iOS `CAMetalLayer` (sokol_app.h, 2 lines). Apple's documented requirement for CPU read / texture copy.
2. In `captureWindow()`, blit the drawable to a `MTLStorageModeShared` staging texture via a cached blit `MTLCommandQueue`, then `getBytes` from the staging texture after `waitUntilCompleted`. This gives proper GPU/CPU synchronization regardless of where in the frame `captureWindow` is called.

The `framebufferOnly=false` cost is tile-memory optimization loss for the swapchain — small and only paid on the present pass. The blit cost is paid only when a screenshot is actually captured.

## Test plan
- [x] Built and ran reproduction app on M1 / macOS 26.5 (Tahoe) with `MTL_DEBUG_LAYER=1`: assertion gone, returned PNG matches window contents (rotating circles + grid + text), 1920×1200 Retina.
- [x] Same app with validation disabled (binary direct launch): still works, no regression.
- [ ] Manual repro on iOS (not tested locally — code path is identical, only `framebufferOnly=false` change applies on iOS, blit/staging code is mac-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)