### PR TITLE
fix(node): make processTimers reentrancy-safe

### DIFF
--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -953,25 +953,41 @@ protected:
     inline static uint64_t nextTimerId_ = 1;
 
     // Process timers (called within updateRecursive)
+    //
+    // Reentrancy-safe: a callback may invoke callAfter / callEvery / cancelTimer
+    // / cancelAllTimers on this same node. We snapshot the ready-timer IDs up
+    // front, then look each one up by ID before firing, copying out the
+    // callback and metadata so vector reallocation during the callback can't
+    // dangle the in-flight reference.
     void processTimers() {
         double currentTime = getElapsedTime();
-        std::vector<Timer> toRemove;
 
-        for (auto& timer : timers_) {
-            if (currentTime >= timer.triggerTime) {
-                timer.callback();
-
-                if (timer.repeating) {
-                    timer.triggerTime = currentTime + timer.interval;
-                } else {
-                    toRemove.push_back(timer);
-                }
+        std::vector<uint64_t> readyIds;
+        readyIds.reserve(timers_.size());
+        for (const auto& t : timers_) {
+            if (currentTime >= t.triggerTime) {
+                readyIds.push_back(t.id);
             }
         }
 
-        // Remove completed non-repeating timers
-        for (const auto& t : toRemove) {
-            cancelTimer(t.id);
+        for (uint64_t id : readyIds) {
+            auto it = std::find_if(timers_.begin(), timers_.end(),
+                [id](const Timer& t) { return t.id == id; });
+            if (it == timers_.end()) continue;  // cancelled by an earlier callback in this batch
+
+            std::function<void()> callback = it->callback;
+            bool   repeating = it->repeating;
+            double interval  = it->interval;
+
+            if (repeating) {
+                it->triggerTime = currentTime + interval;
+                callback();  // safe: we already captured what we need from `it`
+            } else {
+                // Remove before firing so the timer is gone even if the
+                // callback throws or registers a new timer that reallocates.
+                cancelTimer(id);
+                callback();
+            }
         }
     }
 };


### PR DESCRIPTION
## Summary

`Node::processTimers()` was unsafe when a timer callback called any of `callAfter` / `callEvery` / `cancelTimer` / `cancelAllTimers` on the same node. Symptoms ranged from one-shot timers firing twice to silently dropped timers and a `std::bad_function_call` abort.

## Root cause

The previous loop iterated `timers_` by reference while invoking callbacks that could mutate the vector:

```cpp
for (auto& timer : timers_) {
    if (currentTime >= timer.triggerTime) {
        timer.callback();   // ← may push_back / erase timers_

        if (timer.repeating) {
            timer.triggerTime = ...;   // dangling write if realloc happened
        } else {
            toRemove.push_back(timer); // copies a moved-from std::function
        }
    }
}
```

Three concrete failure modes:

1. **Nested registration → realloc → UB.** `push_back` inside the callback reallocates the vector. The `timer` reference and the loop's cached `__end` are now dangling. The post-callback read of `timer.repeating` and `toRemove.push_back(timer)` are UB.
2. **Moved-from `std::function`.** After realloc, the old slot's `std::function` was moved out. Copying it into `toRemove` yields an empty function — invoking it later throws `std::bad_function_call`.
3. **Silent skips.** Even with no realloc, a sibling callback's `cancelTimer` could shift elements such that a ready timer was never reached by the loop.

## Fix

Snapshot ready timer IDs first, then re-look-up each by ID before firing, after copying out the callback and its metadata. Non-repeating timers are cancelled *before* their callback runs so they can't re-fire even if the callback grows `timers_`.

```cpp
std::vector<uint64_t> readyIds;
for (const auto& t : timers_)
    if (currentTime >= t.triggerTime) readyIds.push_back(t.id);

for (uint64_t id : readyIds) {
    auto it = std::find_if(timers_.begin(), timers_.end(),
        [id](const Timer& t){ return t.id == id; });
    if (it == timers_.end()) continue;   // cancelled by an earlier callback

    auto callback = it->callback;        // copy before mutating timers_
    bool   repeating = it->repeating;
    double interval  = it->interval;

    if (repeating) {
        it->triggerTime = currentTime + interval;
        callback();
    } else {
        cancelTimer(id);
        callback();
    }
}
```

## Test plan

Built a 17-case test app (`~/apps/timerTest`) covering every reentrancy pattern:

| # | Case | Want | Before | After |
|---|------|-----:|-------:|------:|
| T1 | simple `callAfter` | 1 | 1 | 1 ✅ |
| T2 | `callAfter` inside `callAfter` (outer / inner) | 1 / 1 | 1 / 1 | 1 / 1 ✅ |
| T3 | one callback registers 3 timers (forces realloc) | 1 each | 1 each | 1 each ✅ |
| T4 | `callEvery` self-cancels after 5 ticks | 5 | 5 | 5 ✅ |
| T5 | `callEvery` callback registers `callAfter` each tick | 3 / 3 | 3 / 3 | 3 / 3 ✅ |
| T6 | `cancelTimer` from another callback | canceller=1, victim=0 | **canceller=2** | 1 / 0 ✅ |
| T7 | `cancelAllTimers` from a callback | cancelAll=1, should_not_fire=0 | **cancelAll=0** | 1 / 0 ✅ |
| T8 | three timers ready in the same `processTimers()` | 1 / 1 / 1 | **0 / 0 / 1** | 1 / 1 / 1 ✅ |

Pre-fix: 4 failures (T6, T7, T8a, T8b). Post-fix: all 17 pass. Verified on M1 / macOS 26.5.

Also confirmed: the original issue #56 reproduction case (saveScreenshot inside a `callAfter` that schedules `exitApp` via another `callAfter`) now runs cleanly with EXIT=0, no `bad_function_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)