### PR TITLE
fix(node): snapshot children list during tree iteration

### DIFF
--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -452,9 +452,14 @@ private:
             mod->update();
         }
 
-        // Automatically update child nodes
-        for (auto& child : children_) {
-            child->updateTree();
+        // Iterate over a snapshot — a child's update() may add, remove, or
+        // reorder siblings (via addChild / removeChild / moveToFront / etc.),
+        // and we want those edits to take effect on the *next* frame rather
+        // than corrupt the in-flight iteration. The snapshot is a shallow
+        // shared_ptr copy so it's cheap and keeps the targets alive.
+        auto childrenSnapshot = children_;
+        for (auto& child : childrenSnapshot) {
+            if (!child->isDead()) child->updateTree();
         }
     }
 
@@ -679,8 +684,10 @@ private:
             return true;  // Consumed
         }
 
-        // Dispatch to child nodes
-        for (auto& child : children_) {
+        // Snapshot — handlers may mutate the tree.
+        auto childrenSnapshot = children_;
+        for (auto& child : childrenSnapshot) {
+            if (child->isDead()) continue;
             if (child->dispatchKeyPressRecursive(key)) {
                 return true;
             }
@@ -696,7 +703,9 @@ private:
             return true;
         }
 
-        for (auto& child : children_) {
+        auto childrenSnapshot = children_;
+        for (auto& child : childrenSnapshot) {
+            if (child->isDead()) continue;
             if (child->dispatchKeyReleaseRecursive(key)) {
                 return true;
             }
@@ -760,8 +769,10 @@ protected:
     // -------------------------------------------------------------------------
 
     virtual void drawChildren() {
-        for (auto& child : children_) {
-            child->drawTree();
+        // Snapshot — see updateTree() for rationale.
+        auto childrenSnapshot = children_;
+        for (auto& child : childrenSnapshot) {
+            if (!child->isDead()) child->drawTree();
         }
     }
 


### PR DESCRIPTION
## Summary

`Node::updateTree`, `drawChildren`, `dispatchKeyPressRecursive` and `dispatchKeyReleaseRecursive` all iterated `children_` directly while calling into user callbacks (`update` / `draw` / `onKeyPress` / `onKeyRelease`). If a handler called `addChild`, `removeChild`, or any sibling reorder on the same parent, the in-flight iterator desynced from the intended traversal, with two visible failure modes:

- the just-moved child could be **visited twice in the same frame** (double-fire), and
- a sibling shifted forward by the `erase` could be **silently skipped that frame**.

Both happen even without a reallocation — a plain shift from `vector::erase` is enough.

Note the design intent was already documented on `getChildren()`:

```cpp
// Get list of child nodes (returns a copy — safe to iterate while modifying the tree)
std::vector<Ptr> getChildren() const { return children_; }
```

The four hot loops just hadn't been brought into line with that contract.

## Fix

Iterate over a shallow `shared_ptr` snapshot at each of the four sites. `isDead()` nodes in the snapshot are skipped so `destroy()`-during-iteration keeps its existing frame-boundary semantics. Net effect: `addChild` / `removeChild` / reorders called from inside `update`/`draw`/key handlers now take effect on the **next** frame, exactly like `destroy()` already does.

The snapshot is just a `vector<shared_ptr<Node>>` copy — refcount inc/dec per child, no reallocation of `children_`, no allocations beyond the snapshot vector itself.

## Reproduction & verification

A minimal repro app (`~/apps/childReorderTest`) creates three children A, B, C, has B call `parent->addChild(B)` on its first `update()` (the standard "move to end" idiom), and logs each `update`:

**Before fix:**
```
frame=1  A count=1
frame=1  B count=1
frame=1  [reorder] B re-adds itself
frame=1  B count=2     ← double-fire
frame=2  A count=2
frame=2  C count=1     ← C silently skipped frame 1
frame=2  B count=3
```

**After fix:**
```
frame=1  A count=1
frame=1  B count=1
frame=1  [reorder] B re-adds itself
frame=1  C count=1     ← C visited normally
frame=2  A count=2
frame=2  C count=2
frame=2  B count=2     ← reorder visible from next frame
```

Regression checked against the 17-case `timerTest` and the original issue #56 reproduction — both still pass.

## Test plan
- [x] childReorderTest: B fires exactly once per frame, C is not skipped, reorder visible from next frame
- [x] timerTest (17 cases) still all PASS
- [x] issue56_repro EXIT=0 under `MTL_DEBUG_LAYER=1`
- [ ] Manual sanity on a real app with deep node trees (not yet done locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)