### PR TITLE
feat(node): add moveToFront / moveToBack reorder methods

### DIFF
--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -170,6 +170,36 @@ public:
         return children_.size();
     }
 
+    // Reorder this node within its parent's child list.
+    //
+    // Children are drawn in vector order: the first child is drawn first
+    // (visually behind), the last child is drawn last (visually in front).
+    // moveToFront() puts this node at the end so it draws on top of its
+    // siblings; moveToBack() puts it at the beginning so it draws underneath.
+    //
+    // Both use std::rotate, so they don't change the vector's size and don't
+    // trigger reallocation. No-op if the node has no parent or is already at
+    // the requested position.
+    void moveToFront() {
+        auto p = getParent();
+        if (!p) return;
+        auto self = shared_from_this();
+        auto& sib = p->children_;
+        auto it = std::find(sib.begin(), sib.end(), self);
+        if (it == sib.end() || it + 1 == sib.end()) return;
+        std::rotate(it, it + 1, sib.end());
+    }
+
+    void moveToBack() {
+        auto p = getParent();
+        if (!p) return;
+        auto self = shared_from_this();
+        auto& sib = p->children_;
+        auto it = std::find(sib.begin(), sib.end(), self);
+        if (it == sib.end() || it == sib.begin()) return;
+        std::rotate(sib.begin(), it, it + 1);
+    }
+
     // -------------------------------------------------------------------------
     // State
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two sibling-reorder methods on `Node` that change a child's z-order without unparenting/reparenting it:

- `moveToFront()` — moves this node to the **end** of its parent's child list, so it draws last (visually on top of its siblings).
- `moveToBack()` — moves this node to the **beginning**, so it draws first (visually behind its siblings).

Children are drawn in vector order: first drawn = behind, last drawn = on top. The naming follows the visual convention ('front' = closer to the viewer = drawn later) rather than the array convention.

## Implementation

Both use `std::rotate`, so they don't change the vector's size and don't trigger reallocation — only a small contiguous range of `shared_ptr` slots is rotated. No-ops when:
- the node has no parent (orphan),
- the node is already at the requested position (already-last for `moveToFront`, already-first for `moveToBack`).

```cpp
void moveToFront() {
    auto p = getParent();
    if (!p) return;
    auto self = shared_from_this();
    auto& sib = p->children_;
    auto it = std::find(sib.begin(), sib.end(), self);
    if (it == sib.end() || it + 1 == sib.end()) return;
    std::rotate(it, it + 1, sib.end());
}

void moveToBack() {
    auto p = getParent();
    if (!p) return;
    auto self = shared_from_this();
    auto& sib = p->children_;
    auto it = std::find(sib.begin(), sib.end(), self);
    if (it == sib.end() || it == sib.begin()) return;
    std::rotate(sib.begin(), it, it + 1);
}
```

## Notes

This builds on top of #84 (children-iteration snapshot fix). Without that fix, calling `moveToFront` from inside an `update`/`draw` callback would still risk corrupting the parent's in-flight iteration via the same iterator-invalidation issue that `addChild` had. With #84 in place, mid-iteration calls are safe and take effect on the next frame.

## Test plan

`~/apps/reorderApiTest` — 8 cases, all PASS:

| # | Case | Order |
|---|------|-------|
| 1 | initial | `A,B,C,D` |
| 2 | `B.moveToFront()` | `A,C,D,B` |
| 3 | `C.moveToBack()` | `C,A,D,B` |
| 4 | `B.moveToFront()` (already last) — no-op | `C,A,D,B` |
| 5 | `C.moveToBack()` (already first) — no-op | `C,A,D,B` |
| 6 | `C.moveToFront()` (was first) | `A,D,B,C` |
| 7 | `C.moveToBack()` (was last) | `C,A,D,B` |
| 8 | `orphan.moveToFront()` / `moveToBack()` — no crash | ok |

🤖 Generated with [Claude Code](https://claude.com/claude-code)