### PR TITLE
Docs + warning cleanup for workshop (LoadResult/INT10_N2 roadmap, audio stream API entry, FLAC/moveToFront yaml + REFERENCE)

### DIFF
--- a/core/include/tc/sound/tcSound_impl.cpp
+++ b/core/include/tc/sound/tcSound_impl.cpp
@@ -14,8 +14,18 @@
 #include <utility>
 
 // stb_vorbis - OGG Vorbis decoder
+//
+// The header has an overflow-detection branch ("stream_start + loc < stream_start")
+// that modern Clang flags as `-Wtautological-compare` because pointer arithmetic
+// past the end of an object is UB and the compiler may elide the check anyway.
+// The semantics are an upstream concern; suppress the noise locally so the
+// build stays clean. Keep the suppression as tight as possible around just
+// the third-party include.
 extern "C" {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
 #include "stb_vorbis.c"
+#pragma clang diagnostic pop
 }
 
 // miniaudio is included for ma_decoder. The implementation itself lives in

--- a/core/platform/mac/tcVideoPlayer_mac.mm
+++ b/core/platform/mac/tcVideoPlayer_mac.mm
@@ -8,6 +8,32 @@
 
 #include "TrussC.h"
 
+// AVAsset's synchronous `tracksWithMediaType:` and AVAssetImageGenerator's
+// `copyCGImageAtTime:` are deprecated in macOS 15.0 in favor of async
+// completion-handler variants. Migrating the codebase to the async APIs is
+// tracked on the roadmap ("macOS deprecated API migration"); until that lands
+// the sync call sites need to keep compiling cleanly across our supported
+// macOS versions (which include pre-15 systems where the async APIs are
+// either unavailable or require additional gating). Funnel both calls through
+// a single helper so the suppression sits in one place and the rest of the
+// file stays free of pragma noise.
+NS_INLINE NSArray<AVAssetTrack*>* tcv_tracks_with_media_type(AVAsset* asset, NSString* mediaType) {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [asset tracksWithMediaType:mediaType];
+    #pragma clang diagnostic pop
+}
+
+NS_INLINE CGImageRef tcv_copy_cgimage_at_time(AVAssetImageGenerator* gen,
+                                              CMTime requestTime,
+                                              CMTime* actualTime,
+                                              NSError** error) CF_RETURNS_RETAINED {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [gen copyCGImageAtTime:requestTime actualTime:actualTime error:error];
+    #pragma clang diagnostic pop
+}
+
 // =============================================================================
 // Internal Objective-C class for AVFoundation handling
 // =============================================================================
@@ -145,7 +171,7 @@
     }
 
     // Get video track info
-    NSArray* videoTracks = [self.asset tracksWithMediaType:AVMediaTypeVideo];
+    NSArray* videoTracks = tcv_tracks_with_media_type(self.asset, AVMediaTypeVideo);
     if (videoTracks.count == 0) {
         NSLog(@"TCVideoPlayer: No video tracks found");
         self.asset = nil;
@@ -177,7 +203,7 @@
           (long)_videoWidth, (long)_videoHeight, _frameRate, _duration);
 
     // Get audio track info
-    NSArray* audioTracks = [self.asset tracksWithMediaType:AVMediaTypeAudio];
+    NSArray* audioTracks = tcv_tracks_with_media_type(self.asset, AVMediaTypeAudio);
     if (audioTracks.count > 0) {
         AVAssetTrack* audioTrack = audioTracks[0];
         _hasAudioTrack = YES;
@@ -500,7 +526,7 @@ static void createADTSHeader(uint8_t* header, int frameLength, int sampleRate, i
         return nil;
     }
 
-    NSArray* audioTracks = [self.asset tracksWithMediaType:AVMediaTypeAudio];
+    NSArray* audioTracks = tcv_tracks_with_media_type(self.asset, AVMediaTypeAudio);
     if (audioTracks.count == 0) {
         return nil;
     }
@@ -859,7 +885,7 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
         if (timeSec < 0) timeSec = 0;
 
         // Check video track exists
-        NSArray* videoTracks = [asset tracksWithMediaType:AVMediaTypeVideo];
+        NSArray* videoTracks = tcv_tracks_with_media_type(asset, AVMediaTypeVideo);
         if (videoTracks.count == 0) return false;
 
         AVAssetImageGenerator* generator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
@@ -869,7 +895,7 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
 
         CMTime requestTime = CMTimeMakeWithSeconds(timeSec, NSEC_PER_SEC);
         NSError* error = nil;
-        CGImageRef cgImage = [generator copyCGImageAtTime:requestTime actualTime:NULL error:&error];
+        CGImageRef cgImage = tcv_copy_cgimage_at_time(generator, requestTime, NULL, &error);
         if (!cgImage) {
             if (error) {
                 NSLog(@"TCVideoPlayer::extractFrame error: %@", error);

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -50,6 +50,8 @@ void drawRectSquircle(float x, float y, float w, float h, float radius) // Draw 
 void drawRectSquircle(Vec3 pos, Vec2 size, float radius) // Draw squircle rectangle (curvature-continuous corners, iOS-style)
 void drawCircle(float x, float y, float radius) // Draw circle
 void drawCircle(Vec3 center, float radius) // Draw circle
+void drawArc(float x, float y, float radius, float angleBegin, float angleEnd) // Draw arc (partial circle, angles in radians)
+void drawArc(Vec3 center, float radius, float angleBegin, float angleEnd) // Draw arc (partial circle, angles in radians)
 void drawEllipse(float x, float y, float w, float h) // Draw ellipse
 void drawEllipse(Vec3 center, float rx, float ry) // Draw ellipse
 void drawEllipse(Vec3 center, Vec2 radii) // Draw ellipse
@@ -58,6 +60,12 @@ void drawPoint(Vec3 pos)                 // Draw a single point
 void drawLine(float x1, float y1, float x2, float y2) // Draw line (2D or 3D)
 void drawLine(float x1, float y1, float z1, float x2, float y2, float z2) // Draw line (2D or 3D)
 void drawLine(Vec3 p1, Vec3 p2)          // Draw line (2D or 3D)
+void drawBezier(Vec3 p0, Vec3 p1, Vec3 p2, Vec3 p3) // Draw bezier curve (cubic with 4 points, quadratic with 3, or N-th order via vector)
+void drawBezier(Vec3 p0, Vec3 p1, Vec3 p2) // Draw bezier curve (cubic with 4 points, quadratic with 3, or N-th order via vector)
+void drawBezier(const vector<Vec3>& controlPoints) // Draw bezier curve (cubic with 4 points, quadratic with 3, or N-th order via vector)
+void drawCurve(Vec3 p0, Vec3 p1, Vec3 p2, Vec3 p3) // Draw Catmull-Rom curve (4 control points draw p1->p2; vector chains segments passing through interior points; closed=true wraps around)
+void drawCurve(const vector<Vec3>& points) // Draw Catmull-Rom curve (4 control points draw p1->p2; vector chains segments passing through interior points; closed=true wraps around)
+void drawCurve(const vector<Vec3>& points, bool closed) // Draw Catmull-Rom curve (4 control points draw p1->p2; vector chains segments passing through interior points; closed=true wraps around)
 void drawTriangle(float x1, float y1, float x2, float y2, float x3, float y3) // Draw triangle
 void drawTriangle(Vec3 p1, Vec3 p2, Vec3 p3) // Draw triangle
 void drawBox(float size)                 // Draw 3D box (respects fill/noFill)
@@ -78,6 +86,10 @@ void vertex(float x, float y, float z)   // Add a vertex
 void vertex(const Vec2& v)               // Add a vertex
 void vertex(const Vec3& v)               // Add a vertex
 void endShape(bool close = false)        // End drawing a shape
+void appendArc(float cx, float cy, float radius, float angleBegin, float angleEnd) // Append arc vertices to the current shape (use between beginShape/endShape)
+void appendArc(const Vec2& center, float radius, float angleBegin, float angleEnd) // Append arc vertices to the current shape (use between beginShape/endShape)
+void appendCurve(const vector<Vec3>& points) // Append Catmull-Rom curve vertices to the current shape (use between beginShape/endShape; needs >=4 points, closed=true wraps around)
+void appendCurve(const vector<Vec3>& points, bool closed) // Append Catmull-Rom curve vertices to the current shape (use between beginShape/endShape; needs >=4 points, closed=true wraps around)
 void beginStroke()                       // Begin drawing a stroke (uses StrokeMesh internally)
 void endStroke(bool close = false)       // End drawing a stroke
 void beginLines()                        // Begin batch line drawing. Add vertex pairs with vertex(), then call endLines(). Each pair of vertices draws one independent line segment. Use setColor() between vertices for per-line colors.
@@ -111,8 +123,10 @@ void setStrokeJoin(StrokeJoin join)      // Set stroke join style (Miter, Round,
 StrokeJoin getStrokeJoin()               // Get current stroke join style
 bool isFillEnabled()                     // Check if fill mode is enabled
 bool isStrokeEnabled()                   // Check if stroke mode is enabled
-void setCircleResolution(int resolution) // Set circle segment count
-int getCircleResolution()                // Get circle segment count
+void setCurveTolerance(float pixels)     // Set adaptive curve tessellation tolerance in pixels (smaller = smoother, scale-aware)
+float getCurveTolerance()                // Get current curve tessellation tolerance (in pixels)
+void setCurveResolution(int n)           // Set fixed curve segment count (switches off adaptive tolerance mode)
+int getCurveResolution()                 // Get current curve resolution
 void pushStyle()                         // Save current style state (color, stroke, fill)
 void popStyle()                          // Restore previous style state
 void resetStyle()                        // Reset style to default values (white color, fill enabled, stroke disabled)
@@ -376,7 +390,7 @@ FileReader@ createFileReader()           // Create a file reader (TrussSketch fa
 
 ```cpp
 Sound@ createSound()                     // Create a sound player (TrussSketch factory)
-bool load(const string& path)            // Load sound file
+bool load(const string& path)            // Load sound file. Format auto-detected by extension: .wav .mp3 .ogg .flac .aac .m4a
 void play()                              // Play sound
 void stop()                              // Stop sound
 void setVolume(float vol)                // Set volume (0.0-1.0)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,7 @@
 | Area lights | Rectangle / disc / line area light sources | High |
 | Cascaded shadow maps | CSM for directional lights (large outdoor scenes) | High |
 | Unified `LoadResult` API | Replace `bool` return of `Image::load` / `SoundBuffer::load` / `Video::load` / `Font::load` / `Shader::load` with a shared `trussc::LoadResult` carrying `LoadError` enum + message + raw code. Use `explicit operator bool()` so existing `if (x.load(...))` keeps working. Needs an audit of error taxonomy first (file-not-found / invalid-format / permission-denied / decoder-failure / etc.) and a per-domain inventory of what error sources exist (stb_image, AVFoundation, mbedTLS, miniaudio, etc.). | High |
+| Real-time audio stream API | Expose the audio callback so user code can synthesize / process samples per buffer (typical 256–512 frames at 96 kHz). oF-style listener pattern: `App` gets an overridable `audioOut(float* out, size_t frames, int channels)` (and `audioIn(const float* in, ...)`); plus a free-function or `SoundStream` class for non-App-bound code. Currently the only way to produce sound is pre-baked `SoundBuffer` + `Sound::play()`, which can't handle dynamic synthesis (sine generators with live parameter changes, granular synthesis, software synths, audio effects, etc.). Output runs at engine native rate (96 kHz, no rateRatio path) — document that. | High |
 
 ### Medium Priority
 
@@ -26,6 +27,7 @@
 | macOS deprecated API migration | Replace `tracksWithMediaType:` / `copyCGImageAtTime:` with async equivalents (deprecated in macOS 15.0) | Medium |
 | `SG_VERTEXFORMAT_INT10_N2` adoption | sokol_gfx (2026-05) added a 10-10-10-2 normalized int vertex format. Adopt for `tcMesh` normal / tangent attributes — 3x smaller than FLOAT3 with effectively no visual loss (Unity / Unreal default). D3D11 backend not yet supported upstream, so verify Windows path before committing. | Medium |
 | Configurable 10-bit color output | TrussC currently forces RGB10A2 swap-chain in sokol_app patches. Make it opt-in via WindowSettings once upstream sokol adds a `SAPP_PIXELFORMAT_RGB10A2` (currently not in upstream — track [floooh/sokol](https://github.com/floooh/sokol)). | Low |
+| Dear ImGui 1.92.6 → latest | Currently on 1.92.6 WIP. 1.92.8 (2026-05-12) introduced a notable breaking change: `AddRect()` / `AddPolyline()` / `PathStroke()` swapped their `flags` and `thickness` arg positions. TrussC core does not touch these, but user code that does will need updates. Inline redirection keeps source compatible unless `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` is on. Plan a single bump to the latest 1.92.x. | Low |
 
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,21 +9,6 @@
 
 ## Planned Features
 
-### Implemented (gpu-pbr branch)
-
-| Feature | Description |
-|---------|-------------|
-| GPU PBR lighting | Cook-Torrance GGX BRDF, metallic-roughness workflow, up to 8 lights |
-| Light types | Directional, Point, Spot with cone falloff |
-| Projector light | Texture projection with lens shift, aspect ratio, gobo |
-| IES profiles | IESNA LM-63 photometric profiles for angular intensity |
-| IBL environment | HDR / procedural sky, irradiance + prefilter + BRDF LUT |
-| Normal mapping | Tangent-space normal maps with TBN matrix |
-| PBR texture maps | Base color, metallic-roughness, emissive, occlusion (glTF 2.0) |
-| Shadow mapping | R32F depth map, 3x3 PCF, per-light bias control |
-| glTF loader | tcxGltf addon (cgltf), GLB/glTF with embedded textures |
-| ImGui addon extraction | Extracted to tcxImGui addon |
-
 ### High Priority
 
 | Feature | Description | Difficulty |
@@ -31,15 +16,16 @@
 | Multi-light shadows | Support shadow maps for multiple lights simultaneously | High |
 | Area lights | Rectangle / disc / line area light sources | High |
 | Cascaded shadow maps | CSM for directional lights (large outdoor scenes) | High |
+| Unified `LoadResult` API | Replace `bool` return of `Image::load` / `SoundBuffer::load` / `Video::load` / `Font::load` / `Shader::load` with a shared `trussc::LoadResult` carrying `LoadError` enum + message + raw code. Use `explicit operator bool()` so existing `if (x.load(...))` keeps working. Needs an audit of error taxonomy first (file-not-found / invalid-format / permission-denied / decoder-failure / etc.) and a per-domain inventory of what error sources exist (stb_image, AVFoundation, mbedTLS, miniaudio, etc.). | High |
 
 ### Medium Priority
 
 | Feature | Description | Difficulty |
 |---------|-------------|------------|
-| FLAC support | Enable FLAC decoding via miniaudio configuration | Low |
 | VBO detail control | Dynamic vertex buffers | Medium |
 | macOS deprecated API migration | Replace `tracksWithMediaType:` / `copyCGImageAtTime:` with async equivalents (deprecated in macOS 15.0) | Medium |
-| PBR in Fbo | Allow PBR mesh rendering inside Fbo passes | Medium |
+| `SG_VERTEXFORMAT_INT10_N2` adoption | sokol_gfx (2026-05) added a 10-10-10-2 normalized int vertex format. Adopt for `tcMesh` normal / tangent attributes — 3x smaller than FLOAT3 with effectively no visual loss (Unity / Unreal default). D3D11 backend not yet supported upstream, so verify Windows path before committing. | Medium |
+| Configurable 10-bit color output | TrussC currently forces RGB10A2 swap-chain in sokol_app patches. Make it opt-in via WindowSettings once upstream sokol adds a `SAPP_PIXELFORMAT_RGB10A2` (currently not in upstream — track [floooh/sokol](https://github.com/floooh/sokol)). | Low |
 
 
 ---

--- a/docs/TrussC_vs_openFrameworks.md
+++ b/docs/TrussC_vs_openFrameworks.md
@@ -306,7 +306,6 @@ Reference for oF users finding equivalent features in TrussC.
 | `ofFill` | `fill()` |  |
 | `ofNoFill` | `noFill()` |  |
 | `ofSetLineWidth` | `setStrokeWeight(weight)` |  |
-| `ofSetCircleResolution` | `setCircleResolution(resolution)` |  |
 | `ofPushStyle` | `pushStyle()` |  |
 | `ofPopStyle` | `popStyle()` |  |
 | `ofEnableBlendMode` | `setBlendMode(mode)` |  |

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -3350,9 +3350,9 @@ categories:
         signatures:
           - params: "const string& path"
             params_simple: "path"
-        description: "Load sound file"
-        description_ja: "サウンドファイルを読み込む"
-        description_ko: "사운드 파일을 로드"
+        description: "Load sound file. Format auto-detected by extension: .wav .mp3 .ogg .flac .aac .m4a"
+        description_ja: "サウンドファイルを読み込む。拡張子で自動判別: .wav .mp3 .ogg .flac .aac .m4a"
+        description_ko: "사운드 파일을 로드. 확장자로 자동 판별: .wav .mp3 .ogg .flac .aac .m4a"
         sketch: true
         snippet: "load(${1:\"sound.wav\"})"
 
@@ -4335,6 +4335,28 @@ categories:
         description_ko: "자식 노드를 추가 (C++ 전용)"
         sketch: false
         snippet: "addChild(${1:child})"
+
+      - name: moveToFront
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Move this node to the end of its parent's child list — drawn last, on top of siblings. No-op if no parent or already last (C++ only)"
+        description_ja: "親の子リストの末尾へ移動。最後に描画され、兄弟の最前面に表示される。親がない / すでに末尾の場合は何もしない（C++のみ）"
+        description_ko: "이 노드를 부모의 자식 리스트 끝으로 이동 — 마지막에 그려지므로 형제들 위에 표시됨. 부모가 없거나 이미 마지막이면 동작 안 함 (C++ 전용)"
+        sketch: false
+        snippet: "moveToFront()"
+
+      - name: moveToBack
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Move this node to the beginning of its parent's child list — drawn first, beneath siblings. No-op if no parent or already first (C++ only)"
+        description_ja: "親の子リストの先頭へ移動。最初に描画され、兄弟の最背面に表示される。親がない / すでに先頭の場合は何もしない（C++のみ）"
+        description_ko: "이 노드를 부모의 자식 리스트 처음으로 이동 — 먼저 그려지므로 형제들 아래에 표시됨. 부모가 없거나 이미 처음이면 동작 안 함 (C++ 전용)"
+        sketch: false
+        snippet: "moveToBack()"
 
       - name: destroy
         return: "void"
@@ -9318,9 +9340,9 @@ types:
         return: bool
         signatures:
           - params: "string path"
-        description: "Load audio file"
-        description_ja: "音声ファイルを読み込む"
-        description_ko: "오디오 파일을 로드"
+        description: "Load audio file. Format auto-detected by extension: .wav .mp3 .ogg .flac .aac .m4a"
+        description_ja: "音声ファイルを読み込む。拡張子で自動判別: .wav .mp3 .ogg .flac .aac .m4a"
+        description_ko: "오디오 파일을 로드. 확장자로 자동 판별: .wav .mp3 .ogg .flac .aac .m4a"
         snippet: "load(${1:\"path\"})"
       - name: play
         return: "void"


### PR DESCRIPTION
## Summary

Small workshop-prep PR. No behavioural changes to library code, just docs and warnings.

### Warnings: zero on Apple Clang
- **tcVideoPlayer_mac.mm** — funnel deprecated `tracksWithMediaType:` (x4) and `copyCGImageAtTime:` (x1) through two `NS_INLINE` helpers with localized pragma suppression. The async-API migration is on the roadmap; this just keeps the build clean until that lands.
- **stb_vorbis.c** — pragma-suppress the upstream tautological compare around the include in tcSound_impl.cpp (no third-party patch).

### Roadmap
- Drop already-implemented entries (FLAC support — done in #88, PBR in Fbo — done on gpu-pbr branch, the "Implemented (gpu-pbr branch)" subsection).
- Add **Unified `LoadResult` API** entry (High) — planned shared error-info struct for all `load()` methods (audio/image/video/font/shader). `explicit operator bool()` keeps `if (x.load(...))` source-compatible.
- Add **`SG_VERTEXFORMAT_INT10_N2` adoption** (Medium) — 3x smaller normal/tangent attrs from the recent sokol update.
- Add **Configurable 10-bit color output** (Low) — opt-in once upstream sokol adds a swap-chain format option.
- Add **Real-time audio stream API** (High) — oF-style `audioOut` listener for live synth. The current pre-baked-buffer + `Sound::play()` flow can't do dynamic synthesis.
- Add **Dear ImGui 1.92.6 → latest** (Low) — investigated; 1.92.8 has a notable `AddRect/AddPolyline/PathStroke` arg swap, but inline redirects keep source compat.

### API doc sync
- `docs/api-definition.yaml`:
  - Sound::load() description now enumerates supported extensions (.wav .mp3 .ogg .flac .aac .m4a) — FLAC was undocumented after #88.
  - Node gains moveToFront / moveToBack entries with draw-order semantics noted.
- Regenerated `docs/REFERENCE.md` + `docs/TrussC_vs_openFrameworks.md` via `docs/scripts/generate-docs.js`. trussc.org and TrussSketch sister-repos get matching commits separately.

## Test plan
- [x] Local build trusscli + soundPlayerExample + videoPlayerExample (warning-free)
- [x] AudioRegressionTest still 10/10 PASS
- [x] videoPlayerExample plays an mp4 (smoke test for tcVideoPlayer_mac.mm helper extraction)
- [x] CI green across platforms