### PR TITLE
Tighten Node tree mutation safety across dispatch sites

### DIFF
--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -134,19 +134,27 @@ public:
 
         auto it = std::find(children_.begin(), children_.end(), child);
         if (it != children_.end()) {
-            onChildRemoved(child);  // Notify before removal
-            (*it)->parent_.reset();
+            // Mutate first, then notify. onChildRemoved overrides may call
+            // addChild / removeChild on this node; firing the callback after
+            // the erase keeps children_ consistent and avoids invalidating
+            // the local iterator before we use it.
             children_.erase(it);
+            child->parent_.reset();
+            onChildRemoved(child);
         }
     }
 
     // Remove all child nodes
     void removeAllChildren() {
-        for (auto& child : children_) {
-            onChildRemoved(child);  // Notify for each child
+        // Mutate first (single vector move), then notify. onChildRemoved
+        // overrides may call addChild on this node; firing the callbacks
+        // after the move lets them see an empty children_.
+        auto cleared = std::move(children_);
+        children_.clear();   // moved-from vector is "valid but unspecified"
+        for (auto& child : cleared) {
             child->parent_.reset();
+            onChildRemoved(child);
         }
-        children_.clear();
     }
 
     // Callback when child is added (overridable)
@@ -469,17 +477,32 @@ private:
             setup();
         }
 
-        // Mod early update (before Node::update)
-        for (auto& [type, mod] : mods_) {
-            mod->earlyUpdate();
+        // Mod early update (before Node::update). Snapshot type indices —
+        // a mod's earlyUpdate() may call addMod / removeMod on this node,
+        // and `mods_` is an unordered_map whose iterators would otherwise
+        // invalidate. New mods added during dispatch are picked up next frame.
+        {
+            std::vector<std::type_index> modTypes;
+            modTypes.reserve(mods_.size());
+            for (auto& [t, m] : mods_) modTypes.push_back(t);
+            for (auto& t : modTypes) {
+                auto it = mods_.find(t);
+                if (it != mods_.end()) it->second->earlyUpdate();
+            }
         }
 
         processTimers();
         update();  // User code
 
-        // Mod update (after Node::update)
-        for (auto& [type, mod] : mods_) {
-            mod->update();
+        // Mod update (after Node::update) — same snapshot rationale as above.
+        {
+            std::vector<std::type_index> modTypes;
+            modTypes.reserve(mods_.size());
+            for (auto& [t, m] : mods_) modTypes.push_back(t);
+            for (auto& t : modTypes) {
+                auto it = mods_.find(t);
+                if (it != mods_.end()) it->second->update();
+            }
         }
 
         // Iterate over a snapshot — a child's update() may add, remove, or
@@ -493,25 +516,39 @@ private:
         }
     }
 
-    // Remove dead children and call cleanup on their subtrees
+    // Remove dead children and call cleanup on their subtrees.
+    //
+    // Two-phase: collect dead children, mutate children_, THEN fire user
+    // callbacks (cleanupTree / onChildRemoved). User code inside those
+    // callbacks may call addChild / removeChild on this node — running them
+    // after the erase guarantees a consistent children_ during dispatch.
     void sweepDeadChildren() {
-        auto it = std::remove_if(children_.begin(), children_.end(),
-            [this](const Ptr& child) {
-                if (child->isDead()) {
-                    child->cleanupTree();
-                    onChildRemoved(child);
-                    child->parent_.reset();
-                    return true;
-                }
-                return false;
-            });
-        children_.erase(it, children_.end());
+        std::vector<Ptr> dead;
+        for (auto& c : children_) {
+            if (c->isDead()) dead.push_back(c);
+        }
+        if (dead.empty()) return;
+
+        children_.erase(
+            std::remove_if(children_.begin(), children_.end(),
+                [](const Ptr& c) { return c->isDead(); }),
+            children_.end());
+
+        for (auto& c : dead) {
+            c->cleanupTree();
+            onChildRemoved(c);
+            c->parent_.reset();
+        }
     }
 
     // Recursively call cleanup() on this node and all descendants
     void cleanupTree() {
-        // Cleanup children first (depth-first, like destructors)
-        for (auto& child : children_) {
+        // Cleanup children first (depth-first, like destructors). Snapshot
+        // because a child's cleanup() may reach back and mutate this node's
+        // children_ (uncommon but legal — e.g. a child that unregisters
+        // siblings from its parent on destruction).
+        auto snapshot = children_;
+        for (auto& child : snapshot) {
             child->cleanupTree();
         }
 
@@ -759,8 +796,11 @@ protected:
 
         HitResult bestResult{};
 
-        // Traverse child nodes from back (reverse draw order)
-        for (auto it = children_.rbegin(); it != children_.rend(); ++it) {
+        // Traverse child nodes from back (reverse draw order). Snapshot in
+        // case a hitTest() override mutates the tree — hitTest is contractually
+        // a pure geometric predicate, but the snapshot is cheap insurance.
+        auto snapshot = children_;
+        for (auto it = snapshot.rbegin(); it != snapshot.rend(); ++it) {
             HitResult childResult = (*it)->findHitNodeRecursive(globalRay, globalInverse);
             if (childResult.hit()) {
                 // Use child's result (later in draw order = front)


### PR DESCRIPTION
## Summary

Tighten Node tree mutation safety across all dispatch sites. The earlier
`children_` snapshot in `updateTree` / `drawChildren` / `dispatchKey*` was
just the first wave — `sweepDeadChildren`, `removeChild`, `removeAllChildren`,
`cleanupTree`, `findHitNodeRecursive`, and the Mods loops all had the same
class of bug (user callback inside the iteration corrupts the in-flight
container) and were verified to fail in practice.

## Verified failure modes (sandbox, ASan + UBSan)

| Site | Diagnostic before fix |
|---|---|
| `sweepDeadChildren` | ASan heap-use-after-free in `remove_if` lambda after `cleanup()` reallocates `children_` |
| `removeChild` | ASan HUAF on `(*it)->parent_.reset()` after `onChildRemoved` triggers `addChild` realloc |
| `removeAllChildren` | Silent data loss + HUAF under realloc (endurance run) |
| `cleanupTree` | UBSan member-call-on-null at `tcNode.h:515` after sibling `cleanup()` mutates `children_` |
| `findHitNodeRecursive` | ASan HUAF in the reverse-iter walk; crash can land one frame later via `updateHoverState`, so the symptom appears far from the cause |
| Mods loop | Standard-undefined; libstdc++ happened not to rehash, so no diagnostic — defensive only |

Endurance run: 1000 frames of chaotic add/remove/destroy/move with the AFTER
build → `parentMismatch=0`, `deadInTree=0` throughout.

## Fixes applied (one file: `core/include/tcNode.h`)

- **`removeChild` / `removeAllChildren`** — erase first, fire `onChildRemoved`
  after. The callback sees an already-consistent `children_`, and the local
  iterator can't be invalidated by re-entry. `removeAllChildren` uses
  `std::move(children_)` so the cost stays O(1).
- **`sweepDeadChildren`** — two-phase: collect dead children, erase them all
  from `children_`, then fire `cleanupTree` + `onChildRemoved` on the local
  list. User code inside the callbacks runs against a consistent vector.
- **`cleanupTree`, `findHitNodeRecursive`** — snapshot `children_` before the
  loop. Costs N shared_ptr copies; N is small in practice and these paths
  already do O(N) work.
- **Mods loops in `updateTree`** — snapshot the `type_index` keys, re-`find`
  each iteration so a removed mod is skipped and a newly-added mod waits
  for the next frame. Same semantics as the existing children-snapshot
  pattern.

No API change. New tree mutations issued from inside a callback land on
the next frame, matching the existing snapshot-iteration contract.

## Performance impact

Bench: static N-node tree, no-op `update()` per node, default
`RelWithDebInfo` (`-O2 -g -DNDEBUG`), no sanitizers, no mutations — isolates
pure snapshot overhead. Median of 21 iterations. Compared the commit
immediately before the first children-snapshot (`a23f244`) against this PR
tip (`ff37454`).

```
  nodes  frames   pre-snapshot   current     Δ rel    Δ /frame   Δ /node/frame
     40  10000      0.0410s      0.0465s    +13.4%   +0.55 µs   +13.8 ns
    121  10000      0.1246s      0.1386s    +11.2%   +1.40 µs   +11.6 ns
   1365   5000      0.7448s      0.7950s     +6.7%  +10.04 µs    +7.4 ns
   5461   2000      1.2191s      1.2623s     +3.5%  +21.60 µs    +4.0 ns
```

- **Per-child overhead is 4–14 ns** (dominated by `shared_ptr` atomic
  refcount inc/dec). It *shrinks* in larger trees because memory-hierarchy
  latency hides the atomics.
- **Typical app (≈10–100 nodes): +1–2 µs/frame ≈ 0.006–0.01% of a 16.6 ms
  60 Hz budget**. Below the noise floor.
- **Pathological (5000+ nodes, empty `update()`): +3.5%** — still well
  within frame budget.
- The bench uses a no-op `update()`. Any real `update()` (matrix math,
  draw calls, layout) dwarfs the snapshot cost, so the *relative* overhead
  in production is strictly smaller than the numbers above.

The fixes are effectively free at the budgets TrussC apps care about.

## Notes

- Builds clean on macOS (`trusscli build` for trusscli, no compiler warnings
  attributable to this change).
- Verification harness, raw logs, and the full audit live outside this repo
  in `~/Desktop/subtask/work/node-mutation-safety-audit.md` (sandbox-side).
