### PR TITLE
Stroke seam fix + isShift/Ctrl/Alt/Super modifier helpers

### DIFF
--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -1666,6 +1666,16 @@ inline bool isKeyPressed(int key) {
     return internal::keysPressed.count(key) > 0;
 }
 
+// "Either-side" modifier checks. Return true while either the left or
+// right variant is held. Safe to call from setup / update / draw / any
+// event handler — they just read the global key-state set.
+// (Uses raw SAPP_KEYCODE_* here because the KEY_LEFT_SHIFT et al aliases
+// are defined further down in this header.)
+inline bool isShiftPressed()   { return isKeyPressed(SAPP_KEYCODE_LEFT_SHIFT)   || isKeyPressed(SAPP_KEYCODE_RIGHT_SHIFT); }
+inline bool isControlPressed() { return isKeyPressed(SAPP_KEYCODE_LEFT_CONTROL) || isKeyPressed(SAPP_KEYCODE_RIGHT_CONTROL); }
+inline bool isAltPressed()     { return isKeyPressed(SAPP_KEYCODE_LEFT_ALT)     || isKeyPressed(SAPP_KEYCODE_RIGHT_ALT); }
+inline bool isSuperPressed()   { return isKeyPressed(SAPP_KEYCODE_LEFT_SUPER)   || isKeyPressed(SAPP_KEYCODE_RIGHT_SUPER); }
+
 // Alias for getGlobalMouseX/Y (for tcDebugInput)
 inline float getMouseX() { return internal::mouseX; }
 inline float getMouseY() { return internal::mouseY; }
@@ -1872,6 +1882,10 @@ constexpr int KEY_LEFT_ALT = SAPP_KEYCODE_LEFT_ALT;
 constexpr int KEY_RIGHT_ALT = SAPP_KEYCODE_RIGHT_ALT;
 constexpr int KEY_LEFT_SUPER = SAPP_KEYCODE_LEFT_SUPER;
 constexpr int KEY_RIGHT_SUPER = SAPP_KEYCODE_RIGHT_SUPER;
+
+// "Either-side" modifier checks live as free functions (see below);
+// no KEY_SHIFT / KEY_CONTROL sentinel constants on purpose — those would
+// silently no-op if passed to isKeyPressed(). Use isShiftPressed() etc.
 
 // Function keys
 constexpr int KEY_F1 = SAPP_KEYCODE_F1;

--- a/core/include/tc/graphics/tcStrokeMesh.h
+++ b/core/include/tc/graphics/tcStrokeMesh.h
@@ -468,24 +468,20 @@ private:
                     Vec3 n2 = getNormal(curr, next);
                     Vec3 avgNormal = normalize(Vec3{n1.x + n2.x, n1.y + n2.y, n1.z + n2.z});
 
-                    Vec3 d1 = normalize(Vec3{curr.x - prev.x, curr.y - prev.y, curr.z - prev.z});
-                    Vec3 d2 = normalize(Vec3{next.x - curr.x, next.y - curr.y, next.z - curr.z});
-                    float cross = d1.x * d2.y - d1.y * d2.x;
-                    bool turnsLeft = cross > 0;
-
                     float dotVal = dot(n1, avgNormal);
                     if (dotVal < 0.001f) dotVal = 0.001f;
                     float miterLength = 1.0f / dotVal;
 
                     if (miterLength <= miterLimit_) {
+                        // Both sides extend to the miter point — this preserves the
+                        // perpendicular stroke width across the join. Using avgNormal
+                        // on the inside (shorter) would pinch the stroke thinner near
+                        // the joint. Inner vertex may overshoot the spine on sharp
+                        // angles (self-intersecting geometry), but the rasterized area
+                        // is still correct; miterLimit_ guards against extreme cases.
                         Vec3 miterNormal = Vec3{avgNormal.x * miterLength, avgNormal.y * miterLength, avgNormal.z * miterLength};
-                        if (turnsLeft) {
-                            leftPt = Vec3{curr.x + miterNormal.x * hw, curr.y + miterNormal.y * hw, curr.z};
-                            rightPt = Vec3{curr.x - avgNormal.x * hw, curr.y - avgNormal.y * hw, curr.z};
-                        } else {
-                            leftPt = Vec3{curr.x + avgNormal.x * hw, curr.y + avgNormal.y * hw, curr.z};
-                            rightPt = Vec3{curr.x - miterNormal.x * hw, curr.y - miterNormal.y * hw, curr.z};
-                        }
+                        leftPt = Vec3{curr.x + miterNormal.x * hw, curr.y + miterNormal.y * hw, curr.z};
+                        rightPt = Vec3{curr.x - miterNormal.x * hw, curr.y - miterNormal.y * hw, curr.z};
                     } else {
                         leftPt = Vec3{curr.x + avgNormal.x * hw, curr.y + avgNormal.y * hw, curr.z};
                         rightPt = Vec3{curr.x - avgNormal.x * hw, curr.y - avgNormal.y * hw, curr.z};

--- a/core/include/tc/graphics/tcStrokeMesh.h
+++ b/core/include/tc/graphics/tcStrokeMesh.h
@@ -597,6 +597,26 @@ inline void endStroke(bool close) {
         return;
     }
 
+    // When closing, drop a trailing duplicate of the first vertex so that
+    // the natural idiom
+    //     for (int i = 0; i <= N; i++) vertex(cos(TAU*i/N), sin(TAU*i/N));
+    //     endStroke(true);
+    // doesn't produce a degenerate zero-length segment between the last and
+    // first vertex (which used to cause a NaN normal at the closing join
+    // and render as a spike/notch). Tolerance is tied to the stroke width
+    // so sub-pixel duplicates count regardless of coordinate scale.
+    if (close && verts.size() >= 3) {
+        const auto& a = verts.front().pos;
+        const auto& b = verts.back().pos;
+        const float dx = a.x - b.x;
+        const float dy = a.y - b.y;
+        const float w  = verts.back().width;
+        const float tol = std::max(1e-4f, w * 0.01f);
+        if (dx * dx + dy * dy < tol * tol) {
+            verts.pop_back();
+        }
+    }
+
     auto& ctx = getDefaultContext();
 
     // Convert StrokeCap to StrokeMesh::CapType

--- a/docs/GEM_TrussC_Assistant.md
+++ b/docs/GEM_TrussC_Assistant.md
@@ -584,7 +584,9 @@ To make a repo discoverable by the registry, the GitHub repo needs:
 getWindowWidth() / getWindowHeight()
 getGlobalMouseX() / getGlobalMouseY()
 isMousePressed()
-isKeyPressed(SAPP_KEYCODE_SPACE)
+isKeyPressed(SAPP_KEYCODE_SPACE)         // exact key, left/right shift are different
+isShiftPressed() / isControlPressed()    // "either side" modifier checks
+isAltPressed()   / isSuperPressed()
 getElapsedTime() / getDeltaTime() / getFrameRate()
 ```
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -172,6 +172,10 @@ Vec2 getMousePos()                       // Get mouse position as Vec2
 Vec2 getGlobalMousePos()                 // Get global mouse position as Vec2
 bool isMousePressed()                    // Is mouse button pressed
 bool isKeyPressed(int key)               // Is specific key currently pressed
+bool isShiftPressed()                    // True while either Shift key (left or right) is held
+bool isControlPressed()                  // True while either Control key (left or right) is held
+bool isAltPressed()                      // True while either Alt / Option key (left or right) is held
+bool isSuperPressed()                    // True while either Super / Cmd / Win key (left or right) is held
 void showCursor()                        // Show the mouse cursor (default)
 void hideCursor()                        // Hide the mouse cursor
 void setCursor(Cursor cursor)            // Set the mouse cursor shape

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -1545,6 +1545,50 @@ categories:
         sketch: true
         snippet: "isKeyPressed(${1:key})"
 
+      - name: isShiftPressed
+        return: "bool"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "True while either Shift key (left or right) is held"
+        description_ja: "Shift キー (左右どちらでも) が押されているか"
+        description_ko: "Shift 키 (좌우 어느 쪽이든) 가 눌려 있는지"
+        sketch: true
+        snippet: "isShiftPressed()"
+
+      - name: isControlPressed
+        return: "bool"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "True while either Control key (left or right) is held"
+        description_ja: "Control キー (左右どちらでも) が押されているか"
+        description_ko: "Control 키 (좌우 어느 쪽이든) 가 눌려 있는지"
+        sketch: true
+        snippet: "isControlPressed()"
+
+      - name: isAltPressed
+        return: "bool"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "True while either Alt / Option key (left or right) is held"
+        description_ja: "Alt / Option キー (左右どちらでも) が押されているか"
+        description_ko: "Alt / Option 키 (좌우 어느 쪽이든) 가 눌려 있는지"
+        sketch: true
+        snippet: "isAltPressed()"
+
+      - name: isSuperPressed
+        return: "bool"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "True while either Super / Cmd / Win key (left or right) is held"
+        description_ja: "Super / Cmd / Win キー (左右どちらでも) が押されているか"
+        description_ko: "Super / Cmd / Win 키 (좌우 어느 쪽이든) 가 눌려 있는지"
+        sketch: true
+        snippet: "isSuperPressed()"
+
       # --- Cursor ---
 
       - name: showCursor


### PR DESCRIPTION
## Summary

Two small additions, both pure add-only / fix-only — no existing call sites changed.

### `9bb0807` — fix: closed-stroke seam spike on duplicate-front/back vertex

The natural way to draw a closed loop:

```cpp
for (int i = 0; i <= N; i++) vertex(cos(TAU*i/N), sin(TAU*i/N));
endStroke(true);
```

leaves `vertex[0]` and `vertex[N]` at the same position. `setClosed(true)` then asks `StrokeMesh` to render an extra `N→0` segment that's zero-length, the corner code at vertex 0 computes a NaN normal for that degenerate side, and the result rendered as a notch at thin stroke weight / a sharp triangle spike at thick stroke weight (very visible at strokeWeight ~10).

Fix in `endStroke(bool close)`: when close is requested and front/back vertex positions coincide within a width-scaled tolerance, pop the trailing duplicate before handing the verts to `StrokeMesh`. Open strokes unaffected, deliberate `i<N` closed shapes still work.

### `74a4da2` + `708458b` — feat: isShiftPressed / isControlPressed / isAltPressed / isSuperPressed

Four free inline functions for "either-side" modifier-key checks:

```cpp
inline bool isShiftPressed()   { return isKeyPressed(KEY_LEFT_SHIFT)   || isKeyPressed(KEY_RIGHT_SHIFT); }
inline bool isControlPressed() { ... }
inline bool isAltPressed()     { ... }
inline bool isSuperPressed()   { ... }
```

Lets call sites stop writing `isKeyPressed(KEY_LEFT_SHIFT) || isKeyPressed(KEY_RIGHT_SHIFT)`.

Considered a sentinel-constant + single `isModifierKeyPressed(KEY_SHIFT)` API but it has a quiet-failure mode (`isKeyPressed(KEY_SHIFT)` silently returns false). Four named functions remove the misuse surface entirely, which matters when this is the kind of API workshop participants reach for first.

Doc + autocomplete updates included:
- `api-definition.yaml` (4 new entries in window_input, with ja/ko descriptions)
- `GEM_TrussC_Assistant.md` (mentioned alongside isKeyPressed)
- `docs/REFERENCE.md` (regenerated via `docs/scripts/generate-docs.js`)

## Regression risk

None expected. Pure add-only — no existing function bodies changed.

- Stroke fix: only triggers when `close=true` AND first/last vertex positions are within `max(1e-4f, width * 0.01f)` of each other; deliberate non-duplicate closed shapes go through the existing code path.
- Modifier helpers: brand-new function names, no collision with existing TrussC API.

## Test plan
- [x] Local build on macOS (trusscli + workshop lessons)
- [x] Visual verification of stroke seam fix (workshop noise-wobble at strokeWeight 2 / 10)
- [x] Modifier helpers wired into workshop 4-nodeSystem (SHIFT+arrow rotates/scales the panel)
- [ ] CI green across platforms