### PR TITLE
Hot Reload across OSes + Xcode generator support

### DIFF
--- a/core/cmake/trussc_app.cmake
+++ b/core/cmake/trussc_app.cmake
@@ -432,6 +432,15 @@ message(\"  [HotReload] Generated \${DEF_FILE} with \${SYM_COUNT} symbols\")
                 -rdynamic)
         endif()
 
+        # Mac/Linux: guest doesn't link to host (symbols resolved at runtime via
+        # dlopen), so without an explicit dependency the IDE-driven host build
+        # leaves libguest.dylib stale or missing. Force the IDE/build system
+        # (Xcode, Ninja, Make) to build guest whenever host is built.
+        # Windows already has guest -> host link dependency above.
+        if(NOT WIN32)
+            add_dependencies(${PROJECT_NAME} guest)
+        endif()
+
     elseif(ANDROID)
         add_library(${PROJECT_NAME} SHARED ${_TC_SOURCES})
     else()
@@ -908,6 +917,7 @@ message(\"  [HotReload] Generated \${DEF_FILE} with \${SYM_COUNT} symbols\")
             MACOSX_BUNDLE TRUE
             MACOSX_BUNDLE_BUNDLE_NAME "${MACOSX_BUNDLE_DISPLAY_NAME}"
             MACOSX_BUNDLE_GUI_IDENTIFIER "com.trussc.${PROJECT_NAME}"
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.trussc.${PROJECT_NAME}"
             MACOSX_BUNDLE_BUNDLE_VERSION "1.0"
             MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0"
             MACOSX_BUNDLE_INFO_PLIST "${TRUSSC_DIR}/resources/Info.plist.in"

--- a/core/cmake/trussc_app.cmake
+++ b/core/cmake/trussc_app.cmake
@@ -283,7 +283,11 @@ endif()
         endif()
         # Windows: デバッグ情報を.objに埋め込み（/Z7）、PDBを生成しない。
         # デバッガがguest.pdbをロックするとホットリロード時のリビルドが失敗するため。
+        # CMakeデフォルトの/Ziを/Z7に置換してD9025 warningを防ぐ。
         if(MSVC)
+            foreach(_cfg DEBUG RELWITHDEBINFO)
+                string(REGEX REPLACE "/Z[iI]" "/Z7" CMAKE_CXX_FLAGS_${_cfg} "${CMAKE_CXX_FLAGS_${_cfg}}")
+            endforeach()
             target_compile_options(guest PRIVATE /Z7)
             set_target_properties(guest PROPERTIES LINK_FLAGS "/DEBUG /PDBALTPATH:none")
         endif()

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -1556,59 +1556,13 @@ inline float getAspectRatio() {
 // Time
 // ---------------------------------------------------------------------------
 
-inline double getElapsedTime() {
-    auto now = std::chrono::high_resolution_clock::now();
-    if (!internal::startTimeInitialized) {
-        internal::startTime = now;
-        internal::startTimeInitialized = true;
-        return 0.0;
-    }
-    auto duration = std::chrono::duration<double>(now - internal::startTime);
-    return duration.count();
-}
-
-// Number of update calls
-// In decoupled mode, may be called more frequently than draw
-inline uint64_t getUpdateCount() {
-    return internal::updateFrameCount;
-}
-
-// Draw frame count (sokol's frame_count)
-inline uint64_t getDrawCount() {
-    return sapp_frame_count();
-}
-
-// Alias for getUpdateCount (for general use)
-inline uint64_t getFrameCount() {
-    return internal::updateFrameCount;
-}
-
-inline double getDeltaTime() {
-    return internal::updateDeltaTime;
-}
-
-// Get frame rate (10-frame moving average, based on update delta time)
-inline double getFrameRate() {
-    // Add current update delta time to buffer
-    double dt = internal::updateDeltaTime;
-    if (dt <= 0.0) return 0.0;
-    internal::frameTimeBuffer[internal::frameTimeIndex] = dt;
-    internal::frameTimeIndex = (internal::frameTimeIndex + 1) % 10;
-    if (internal::frameTimeIndex == 0) {
-        internal::frameTimeBufferFilled = true;
-    }
-
-    // Calculate average
-    int count = internal::frameTimeBufferFilled ? 10 : internal::frameTimeIndex;
-    if (count == 0) return 0.0;
-
-    double sum = 0.0;
-    for (int i = 0; i < count; i++) {
-        sum += internal::frameTimeBuffer[i];
-    }
-    double avgDt = sum / count;
-    return avgDt > 0.0 ? 1.0 / avgDt : 0.0;
-}
+// Non-inline: Host/Guest share the same state on Windows hot-reload
+double getElapsedTime();
+uint64_t getUpdateCount();
+uint64_t getDrawCount();
+uint64_t getFrameCount();
+double getDeltaTime();
+double getFrameRate();
 
 // ---------------------------------------------------------------------------
 // Sokol memory tracking

--- a/core/include/tc/animation/tcTween.h
+++ b/core/include/tc/animation/tcTween.h
@@ -10,7 +10,7 @@
 namespace trussc {
 
 // Forward declaration
-inline double getDeltaTime();
+double getDeltaTime();
 
 // Tween class for animating values with easing
 // Works with any type that supports lerp (float, Vec2, Vec3, Vec4, Color, etc.)

--- a/core/include/tc/app/tcGlobal.cpp
+++ b/core/include/tc/app/tcGlobal.cpp
@@ -458,4 +458,72 @@ void resumeSwapchainPass() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Non-inline singletons / accessors (Hot Reload: Host/Guest share state)
+// ---------------------------------------------------------------------------
+
+CoreEvents& events() {
+    static CoreEvents instance;
+    return instance;
+}
+
+double getElapsedTime() {
+    auto now = std::chrono::high_resolution_clock::now();
+    if (!internal::startTimeInitialized) {
+        internal::startTime = now;
+        internal::startTimeInitialized = true;
+        return 0.0;
+    }
+    auto duration = std::chrono::duration<double>(now - internal::startTime);
+    return duration.count();
+}
+
+uint64_t getUpdateCount() {
+    return internal::updateFrameCount;
+}
+
+uint64_t getDrawCount() {
+    return sapp_frame_count();
+}
+
+uint64_t getFrameCount() {
+    return internal::updateFrameCount;
+}
+
+double getDeltaTime() {
+    return internal::updateDeltaTime;
+}
+
+double getFrameRate() {
+    double dt = internal::updateDeltaTime;
+    if (dt <= 0.0) return 0.0;
+    internal::frameTimeBuffer[internal::frameTimeIndex] = dt;
+    internal::frameTimeIndex = (internal::frameTimeIndex + 1) % 10;
+    if (internal::frameTimeIndex == 0) {
+        internal::frameTimeBufferFilled = true;
+    }
+
+    int count = internal::frameTimeBufferFilled ? 10 : internal::frameTimeIndex;
+    if (count == 0) return 0.0;
+
+    double sum = 0.0;
+    for (int i = 0; i < count; i++) {
+        sum += internal::frameTimeBuffer[i];
+    }
+    double avgDt = sum / count;
+    return avgDt > 0.0 ? 1.0 / avgDt : 0.0;
+}
+
+namespace internal {
+ElapsedTimeClock& getElapsedClock() {
+    static ElapsedTimeClock clock;
+    return clock;
+}
+} // namespace internal
+
+Logger& tcGetLogger() {
+    static Logger logger;
+    return logger;
+}
+
 } // namespace trussc

--- a/core/include/tc/app/tcGlobal.cpp
+++ b/core/include/tc/app/tcGlobal.cpp
@@ -1,6 +1,23 @@
 // =============================================================================
 // tcGlobal.cpp - TrussC Global Functions Implementation
-// Large functions moved from TrussC.h for better compile times
+//
+// Two kinds of definitions live here:
+//
+//   1. Large lifecycle / frame-management functions moved out of TrussC.h
+//      to keep header compile times down (setup, cleanup, present, clear,
+//      swapchain pass helpers, ...).
+//
+//   2. Singletons and accessors that MUST be non-inline so Host (EXE) and
+//      Guest (DLL) share a single instance during hot reload on Windows.
+//      `inline` functions with static locals create per-module instances
+//      under MSVC's per-DLL symbol namespace — splitting events(),
+//      getDefaultContext(), timers, the logger, etc. between modules
+//      causes silent breakage (drawRectRounded white, tweens frozen, no
+//      logs in guest, ...). Moving the definition into this .cpp keeps
+//      one canonical instance shared via the host's exported symbols.
+//
+// When adding a new global singleton accessor, prefer defining it here
+// (or in a sibling .cpp) rather than inline in a header.
 // =============================================================================
 
 #include <TrussC.h>

--- a/core/include/tc/app/tcHotReloadHost.h
+++ b/core/include/tc/app/tcHotReloadHost.h
@@ -293,7 +293,7 @@ struct Host {
 
         // Detect the build directory — try preset-style names first, fall back to build/
 #ifdef __APPLE__
-        const char* presetDirs[] = {"build-macos", "build"};
+        const char* presetDirs[] = {"build-macos", "xcode", "build"};
 #elif defined(_WIN32)
         const char* presetDirs[] = {"build-windows", "build"};
 #else
@@ -317,23 +317,38 @@ struct Host {
             return false;
         }
 
-        // Guest library path
-        // Ninja: buildDir直下に出力。VS generator: Release/等のサブディレクトリ。
+        // Guest library path: search known locations for the built dylib.
+        // Single-config (Ninja/Make): buildDir直下。
+        // Multi-config (Xcode/VS): <config>/ サブディレクトリ。
+        // Files are searched in priority order; whichever exists wins.
 #ifdef __APPLE__
-        guestLibPath = buildDir + "/libguest.dylib";
+        const string guestName = "libguest.dylib";
 #elif defined(_WIN32)
-        // Ninja (CMakePresets.json) ではサブディレクトリなし。
-        // Visual Studio multi-config generator は Release/ や Debug/ を作る。
-        if (fs::exists(buildDir + "/guest.dll")) {
-            guestLibPath = buildDir + "/guest.dll";
-        } else if (fs::exists(buildDir + "/Debug/guest.dll")) {
-            guestLibPath = buildDir + "/Debug/guest.dll";
-        } else {
-            guestLibPath = buildDir + "/Release/guest.dll";
-        }
+        const string guestName = "guest.dll";
 #else
-        guestLibPath = buildDir + "/libguest.so";
+        const string guestName = "libguest.so";
 #endif
+        const char* configs[] = {"Debug", "Release", "RelWithDebInfo", "MinSizeRel"};
+        guestLibPath = "";
+        if (fs::exists(buildDir + "/" + guestName)) {
+            guestLibPath = buildDir + "/" + guestName;
+        } else {
+            for (const char* c : configs) {
+                string candidate = buildDir + "/" + c + "/" + guestName;
+                if (fs::exists(candidate)) { guestLibPath = candidate; break; }
+            }
+        }
+        // Nothing yet — the initial rebuildGuest() below will create it. Pick
+        // a sensible default destination so the post-rebuild load() finds it.
+        // If any config subdir exists, we're in a multi-config tree → Debug/.
+        if (guestLibPath.empty()) {
+            bool multiConfig = false;
+            for (const char* c : configs) {
+                if (fs::exists(buildDir + "/" + c)) { multiConfig = true; break; }
+            }
+            guestLibPath = multiConfig ? (buildDir + "/Debug/" + guestName)
+                                       : (buildDir + "/" + guestName);
+        }
 
         // Initial build of the Guest
         if (!rebuildGuest()) {
@@ -368,6 +383,9 @@ struct Host {
         // Only rebuild the guest target — fast incremental build.
         // argv is passed directly to posix_spawnp / _spawnvp — no shell
         // is involved, so $(...), ``, ; etc. in buildDir cannot run.
+        // For multi-config generators (Xcode, Visual Studio), cmake picks the
+        // generator's default config (Debug) when --config is omitted — which
+        // matches the layout the rest of init() expects (Debug/libguest.dylib).
         int rc = runBuildCommand({cmake, "--build", buildDir,
                                   "--target", "guest", "--parallel"});
         if (rc != 0) {

--- a/core/include/tc/app/tcHotReloadHost.h
+++ b/core/include/tc/app/tcHotReloadHost.h
@@ -57,7 +57,7 @@ struct GuestLibrary {
 #endif
     CreateAppFn createApp = nullptr;
     DestroyAppFn destroyApp = nullptr;
-    App* app = nullptr;
+    std::shared_ptr<App> app;
     string loadedPath;  // actual path loaded (may be a temp copy on Windows)
 
     bool load(const string& path) {
@@ -120,17 +120,18 @@ struct GuestLibrary {
 
     App* create() {
         if (createApp) {
-            app = createApp();
-            return app;
+            App* raw = createApp();
+            auto deleter = destroyApp;
+            app = std::shared_ptr<App>(raw, [deleter](App* p) {
+                if (deleter) deleter(p);
+            });
+            return raw;
         }
         return nullptr;
     }
 
     void destroy() {
-        if (app && destroyApp) {
-            destroyApp(app);
-            app = nullptr;
-        }
+        app.reset();
     }
 
     void unload() {
@@ -450,7 +451,7 @@ struct Host {
         }
     }
 
-    App* getApp() { return guest.app; }
+    App* getApp() { return guest.app.get(); }
 };
 
 // ---------------------------------------------------------------------------

--- a/core/include/tc/app/tcHotReloadHost.h
+++ b/core/include/tc/app/tcHotReloadHost.h
@@ -25,6 +25,7 @@
 extern char** environ;
 #endif
 #include <filesystem>
+#include <fstream>
 #include <chrono>
 #include <string>
 #include <vector>
@@ -37,6 +38,7 @@ namespace hot_reload {
 namespace fs = std::filesystem;
 using std::string;
 using std::vector;
+using std::ifstream;
 using std::cout;
 using std::cerr;
 using Clock = std::chrono::steady_clock;
@@ -200,7 +202,23 @@ struct FileWatcher {
 // Find cmake binary (same logic as trusscli)
 // ---------------------------------------------------------------------------
 
-inline string findCMake() {
+inline string findCMake(const string& buildDir = "") {
+    // Prefer the cmake that originally configured this build directory.
+    // On Windows, PATH may resolve to an older VS cmake that doesn't
+    // know the generator used by the current build (e.g. "Visual Studio 18 2026").
+    if (!buildDir.empty()) {
+        string cachePath = buildDir + "/CMakeCache.txt";
+        if (fs::exists(cachePath)) {
+            ifstream cache(cachePath);
+            string line;
+            while (getline(cache, line)) {
+                if (line.rfind("CMAKE_COMMAND:INTERNAL=", 0) == 0) {
+                    string path = line.substr(23);
+                    if (fs::exists(path)) return path;
+                }
+            }
+        }
+    }
 #ifdef __APPLE__
     const char* paths[] = {
         "/opt/homebrew/bin/cmake",
@@ -230,11 +248,36 @@ inline int runBuildCommand(const vector<string>& argv) {
     if (argv.empty()) return -1;
 
 #ifdef _WIN32
-    vector<const char*> cargv;
-    cargv.reserve(argv.size() + 1);
-    for (const auto& a : argv) cargv.push_back(a.c_str());
-    cargv.push_back(nullptr);
-    return (int)_spawnvp(_P_WAIT, cargv[0], cargv.data());
+    // Build a quoted command line for CreateProcess.
+    // _spawnvp can mangle argv when the executable path contains spaces.
+    string cmdLine;
+    for (size_t i = 0; i < argv.size(); i++) {
+        if (i > 0) cmdLine += ' ';
+        bool needsQuote = argv[i].find(' ') != string::npos;
+        if (needsQuote) cmdLine += '"';
+        cmdLine += argv[i];
+        if (needsQuote) cmdLine += '"';
+    }
+    STARTUPINFOA si = {};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput  = GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+    si.hStdError  = GetStdHandle(STD_ERROR_HANDLE);
+    PROCESS_INFORMATION pi = {};
+    vector<char> buf(cmdLine.begin(), cmdLine.end());
+    buf.push_back('\0');
+    if (!CreateProcessA(argv[0].c_str(), buf.data(),
+                        nullptr, nullptr, TRUE, 0, nullptr, nullptr, &si, &pi)) {
+        cerr << "[HotReload] Failed to launch: " << argv[0] << "\n";
+        return -1;
+    }
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD exitCode = 1;
+    GetExitCodeProcess(pi.hProcess, &exitCode);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return (int)exitCode;
 #else
     vector<char*> cargv;
     cargv.reserve(argv.size() + 1);
@@ -295,7 +338,7 @@ struct Host {
 #ifdef __APPLE__
         const char* presetDirs[] = {"build-macos", "xcode", "build"};
 #elif defined(_WIN32)
-        const char* presetDirs[] = {"build-windows", "build"};
+        const char* presetDirs[] = {"build-windows", "vs", "build"};
 #else
         const char* presetDirs[] = {"build-linux", "build"};
 #endif
@@ -377,7 +420,7 @@ struct Host {
     }
 
     bool rebuildGuest() {
-        string cmake = findCMake();
+        string cmake = findCMake(buildDir);
         logNotice("HotReload") << "Rebuilding guest...";
 
         // Only rebuild the guest target — fast incremental build.

--- a/core/include/tc/events/tcCoreEvents.h
+++ b/core/include/tc/events/tcCoreEvents.h
@@ -55,11 +55,8 @@ public:
 };
 
 // ---------------------------------------------------------------------------
-// Global accessor
+// Global accessor (non-inline: Host/Guest share the same instance on Windows)
 // ---------------------------------------------------------------------------
-inline CoreEvents& events() {
-    static CoreEvents instance;
-    return instance;
-}
+CoreEvents& events();
 
 } // namespace trussc

--- a/core/include/tc/graphics/tcRenderContext.cpp
+++ b/core/include/tc/graphics/tcRenderContext.cpp
@@ -447,4 +447,12 @@ void RenderContext::drawBitmapString(const std::string& text, float x, float y,
     }
 }
 
+// ---------------------------------------------------------------------------
+// Default context singleton (non-inline — see tcRenderContext.h comment)
+// ---------------------------------------------------------------------------
+RenderContext& getDefaultContext() {
+    static RenderContext instance;
+    return instance;
+}
+
 } // namespace trussc

--- a/core/include/tc/graphics/tcRenderContext.h
+++ b/core/include/tc/graphics/tcRenderContext.h
@@ -947,10 +947,9 @@ private:
 
 // ---------------------------------------------------------------------------
 // Default context (singleton)
+// Non-inline so that Host and Guest (hot-reload DLL) share the same
+// static instance — inline would give each module its own copy on Windows.
 // ---------------------------------------------------------------------------
-inline RenderContext& getDefaultContext() {
-    static RenderContext instance;
-    return instance;
-}
+RenderContext& getDefaultContext();
 
 } // namespace trussc

--- a/core/include/tc/sound/tcSound_impl.cpp
+++ b/core/include/tc/sound/tcSound_impl.cpp
@@ -22,10 +22,14 @@
 // build stays clean. Keep the suppression as tight as possible around just
 // the third-party include.
 extern "C" {
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
 #include "stb_vorbis.c"
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 }
 
 // miniaudio is included for ma_decoder. The implementation itself lives in

--- a/core/include/tc/utils/tcLog.h
+++ b/core/include/tc/utils/tcLog.h
@@ -200,10 +200,8 @@ private:
 // ---------------------------------------------------------------------------
 // Global logger
 // ---------------------------------------------------------------------------
-inline Logger& tcGetLogger() {
-    static Logger logger;
-    return logger;
-}
+// Non-inline: Host/Guest share the same logger on Windows hot-reload
+Logger& tcGetLogger();
 
 // ---------------------------------------------------------------------------
 // Convenience functions

--- a/core/include/tc/utils/tcTime.h
+++ b/core/include/tc/utils/tcTime.h
@@ -51,10 +51,8 @@ private:
     std::chrono::steady_clock::time_point startTime_;
 };
 
-inline ElapsedTimeClock& getElapsedClock() {
-    static ElapsedTimeClock clock;
-    return clock;
-}
+// Non-inline: Host/Guest share the same clock on Windows hot-reload
+ElapsedTimeClock& getElapsedClock();
 
 // String replacement (for getTimestampString)
 inline void stringReplace(std::string& input, const std::string& searchStr, const std::string& replaceStr) {

--- a/tools/src/ProjectGenerator.cpp
+++ b/tools/src/ProjectGenerator.cpp
@@ -857,10 +857,18 @@ void ProjectGenerator::generateVisualStudioProject(const string& path) {
         }
     }
 
+    // Pass TRUSSC_DIR so cmake finds core/ even when the project lives
+    // outside the TrussC repo tree (the CMakeLists.txt fallback is relative)
+    string trusscDir = getTrusscDirValue(path);
+    string trusscDirArg;
+    if (!trusscDir.empty()) {
+        trusscDirArg = " -DTRUSSC_DIR=\"" + trusscDir + "\"";
+    }
+
 #ifdef _WIN32
-    string cmd = "cd /d \"" + vsPath + "\" && " + cmakeBin + " -G \"" + generator + "\" ..";
+    string cmd = "cd /d \"" + vsPath + "\" && " + cmakeBin + " -G \"" + generator + "\"" + trusscDirArg + " ..";
 #else
-    string cmd = "cd \"" + vsPath + "\" && " + getCmakePath() + " -G \"" + generator + "\" ..";
+    string cmd = "cd \"" + vsPath + "\" && " + getCmakePath() + " -G \"" + generator + "\"" + trusscDirArg + " ..";
 #endif
     log("Running: " + cmakeBin + " -G \"" + generator + "\"");
 

--- a/tools/src/ProjectGenerator.cpp
+++ b/tools/src/ProjectGenerator.cpp
@@ -307,17 +307,12 @@ void ProjectGenerator::writeCMakePresets(const string& destPath) {
     macosBuildPreset["jobs"] = 4;
     presets["buildPresets"].push_back(macosBuildPreset);
 
-    // Xcode preset
-    Json xcodePreset;
-    xcodePreset["name"] = "xcode";
-    xcodePreset["displayName"] = "Xcode";
-    xcodePreset["binaryDir"] = "${sourceDir}/xcode";
-    xcodePreset["generator"] = "Xcode";
-    xcodePreset["cacheVariables"]["CMAKE_OSX_DEPLOYMENT_TARGET"] = "14.0";
-    if (!trusscDir.empty()) {
-        xcodePreset["cacheVariables"]["TRUSSC_DIR"] = trusscDir;
-    }
-    presets["configurePresets"].push_back(xcodePreset);
+    // NOTE: Xcode project is generated via direct `cmake -G Xcode` invocation
+    // (see generateXcodeProject), not through a preset. This keeps macOS users
+    // with only one configurePreset ("macos"), so VSCode/Cursor's CMake Tools
+    // auto-selects it instead of showing a "macos vs xcode" quick pick on
+    // every workspace open. Same pattern as the Visual Studio generator on
+    // Windows — both are IDE project generators driven by trusscli directly.
 
 #elif defined(_WIN32)
     // Windows preset with ninja path and environment
@@ -809,8 +804,21 @@ void ProjectGenerator::generateXcodeProject(const string& path) {
         fs::remove_all(xcodePath);
     }
 
-    string cmd = "cd \"" + path + "\" && " + getCmakePath() + " --preset xcode";
-    log("Running: cmake --preset xcode");
+    // Pass TRUSSC_DIR so cmake finds core/ when the project lives outside the
+    // TrussC repo tree (the CMakeLists.txt fallback is relative). Mirrors the
+    // VS generator path — same reasoning, same code shape.
+    string trusscDir = getTrusscDirValue(path);
+    string trusscDirArg;
+    if (!trusscDir.empty()) {
+        trusscDirArg = " -DTRUSSC_DIR=\"" + trusscDir + "\"";
+    }
+
+    // Direct -G Xcode invocation (no preset). See writeCMakePresets() for why
+    // we don't emit an "xcode" preset on macOS.
+    string cmd = "cd \"" + path + "\" && " + getCmakePath()
+        + " -G Xcode -B xcode -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0"
+        + trusscDirArg;
+    log("Running: cmake -G Xcode -B xcode");
 
     auto [result, output] = executeCommand(cmd);
     if (!output.empty()) {


### PR DESCRIPTION
## Summary

- Root-cause fixes that make hot reload actually work on Windows when launched from Visual Studio
- Hot reload now works on macOS when the project is generated with the Xcode generator
- Side benefit: CMake Tools no longer shows a "Select Configure Preset" quick pick on every workspace open on macOS

## Main changes

- **`2bc3168`** Move singleton accessors to non-inline (`.cpp`) so Host (EXE) and Guest (DLL) share one instance under MSVC's per-DLL symbol namespace. Without this, `getDefaultContext`, `events`, `tcGetLogger`, and the timer accessors got duplicated across modules, causing `drawRectRounded` to render white, tweens to freeze, logging to vanish from the guest, and `getDeltaTime()` to stay at 0.
- **`d7d884c`** Wrap the hot-reload `App` in a `std::shared_ptr` with a custom deleter so `enable_shared_from_this` is initialized properly. Without this, `Node::addChild()` asserted on an expired `weak_from_this()`. macOS hid the bug because `RelWithDebInfo`'s `-DNDEBUG` no-op'd the assert and the silent fallout (always-null `getParent()`) only surfaces when user code actually walks the parent pointer.
- **`0edb76a`** Make the hot-reload host succeed at rebuilding the guest when the project was opened from Visual Studio: add `"vs"` to the build-dir search list, read `CMAKE_COMMAND` out of `CMakeCache.txt` (so we don't pick up an older PATH cmake that doesn't know the current VS generator), and use `CreateProcessA` instead of `_spawnvp` to tolerate spaces in the cmake path.
- **`f6fbe68`** Make hot reload usable from the Xcode generator on macOS: add `"xcode"` to the build-dir search list, locate the guest dylib under the multi-config `Debug/Release/...` subdirs, and add an explicit `add_dependencies(host guest)` on Mac/Linux (the IDE-driven host build would otherwise skip the guest target since it isn't linked from the host on those platforms).
- **`8c10081`** Drop the `"xcode"` configurePreset from CMakePresets.json on macOS and call `cmake -G Xcode -B xcode` directly from `generateXcodeProject()`, mirroring the pattern the Visual Studio generator already uses. This leaves a single configurePreset on macOS so CMake Tools auto-selects it instead of prompting on every workspace open.
- **`5ada925` / `f4b6bd7`** trusscli VS project generation no longer fails when `TRUSSC_DIR` isn't set explicitly; quiet a couple of cosmetic MSVC warnings (D9025, C4068).
- **`96fdf15`** Documentation comment on `tcGlobal.cpp` explaining its expanded role (lifecycle functions + the new non-inline singleton convergence point).

## Test plan

- [x] macOS: Ninja preset + Xcode generator, hot reload init + live reload (workshop `4-nodeSystem` and `3-tween`)
- [x] Windows: hot reload + `drawRectRounded` colour verified locally
- [x] Linux: verify on real hardware