### PR TITLE
Linux hot reload: prevent STB_GNU_UNIQUE singletons from surviving dlclose

### DIFF
--- a/core/cmake/trussc_app.cmake
+++ b/core/cmake/trussc_app.cmake
@@ -306,6 +306,20 @@ endif()
         # parsing each guest .cpp (~2s for ~2700 lines), so caching it once
         # per build dramatically shortens reload turnaround.
         target_precompile_headers(guest PRIVATE <TrussC.h>)
+        # Linux/GCC: disable STB_GNU_UNIQUE bindings for the Guest. GCC's
+        # default -fgnu-unique-symbols marks Meyer's singletons (inline
+        # function static locals like `static Foo& instance(){ static Foo f; }`)
+        # as STB_GNU_UNIQUE, which glibc's loader treats as unloadable —
+        # dlclose() does not destroy them and a subsequent dlopen() reuses
+        # the same memory. On hot reload this leaves stale, "already
+        # initialized" state behind in the new Guest, e.g. tcxImGui's
+        # ImGuiManager singleton keeps initialized_=true so simgui_setup()
+        # short-circuits and ImGui::CreateContext() never runs — the next
+        # ImGui::GetIO() then dereferences a NULL GImGui and crashes.
+        # macOS/Windows use different binding rules and aren't affected.
+        if(NOT APPLE AND NOT WIN32)
+            target_compile_options(guest PRIVATE -fno-gnu-unique)
+        endif()
         # Guest: resolve TrussC symbols at runtime from the Host process.
         # macOS/Linux use flat namespace lookup; Windows uses import library.
         if(APPLE)


### PR DESCRIPTION
## Summary

GCC's default `-fgnu-unique-symbols` marks Meyer's singletons (function-local `static`) as `STB_GNU_UNIQUE`. glibc's dynamic loader treats those symbols as **unloadable** — `dlclose()` doesn't destroy them, and the next `dlopen()` reuses the same memory. On hot reload this leaves stale "already initialized" state inside the new Guest, breaking any addon that holds a singleton.

Concrete impact: tcxImGui's `ImGuiManager::initialized_` stayed `true` across reloads → `simgui_setup()` short-circuited → `ImGui::CreateContext()` was never called → the next `ImGui::GetIO()` dereferenced a NULL `GImGui` and crashed at offset 0xd2 in `simgui_new_frame`.

## Fix

Pass `-fno-gnu-unique` to the Guest target on Linux. Static locals become regular weak symbols, `dlclose()` actually unloads them, and every reload starts from a clean slate.

macOS (Clang) and Windows (MSVC) use different binding rules and aren't affected, so the flag is gated `if(NOT APPLE AND NOT WIN32)`.

## Why it matters beyond tcxImGui

Any addon that uses a Meyer's singleton (audio engine, OSC socket pool, future stateful addons) hit the same trap on Linux hot reload. This one-line CMake change immunizes the whole pattern.

## Test plan

- [x] Linux: tcxImGui hot reload no longer crashes across reload cycles
- [ ] macOS / Windows: confirm unaffected (flag is gated, no impact expected)