### PR TITLE
Merge dev → main: tcxLua CI fix (bindgen restoration + init overload)

### DIFF
--- a/addons/tcxLua/src/generated/trussc_generated.cpp
+++ b/addons/tcxLua/src/generated/trussc_generated.cpp
@@ -71,48 +71,48 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua){
     lua->set_function("randomSeed", [](unsigned int seed){  trussc::randomSeed(seed); });
     // tcLog.h, LINE 35
     lua->set_function("logLevelToString", [](LogLevel level){ return trussc::logLevelToString(level); });
-    // tcLog.h, LINE 211
+    // tcLog.h, LINE 209
     lua->set_function("tcSetConsoleLogLevel", [](LogLevel level){  trussc::tcSetConsoleLogLevel(level); });
-    // tcLog.h, LINE 215
+    // tcLog.h, LINE 213
     lua->set_function("tcSetFileLogLevel", [](LogLevel level){  trussc::tcSetFileLogLevel(level); });
-    // tcLog.h, LINE 219
+    // tcLog.h, LINE 217
     lua->set_function("tcSetLogFile", [](const std::string & path){ return trussc::tcSetLogFile(path); });
-    // tcLog.h, LINE 223
+    // tcLog.h, LINE 221
     lua->set_function("tcCloseLogFile", [](){  trussc::tcCloseLogFile(); });
-    // tcLog.h, LINE 284
+    // tcLog.h, LINE 282
     lua->set_function("tcLog", [](LogLevel level){ return trussc::tcLog(level); });
-    // tcLog.h, LINE 288
+    // tcLog.h, LINE 286
     lua->set_function("logVerbose", [](const std::string & module){ return trussc::logVerbose(module); });
-    // tcLog.h, LINE 292
+    // tcLog.h, LINE 290
     lua->set_function("logNotice", [](const std::string & module){ return trussc::logNotice(module); });
-    // tcLog.h, LINE 296
+    // tcLog.h, LINE 294
     lua->set_function("logWarning", [](const std::string & module){ return trussc::logWarning(module); });
-    // tcLog.h, LINE 300
+    // tcLog.h, LINE 298
     lua->set_function("logError", [](const std::string & module){ return trussc::logError(module); });
-    // tcLog.h, LINE 304
+    // tcLog.h, LINE 302
     lua->set_function("logFatal", [](const std::string & module){ return trussc::logFatal(module); });
-    // tcLog.h, LINE 311
+    // tcLog.h, LINE 309
     lua->set_function("tcLogVerbose", [](const std::string & module){ return trussc::tcLogVerbose(module); });
-    // tcLog.h, LINE 312
+    // tcLog.h, LINE 310
     lua->set_function("tcLogNotice", [](const std::string & module){ return trussc::tcLogNotice(module); });
-    // tcLog.h, LINE 313
+    // tcLog.h, LINE 311
     lua->set_function("tcLogWarning", [](const std::string & module){ return trussc::tcLogWarning(module); });
-    // tcLog.h, LINE 314
+    // tcLog.h, LINE 312
     lua->set_function("tcLogError", [](const std::string & module){ return trussc::tcLogError(module); });
-    // tcLog.h, LINE 315
+    // tcLog.h, LINE 313
     lua->set_function("tcLogFatal", [](const std::string & module){ return trussc::tcLogFatal(module); });
-    // TrussC.h, LINE 343
+    // TrussC.h, LINE 351
     lua->set_function("getDpiScale", [](){ return trussc::getDpiScale(); });
-    // TrussC.h, LINE 348
+    // TrussC.h, LINE 356
     lua->set_function("getFramebufferWidth", [](){ return trussc::getFramebufferWidth(); });
-    // TrussC.h, LINE 352
+    // TrussC.h, LINE 360
     lua->set_function("getFramebufferHeight", [](){ return trussc::getFramebufferHeight(); });
-    // TrussC.h, LINE 363
+    // TrussC.h, LINE 371
     lua->set_function("beginFrame", [](){  trussc::beginFrame(); });
-    // TrussC.h, LINE 379
-    // TrussC.h, LINE 382
     // TrussC.h, LINE 387
-    // TrussC.h, LINE 392
+    // TrussC.h, LINE 390
+    // TrussC.h, LINE 395
+    // TrussC.h, LINE 400
     lua->set_function("clear", sol::overload(
         [](float r, float g, float b, float a){  trussc::clear(r, g, b, a); },
         [](){  trussc::clear(); },
@@ -123,21 +123,21 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua){
         // NOTE: additional overloads provided by user,
         [](float r, float g, float b){  trussc::clear(r, g, b); }
     ));
-    // TrussC.h, LINE 397
+    // TrussC.h, LINE 405
     lua->set_function("flushDeferredShaderDraws", [](){  trussc::flushDeferredShaderDraws(); });
-    // TrussC.h, LINE 404
+    // TrussC.h, LINE 412
     lua->set_function("ensureSwapchainPass", [](){  trussc::ensureSwapchainPass(); });
-    // TrussC.h, LINE 407
+    // TrussC.h, LINE 415
     lua->set_function("present", [](){  trussc::present(); });
-    // TrussC.h, LINE 410
+    // TrussC.h, LINE 418
     lua->set_function("isInSwapchainPass", [](){ return trussc::isInSwapchainPass(); });
-    // TrussC.h, LINE 413
+    // TrussC.h, LINE 421
     lua->set_function("suspendSwapchainPass", [](){  trussc::suspendSwapchainPass(); });
-    // TrussC.h, LINE 416
+    // TrussC.h, LINE 424
     lua->set_function("resumeSwapchainPass", [](){  trussc::resumeSwapchainPass(); });
-    // TrussC.h, LINE 423
-    // TrussC.h, LINE 428
-    // TrussC.h, LINE 433
+    // TrussC.h, LINE 431
+    // TrussC.h, LINE 436
+    // TrussC.h, LINE 441
     lua->set_function("setColor", sol::overload(
         [](float r, float g, float b, float a){  trussc::setColor(r, g, b, a); },
         [](float gray, float a){  trussc::setColor(gray, a); },
@@ -147,212 +147,254 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua){
         // NOTE: additional overloads provided by user,
         [](float r, float g, float b){  trussc::setColor(r, g, b); }
     ));
-    // TrussC.h, LINE 438
+    // TrussC.h, LINE 446
     lua->set_function("getColor", [](){ return trussc::getColor(); });
-    // TrussC.h, LINE 443
+    // TrussC.h, LINE 451
     lua->set_function("setColorHSB", sol::overload(
         [](float h, float s, float b, float a){  trussc::setColorHSB(h, s, b, a); },
         // NOTE: additional overloads provided by user,
         [](float h, float s, float b){  trussc::setColorHSB(h, s, b); }
     ));
-    // TrussC.h, LINE 448
+    // TrussC.h, LINE 456
     lua->set_function("setColorOKLab", [](float L, float a_lab, float b_lab, float alpha){  trussc::setColorOKLab(L, a_lab, b_lab, alpha); });
-    // TrussC.h, LINE 453
+    // TrussC.h, LINE 461
     lua->set_function("setColorOKLCH", [](float L, float C, float H, float alpha){  trussc::setColorOKLCH(L, C, H, alpha); });
-    // TrussC.h, LINE 458
+    // TrussC.h, LINE 466
     lua->set_function("fill", [](){  trussc::fill(); });
-    // TrussC.h, LINE 463
+    // TrussC.h, LINE 471
     lua->set_function("noFill", [](){  trussc::noFill(); });
-    // TrussC.h, LINE 468
-    lua->set_function("setStrokeWeight", [](float weight){  trussc::setStrokeWeight(weight); });
-    // TrussC.h, LINE 472
-    lua->set_function("getStrokeWeight", [](){ return trussc::getStrokeWeight(); });
     // TrussC.h, LINE 476
-    lua->set_function("setStrokeCap", [](StrokeCap cap){  trussc::setStrokeCap(cap); });
+    lua->set_function("setStrokeWeight", [](float weight){  trussc::setStrokeWeight(weight); });
     // TrussC.h, LINE 480
-    lua->set_function("getStrokeCap", [](){ return trussc::getStrokeCap(); });
+    lua->set_function("getStrokeWeight", [](){ return trussc::getStrokeWeight(); });
     // TrussC.h, LINE 484
-    lua->set_function("setStrokeJoin", [](StrokeJoin join){  trussc::setStrokeJoin(join); });
+    lua->set_function("setStrokeCap", [](StrokeCap cap){  trussc::setStrokeCap(cap); });
     // TrussC.h, LINE 488
+    lua->set_function("getStrokeCap", [](){ return trussc::getStrokeCap(); });
+    // TrussC.h, LINE 492
+    lua->set_function("setStrokeJoin", [](StrokeJoin join){  trussc::setStrokeJoin(join); });
+    // TrussC.h, LINE 496
     lua->set_function("getStrokeJoin", [](){ return trussc::getStrokeJoin(); });
-    // TrussC.h, LINE 511
-    // TrussC.h, LINE 517
+    // TrussC.h, LINE 519
+    // TrussC.h, LINE 525
     lua->set_function("setScissor", sol::overload(
         [](float x, float y, float w, float h){  trussc::setScissor(x, y, w, h); },
         [](int x, int y, int w, int h){  trussc::setScissor(x, y, w, h); }
     ));
-    // TrussC.h, LINE 522
+    // TrussC.h, LINE 530
     lua->set_function("resetScissor", [](){  trussc::resetScissor(); });
-    // TrussC.h, LINE 528
+    // TrussC.h, LINE 536
     lua->set_function("pushScissor", [](float x, float y, float w, float h){  trussc::pushScissor(x, y, w, h); });
-    // TrussC.h, LINE 546
+    // TrussC.h, LINE 554
     lua->set_function("popScissor", [](){  trussc::popScissor(); });
-    // TrussC.h, LINE 568
+    // TrussC.h, LINE 576
     lua->set_function("pushMatrix", [](){  trussc::pushMatrix(); });
-    // TrussC.h, LINE 573
+    // TrussC.h, LINE 581
     lua->set_function("popMatrix", [](){  trussc::popMatrix(); });
-    // TrussC.h, LINE 578
+    // TrussC.h, LINE 586
     lua->set_function("pushStyle", [](){  trussc::pushStyle(); });
-    // TrussC.h, LINE 583
+    // TrussC.h, LINE 591
     lua->set_function("popStyle", [](){  trussc::popStyle(); });
-    // TrussC.h, LINE 588
+    // TrussC.h, LINE 596
     lua->set_function("resetStyle", [](){  trussc::resetStyle(); });
-    // TrussC.h, LINE 593
-    // TrussC.h, LINE 597
     // TrussC.h, LINE 601
+    // TrussC.h, LINE 605
+    // TrussC.h, LINE 609
     lua->set_function("translate", sol::overload(
         [](Vec3 pos){  trussc::translate(pos); },
         [](float x, float y, float z){  trussc::translate(x, y, z); },
         [](float x, float y){  trussc::translate(x, y); }
     ));
-    // TrussC.h, LINE 606
-    // TrussC.h, LINE 643
-    // TrussC.h, LINE 649
-    // TrussC.h, LINE 653
+    // TrussC.h, LINE 614
+    // TrussC.h, LINE 651
+    // TrussC.h, LINE 657
+    // TrussC.h, LINE 661
     lua->set_function("rotate", sol::overload(
         [](float radians){  trussc::rotate(radians); },
         [](float x, float y, float z){  trussc::rotate(x, y, z); },
         [](const Vec3 & euler){  trussc::rotate(euler); },
         [](const Quaternion & quat){  trussc::rotate(quat); }
     ));
-    // TrussC.h, LINE 611
+    // TrussC.h, LINE 619
     lua->set_function("rotateX", [](float radians){  trussc::rotateX(radians); });
-    // TrussC.h, LINE 616
+    // TrussC.h, LINE 624
     lua->set_function("rotateY", [](float radians){  trussc::rotateY(radians); });
-    // TrussC.h, LINE 621
+    // TrussC.h, LINE 629
     lua->set_function("rotateZ", [](float radians){  trussc::rotateZ(radians); });
-    // TrussC.h, LINE 626
-    // TrussC.h, LINE 658
-    // TrussC.h, LINE 664
+    // TrussC.h, LINE 634
+    // TrussC.h, LINE 666
+    // TrussC.h, LINE 672
     lua->set_function("rotateDeg", sol::overload(
         [](float degrees){  trussc::rotateDeg(degrees); },
         [](float x, float y, float z){  trussc::rotateDeg(x, y, z); },
         [](const Vec3 & euler){  trussc::rotateDeg(euler); }
     ));
-    // TrussC.h, LINE 630
-    lua->set_function("rotateXDeg", [](float degrees){  trussc::rotateXDeg(degrees); });
-    // TrussC.h, LINE 634
-    lua->set_function("rotateYDeg", [](float degrees){  trussc::rotateYDeg(degrees); });
     // TrussC.h, LINE 638
+    lua->set_function("rotateXDeg", [](float degrees){  trussc::rotateXDeg(degrees); });
+    // TrussC.h, LINE 642
+    lua->set_function("rotateYDeg", [](float degrees){  trussc::rotateYDeg(degrees); });
+    // TrussC.h, LINE 646
     lua->set_function("rotateZDeg", [](float degrees){  trussc::rotateZDeg(degrees); });
-    // TrussC.h, LINE 669
-    // TrussC.h, LINE 674
-    // TrussC.h, LINE 679
+    // TrussC.h, LINE 677
+    // TrussC.h, LINE 682
+    // TrussC.h, LINE 687
     lua->set_function("scale", sol::overload(
         [](float s){  trussc::scale(s); },
         [](float sx, float sy){  trussc::scale(sx, sy); },
         [](float sx, float sy, float sz){  trussc::scale(sx, sy, sz); }
     ));
-    // TrussC.h, LINE 684
+    // TrussC.h, LINE 692
     lua->set_function("getCurrentMatrix", [](){ return trussc::getCurrentMatrix(); });
-    // TrussC.h, LINE 689
+    // TrussC.h, LINE 697
     lua->set_function("resetMatrix", [](){  trussc::resetMatrix(); });
-    // TrussC.h, LINE 694
+    // TrussC.h, LINE 702
     lua->set_function("setMatrix", [](const Mat4 & mat){  trussc::setMatrix(mat); });
-    // TrussC.h, LINE 704
+    // TrussC.h, LINE 712
     lua->set_function("setBlendMode", [](BlendMode mode){  trussc::setBlendMode(mode); });
-    // TrussC.h, LINE 713
+    // TrussC.h, LINE 721
     lua->set_function("getBlendMode", [](){ return trussc::getBlendMode(); });
-    // TrussC.h, LINE 718
+    // TrussC.h, LINE 726
     lua->set_function("resetBlendMode", [](){  trussc::resetBlendMode(); });
-    // TrussC.h, LINE 723
+    // TrussC.h, LINE 731
     lua->set_function("restoreBlendPipeline", [](){  trussc::restoreBlendPipeline(); });
-    // TrussC.h, LINE 736
+    // TrussC.h, LINE 744
     lua->set_function("enable3D", [](){  trussc::enable3D(); });
-    // TrussC.h, LINE 745
+    // TrussC.h, LINE 753
     lua->set_function("enable3DPerspective", [](float fovY, float nearZ, float farZ){  trussc::enable3DPerspective(fovY, nearZ, farZ); });
-    // TrussC.h, LINE 866
+    // TrussC.h, LINE 874
     lua->set_function("setupScreenFov", [](float fovDeg, float nearDist, float farDist){  trussc::setupScreenFov(fovDeg, nearDist, farDist); });
-    // TrussC.h, LINE 873
+    // TrussC.h, LINE 881
     lua->set_function("setupScreenPerspective", [](float fovDeg, float nearDist, float farDist){  trussc::setupScreenPerspective(fovDeg, nearDist, farDist); });
-    // TrussC.h, LINE 878
+    // TrussC.h, LINE 886
     lua->set_function("setupScreenOrtho", [](){  trussc::setupScreenOrtho(); });
-    // TrussC.h, LINE 884
+    // TrussC.h, LINE 892
     lua->set_function("setDefaultScreenFov", [](float fovDeg){  trussc::setDefaultScreenFov(fovDeg); });
-    // TrussC.h, LINE 888
+    // TrussC.h, LINE 896
     lua->set_function("getDefaultScreenFov", [](){ return trussc::getDefaultScreenFov(); });
-    // TrussC.h, LINE 893
-    lua->set_function("setNearClip", [](float nearDist){  trussc::setNearClip(nearDist); });
-    // TrussC.h, LINE 897
-    lua->set_function("setFarClip", [](float farDist){  trussc::setFarClip(farDist); });
     // TrussC.h, LINE 901
-    lua->set_function("getNearClip", [](){ return trussc::getNearClip(); });
+    lua->set_function("setNearClip", [](float nearDist){  trussc::setNearClip(nearDist); });
     // TrussC.h, LINE 905
+    lua->set_function("setFarClip", [](float farDist){  trussc::setFarClip(farDist); });
+    // TrussC.h, LINE 909
+    lua->set_function("getNearClip", [](){ return trussc::getNearClip(); });
+    // TrussC.h, LINE 913
     lua->set_function("getFarClip", [](){ return trussc::getFarClip(); });
-    // TrussC.h, LINE 915
+    // TrussC.h, LINE 923
     lua->set_function("worldToScreen", [](const Vec3 & worldPos){ return trussc::worldToScreen(worldPos); });
-    // TrussC.h, LINE 944
+    // TrussC.h, LINE 952
     lua->set_function("screenToWorld", [](const Vec2 & screenPos, float worldZ){ return trussc::screenToWorld(screenPos, worldZ); });
-    // TrussC.h, LINE 990
+    // TrussC.h, LINE 998
     lua->set_function("disable3D", [](){  trussc::disable3D(); });
-    // TrussC.h, LINE 999
-    // TrussC.h, LINE 1003
     // TrussC.h, LINE 1007
+    // TrussC.h, LINE 1011
+    // TrussC.h, LINE 1015
     lua->set_function("drawRect", sol::overload(
         [](Vec3 pos, Vec2 size){  trussc::drawRect(pos, size); },
         [](Vec3 pos, float w, float h){  trussc::drawRect(pos, w, h); },
         [](float x, float y, float w, float h){  trussc::drawRect(x, y, w, h); }
     ));
-    // TrussC.h, LINE 1012
-    // TrussC.h, LINE 1016
+    // TrussC.h, LINE 1020
+    // TrussC.h, LINE 1024
     lua->set_function("drawRectRounded", sol::overload(
         [](Vec3 pos, Vec2 size, float radius){  trussc::drawRectRounded(pos, size, radius); },
         [](float x, float y, float w, float h, float radius){  trussc::drawRectRounded(x, y, w, h, radius); }
     ));
-    // TrussC.h, LINE 1021
-    // TrussC.h, LINE 1025
+    // TrussC.h, LINE 1029
+    // TrussC.h, LINE 1033
     lua->set_function("drawRectSquircle", sol::overload(
         [](Vec3 pos, Vec2 size, float radius){  trussc::drawRectSquircle(pos, size, radius); },
         [](float x, float y, float w, float h, float radius){  trussc::drawRectSquircle(x, y, w, h, radius); }
     ));
-    // TrussC.h, LINE 1030
-    // TrussC.h, LINE 1034
+    // TrussC.h, LINE 1038
+    // TrussC.h, LINE 1042
     lua->set_function("drawCircle", sol::overload(
         [](Vec3 center, float radius){  trussc::drawCircle(center, radius); },
         [](float cx, float cy, float radius){  trussc::drawCircle(cx, cy, radius); }
     ));
-    // TrussC.h, LINE 1039
-    // TrussC.h, LINE 1043
     // TrussC.h, LINE 1047
+    // TrussC.h, LINE 1051
+    // TrussC.h, LINE 1055
     lua->set_function("drawEllipse", sol::overload(
         [](Vec3 center, Vec2 radii){  trussc::drawEllipse(center, radii); },
         [](Vec3 center, float rx, float ry){  trussc::drawEllipse(center, rx, ry); },
         [](float cx, float cy, float rx, float ry){  trussc::drawEllipse(cx, cy, rx, ry); }
     ));
-    // TrussC.h, LINE 1052
-    // TrussC.h, LINE 1056
     // TrussC.h, LINE 1060
+    // TrussC.h, LINE 1063
+    lua->set_function("drawArc", sol::overload(
+        [](Vec3 center, float radius, float angleBegin, float angleEnd){  trussc::drawArc(center, radius, angleBegin, angleEnd); },
+        [](float x, float y, float radius, float angleBegin, float angleEnd){  trussc::drawArc(x, y, radius, angleBegin, angleEnd); }
+    ));
+    // TrussC.h, LINE 1068
+    // TrussC.h, LINE 1071
+    // TrussC.h, LINE 1074
+    lua->set_function("drawBezier", sol::overload(
+        [](Vec3 p0, Vec3 p1, Vec3 p2, Vec3 p3){  trussc::drawBezier(p0, p1, p2, p3); },
+        [](Vec3 p0, Vec3 p1, Vec3 p2){  trussc::drawBezier(p0, p1, p2); },
+        [](const std::vector <Vec3>& controlPoints){  trussc::drawBezier(controlPoints); }
+    ));
+    // TrussC.h, LINE 1080
+    // TrussC.h, LINE 1084
+    // TrussC.h, LINE 1088
+    lua->set_function("drawCurve", sol::overload(
+        [](Vec3 p0, Vec3 p1, Vec3 p2, Vec3 p3){  trussc::drawCurve(p0, p1, p2, p3); },
+        [](const std::vector <Vec3>& points){  trussc::drawCurve(points); },
+        [](const std::vector <Vec3>& points, bool closed){  trussc::drawCurve(points, closed); }
+    ));
+    // TrussC.h, LINE 1093
+    // TrussC.h, LINE 1097
+    // TrussC.h, LINE 1101
     lua->set_function("drawLine", sol::overload(
         [](Vec3 p1, Vec3 p2){  trussc::drawLine(p1, p2); },
         [](float x1, float y1, float x2, float y2){  trussc::drawLine(x1, y1, x2, y2); },
         [](float x1, float y1, float z1, float x2, float y2, float z2){  trussc::drawLine(x1, y1, z1, x2, y2, z2); }
     ));
-    // TrussC.h, LINE 1065
-    // TrussC.h, LINE 1069
+    // TrussC.h, LINE 1106
+    // TrussC.h, LINE 1110
     lua->set_function("drawTriangle", sol::overload(
         [](Vec3 p1, Vec3 p2, Vec3 p3){  trussc::drawTriangle(p1, p2, p3); },
         [](float x1, float y1, float x2, float y2, float x3, float y3){  trussc::drawTriangle(x1, y1, x2, y2, x3, y3); }
     ));
-    // TrussC.h, LINE 1074
-    // TrussC.h, LINE 1078
+    // TrussC.h, LINE 1115
+    // TrussC.h, LINE 1119
     lua->set_function("drawPoint", sol::overload(
         [](Vec3 pos){  trussc::drawPoint(pos); },
         [](float x, float y){  trussc::drawPoint(x, y); }
     ));
-    // TrussC.h, LINE 1083
-    lua->set_function("setCircleResolution", [](int res){  trussc::setCircleResolution(res); });
-    // TrussC.h, LINE 1087
-    lua->set_function("getCircleResolution", [](){ return trussc::getCircleResolution(); });
-    // TrussC.h, LINE 1092
-    lua->set_function("isFillEnabled", [](){ return trussc::isFillEnabled(); });
-    // TrussC.h, LINE 1096
-    lua->set_function("isStrokeEnabled", [](){ return trussc::isStrokeEnabled(); });
+    // TrussC.h, LINE 1127
+    lua->set_function("setCurveTolerance", [](float pixels){  trussc::setCurveTolerance(pixels); });
     // TrussC.h, LINE 1130
-    // TrussC.h, LINE 1134
+    lua->set_function("setCurveResolution", [](int n){  trussc::setCurveResolution(n); });
+    // TrussC.h, LINE 1133
+    lua->set_function("getCurveTolerance", [](){ return trussc::getCurveTolerance(); });
+    // TrussC.h, LINE 1136
+    lua->set_function("getCurveResolution", [](){ return trussc::getCurveResolution(); });
     // TrussC.h, LINE 1139
-    // TrussC.h, LINE 1143
-    // TrussC.h, LINE 1148
-    // TrussC.h, LINE 1153
+    lua->set_function("getCurveMode", [](){ return trussc::getCurveMode(); });
+    // TrussC.h, LINE 1147
+    lua->set_function("setCircleResolution", [](int res){  trussc::setCircleResolution(res); });
+    // TrussC.h, LINE 1152
+    lua->set_function("getCircleResolution", [](){ return trussc::getCircleResolution(); });
+    // TrussC.h, LINE 1157
+    lua->set_function("isFillEnabled", [](){ return trussc::isFillEnabled(); });
+    // TrussC.h, LINE 1161
+    lua->set_function("isStrokeEnabled", [](){ return trussc::isStrokeEnabled(); });
+    // TrussC.h, LINE 1208
+    // TrussC.h, LINE 1672
+    lua->set_function("getFrameCount", sol::overload(
+        [](){ return trussc::getFrameCount(); },
+        [](){ return trussc::getFrameCount(); }
+    ));
+    // TrussC.h, LINE 1209
+    lua->set_function("ensureFontAtlas", [](int rows){  trussc::ensureFontAtlas(rows); });
+    // TrussC.h, LINE 1280
+    lua->set_function("ensureFontAtlasForText", [](const std::string & text){  trussc::ensureFontAtlasForText(text); });
+    // TrussC.h, LINE 1288
+    // TrussC.h, LINE 1292
+    // TrussC.h, LINE 1297
+    // TrussC.h, LINE 1301
+    // TrussC.h, LINE 1306
+    // TrussC.h, LINE 1311
     lua->set_function("drawBitmapString", sol::overload(
         [](const std::string & text, Vec3 pos, bool screenFixed){  trussc::drawBitmapString(text, pos, screenFixed); },
         [](const std::string & text, float x, float y, bool screenFixed){  trussc::drawBitmapString(text, x, y, screenFixed); },
@@ -363,143 +405,149 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua){
         // NOTE: additional overloads provided by user,
         [](const std::string& s, float x, float y){  trussc::drawBitmapString(s, x, y); }
     ));
-    // TrussC.h, LINE 1159
+    // TrussC.h, LINE 1317
     lua->set_function("setTextAlign", [](Direction h, Direction v){  trussc::setTextAlign(h, v); });
-    // TrussC.h, LINE 1164
+    // TrussC.h, LINE 1322
     lua->set_function("getTextAlignH", [](){ return trussc::getTextAlignH(); });
-    // TrussC.h, LINE 1168
+    // TrussC.h, LINE 1326
     lua->set_function("getTextAlignV", [](){ return trussc::getTextAlignV(); });
-    // TrussC.h, LINE 1173
+    // TrussC.h, LINE 1331
     lua->set_function("setBitmapLineHeight", [](float h){  trussc::setBitmapLineHeight(h); });
-    // TrussC.h, LINE 1178
+    // TrussC.h, LINE 1336
     lua->set_function("getBitmapLineHeight", [](){ return trussc::getBitmapLineHeight(); });
-    // TrussC.h, LINE 1183
+    // TrussC.h, LINE 1341
     lua->set_function("getBitmapFontHeight", [](){ return trussc::getBitmapFontHeight(); });
-    // TrussC.h, LINE 1188
+    // TrussC.h, LINE 1346
     lua->set_function("getBitmapStringWidth", [](const std::string & text){ return trussc::getBitmapStringWidth(text); });
-    // TrussC.h, LINE 1193
+    // TrussC.h, LINE 1351
     lua->set_function("getBitmapStringHeight", [](const std::string & text){ return trussc::getBitmapStringHeight(text); });
-    // TrussC.h, LINE 1198
+    // TrussC.h, LINE 1356
     lua->set_function("getBitmapStringBBox", [](const std::string & text){ return trussc::getBitmapStringBBox(text); });
-    // TrussC.h, LINE 1203
+    // TrussC.h, LINE 1361
     lua->set_function("drawBitmapStringHighlight", sol::overload(
         [](const std::string & text, float x, float y, const Color & background, const Color & foreground){  trussc::drawBitmapStringHighlight(text, x, y, background, foreground); },
         // NOTE: additional overloads provided by user,
         [](const std::string& s, float x, float y){  trussc::drawBitmapStringHighlight(s, x, y); }
     ));
-    // TrussC.h, LINE 1309
+    // TrussC.h, LINE 1475
     lua->set_function("setWindowTitle", [](const std::string & title){  trussc::setWindowTitle(title); });
-    // TrussC.h, LINE 1349
+    // TrussC.h, LINE 1515
     lua->set_function("showCursor", [](){  trussc::showCursor(); });
-    // TrussC.h, LINE 1354
+    // TrussC.h, LINE 1520
     lua->set_function("hideCursor", [](){  trussc::hideCursor(); });
-    // TrussC.h, LINE 1359
+    // TrussC.h, LINE 1525
     lua->set_function("setCursor", [](Cursor cursor){  trussc::setCursor(cursor); });
-    // TrussC.h, LINE 1364
+    // TrussC.h, LINE 1530
     lua->set_function("getCursor", [](){ return trussc::getCursor(); });
-    // TrussC.h, LINE 1370
-    // TrussC.h, LINE 2526
+    // TrussC.h, LINE 1536
+    // TrussC.h, LINE 2660
     lua->set_function("bindCursorImage", sol::overload(
         [](Cursor cursor, int width, int height, const unsigned char * pixels, int hotspotX, int hotspotY){  trussc::bindCursorImage(cursor, width, height, pixels, hotspotX, hotspotY); },
         [](Cursor cursor, const Image & image, int hotspotX, int hotspotY){  trussc::bindCursorImage(cursor, image, hotspotX, hotspotY); }
     ));
-    // TrussC.h, LINE 1386
+    // TrussC.h, LINE 1552
     lua->set_function("unbindCursorImage", [](Cursor cursor){  trussc::unbindCursorImage(cursor); });
-    // TrussC.h, LINE 1395
-    lua->set_function("setClipboardString", [](const std::string & text){  trussc::setClipboardString(text); });
-    // TrussC.h, LINE 1404
-    lua->set_function("getClipboardString", [](){ return trussc::getClipboardString(); });
-    // TrussC.h, LINE 1412
-    lua->set_function("setWindowSize", [](int width, int height){  trussc::setWindowSize(width, height); });
-    // TrussC.h, LINE 1424
-    lua->set_function("setFullscreen", [](bool full){  trussc::setFullscreen(full); });
-    // TrussC.h, LINE 1431
-    lua->set_function("isFullscreen", [](){ return trussc::isFullscreen(); });
-    // TrussC.h, LINE 1436
-    lua->set_function("toggleFullscreen", [](){  trussc::toggleFullscreen(); });
-    // TrussC.h, LINE 1466
-    lua->set_function("setOrientation", [](Orientation mask){  trussc::setOrientation(mask); });
-    // TrussC.h, LINE 1473
-    lua->set_function("getWindowWidth", [](){ return trussc::getWindowWidth(); });
-    // TrussC.h, LINE 1481
-    lua->set_function("getWindowHeight", [](){ return trussc::getWindowHeight(); });
-    // TrussC.h, LINE 1489
-    lua->set_function("getWindowSize", [](){ return trussc::getWindowSize(); });
-    // TrussC.h, LINE 1494
-    lua->set_function("getAspectRatio", [](){ return trussc::getAspectRatio(); });
-    // TrussC.h, LINE 1502
-    lua->set_function("getElapsedTime", [](){ return trussc::getElapsedTime(); });
-    // TrussC.h, LINE 1515
-    lua->set_function("getUpdateCount", [](){ return trussc::getUpdateCount(); });
-    // TrussC.h, LINE 1520
-    lua->set_function("getDrawCount", [](){ return trussc::getDrawCount(); });
-    // TrussC.h, LINE 1525
-    lua->set_function("getFrameCount", [](){ return trussc::getFrameCount(); });
-    // TrussC.h, LINE 1529
-    lua->set_function("getDeltaTime", [](){ return trussc::getDeltaTime(); });
-    // TrussC.h, LINE 1534
-    lua->set_function("getFrameRate", [](){ return trussc::getFrameRate(); });
     // TrussC.h, LINE 1561
-    lua->set_function("getSokolMemoryBytes", [](){ return trussc::getSokolMemoryBytes(); });
-    // TrussC.h, LINE 1564
-    lua->set_function("getSokolMemoryAllocs", [](){ return trussc::getSokolMemoryAllocs(); });
-    // TrussC.h, LINE 1569
-    lua->set_function("releaseSglBuffers", [](){  trussc::releaseSglBuffers(); });
+    lua->set_function("setClipboardString", [](const std::string & text){  trussc::setClipboardString(text); });
+    // TrussC.h, LINE 1570
+    lua->set_function("getClipboardString", [](){ return trussc::getClipboardString(); });
     // TrussC.h, LINE 1578
-    lua->set_function("getGlobalMouseX", [](){ return trussc::getGlobalMouseX(); });
-    // TrussC.h, LINE 1583
-    lua->set_function("getGlobalMouseY", [](){ return trussc::getGlobalMouseY(); });
-    // TrussC.h, LINE 1588
-    lua->set_function("getGlobalPMouseX", [](){ return trussc::getGlobalPMouseX(); });
-    // TrussC.h, LINE 1593
-    lua->set_function("getGlobalPMouseY", [](){ return trussc::getGlobalPMouseY(); });
-    // TrussC.h, LINE 1598
-    lua->set_function("isMousePressed", [](){ return trussc::isMousePressed(); });
-    // TrussC.h, LINE 1603
-    lua->set_function("getMouseButton", [](){ return trussc::getMouseButton(); });
-    // TrussC.h, LINE 1608
-    lua->set_function("isKeyPressed", [](int key){ return trussc::isKeyPressed(key); });
-    // TrussC.h, LINE 1613
-    lua->set_function("getMouseX", [](){ return trussc::getMouseX(); });
-    // TrussC.h, LINE 1614
-    lua->set_function("getMouseY", [](){ return trussc::getMouseY(); });
-    // TrussC.h, LINE 1615
-    lua->set_function("getMousePos", [](){ return trussc::getMousePos(); });
-    // TrussC.h, LINE 1616
-    lua->set_function("getGlobalMousePos", [](){ return trussc::getGlobalMousePos(); });
-    // TrussC.h, LINE 1624
-    lua->set_function("setTouchAsMouse", [](bool enabled){  trussc::setTouchAsMouse(enabled); });
-    // TrussC.h, LINE 1625
-    lua->set_function("getTouchAsMouse", [](){ return trussc::getTouchAsMouse(); });
+    lua->set_function("setWindowSize", [](int width, int height){  trussc::setWindowSize(width, height); });
+    // TrussC.h, LINE 1590
+    lua->set_function("setFullscreen", [](bool full){  trussc::setFullscreen(full); });
+    // TrussC.h, LINE 1597
+    lua->set_function("isFullscreen", [](){ return trussc::isFullscreen(); });
+    // TrussC.h, LINE 1602
+    lua->set_function("toggleFullscreen", [](){  trussc::toggleFullscreen(); });
     // TrussC.h, LINE 1632
+    lua->set_function("setOrientation", [](Orientation mask){  trussc::setOrientation(mask); });
+    // TrussC.h, LINE 1639
+    lua->set_function("getWindowWidth", [](){ return trussc::getWindowWidth(); });
+    // TrussC.h, LINE 1647
+    lua->set_function("getWindowHeight", [](){ return trussc::getWindowHeight(); });
+    // TrussC.h, LINE 1655
+    lua->set_function("getWindowSize", [](){ return trussc::getWindowSize(); });
+    // TrussC.h, LINE 1660
+    lua->set_function("getAspectRatio", [](){ return trussc::getAspectRatio(); });
+    // TrussC.h, LINE 1669
+    lua->set_function("getElapsedTime", [](){ return trussc::getElapsedTime(); });
+    // TrussC.h, LINE 1670
+    lua->set_function("getUpdateCount", [](){ return trussc::getUpdateCount(); });
+    // TrussC.h, LINE 1671
+    lua->set_function("getDrawCount", [](){ return trussc::getDrawCount(); });
+    // TrussC.h, LINE 1673
+    lua->set_function("getDeltaTime", [](){ return trussc::getDeltaTime(); });
+    // TrussC.h, LINE 1674
+    lua->set_function("getFrameRate", [](){ return trussc::getFrameRate(); });
+    // TrussC.h, LINE 1681
+    lua->set_function("getSokolMemoryBytes", [](){ return trussc::getSokolMemoryBytes(); });
+    // TrussC.h, LINE 1684
+    lua->set_function("getSokolMemoryAllocs", [](){ return trussc::getSokolMemoryAllocs(); });
+    // TrussC.h, LINE 1689
+    lua->set_function("releaseSglBuffers", [](){  trussc::releaseSglBuffers(); });
+    // TrussC.h, LINE 1698
+    lua->set_function("getGlobalMouseX", [](){ return trussc::getGlobalMouseX(); });
+    // TrussC.h, LINE 1703
+    lua->set_function("getGlobalMouseY", [](){ return trussc::getGlobalMouseY(); });
+    // TrussC.h, LINE 1708
+    lua->set_function("getGlobalPMouseX", [](){ return trussc::getGlobalPMouseX(); });
+    // TrussC.h, LINE 1713
+    lua->set_function("getGlobalPMouseY", [](){ return trussc::getGlobalPMouseY(); });
+    // TrussC.h, LINE 1718
+    lua->set_function("isMousePressed", [](){ return trussc::isMousePressed(); });
+    // TrussC.h, LINE 1723
+    lua->set_function("getMouseButton", [](){ return trussc::getMouseButton(); });
+    // TrussC.h, LINE 1728
+    lua->set_function("isKeyPressed", [](int key){ return trussc::isKeyPressed(key); });
+    // TrussC.h, LINE 1737
+    lua->set_function("isShiftPressed", [](){ return trussc::isShiftPressed(); });
+    // TrussC.h, LINE 1738
+    lua->set_function("isControlPressed", [](){ return trussc::isControlPressed(); });
+    // TrussC.h, LINE 1739
+    lua->set_function("isAltPressed", [](){ return trussc::isAltPressed(); });
+    // TrussC.h, LINE 1740
+    lua->set_function("isSuperPressed", [](){ return trussc::isSuperPressed(); });
+    // TrussC.h, LINE 1743
+    lua->set_function("getMouseX", [](){ return trussc::getMouseX(); });
+    // TrussC.h, LINE 1744
+    lua->set_function("getMouseY", [](){ return trussc::getMouseY(); });
+    // TrussC.h, LINE 1745
+    lua->set_function("getMousePos", [](){ return trussc::getMousePos(); });
+    // TrussC.h, LINE 1746
+    lua->set_function("getGlobalMousePos", [](){ return trussc::getGlobalMousePos(); });
+    // TrussC.h, LINE 1754
+    lua->set_function("setTouchAsMouse", [](bool enabled){  trussc::setTouchAsMouse(enabled); });
+    // TrussC.h, LINE 1755
+    lua->set_function("getTouchAsMouse", [](){ return trussc::getTouchAsMouse(); });
+    // TrussC.h, LINE 1762
     lua->set_function("getBackendName", [](){ return trussc::getBackendName(); });
-    // TrussC.h, LINE 1646
+    // TrussC.h, LINE 1776
     lua->set_function("getMemoryUsage", [](){ return trussc::getMemoryUsage(); });
-    // TrussC.h, LINE 1686
+    // TrussC.h, LINE 1816
     lua->set_function("getNodeCount", [](){ return trussc::getNodeCount(); });
-    // TrussC.h, LINE 1687
+    // TrussC.h, LINE 1817
     lua->set_function("getTextureCount", [](){ return trussc::getTextureCount(); });
-    // TrussC.h, LINE 1688
+    // TrussC.h, LINE 1818
     lua->set_function("getFboCount", [](){ return trussc::getFboCount(); });
-    // TrussC.h, LINE 1712
+    // TrussC.h, LINE 1842
     lua->set_function("setFps", [](float fps){  trussc::setFps(fps); });
-    // TrussC.h, LINE 1722
+    // TrussC.h, LINE 1852
     lua->set_function("setIndependentFps", [](float updateFps, float drawFps){  trussc::setIndependentFps(updateFps, drawFps); });
-    // TrussC.h, LINE 1731
+    // TrussC.h, LINE 1861
     lua->set_function("getFpsSettings", [](){ return trussc::getFpsSettings(); });
-    // TrussC.h, LINE 1751
+    // TrussC.h, LINE 1881
     lua->set_function("getFps", [](){ return trussc::getFps(); });
-    // TrussC.h, LINE 1757
+    // TrussC.h, LINE 1887
     lua->set_function("redraw", [](int count){  trussc::redraw(count); });
-    // TrussC.h, LINE 1765
+    // TrussC.h, LINE 1895
     lua->set_function("requestExitApp", [](){  trussc::requestExitApp(); });
-    // TrussC.h, LINE 1771
+    // TrussC.h, LINE 1901
     lua->set_function("exitApp", [](){  trussc::exitApp(); });
-    // TrussC.h, LINE 1781
+    // TrussC.h, LINE 1911
     lua->set_function("grabScreen", [](Pixels & outPixels){ return trussc::grabScreen(outPixels); });
-    // TrussC.h, LINE 1920
+    // TrussC.h, LINE 2054
     lua->set_function("registerInspectionTools", [](){  trussc::mcp::registerInspectionTools(); });
-    // TrussC.h, LINE 1921
+    // TrussC.h, LINE 2055
     lua->set_function("registerDebuggerTools", [](){  trussc::mcp::registerDebuggerTools(); });
     // tcPrimitives.h, LINE 11
     lua->set_function("createPlane", [](float width, float height, int cols, int rows){ return trussc::createPlane(width, height, cols, rows); });
@@ -519,12 +567,12 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua){
     lua->set_function("createIcoSphere", [](float radius, int subdivisions){ return trussc::createIcoSphere(radius, subdivisions); });
     // tcPrimitives.h, LINE 430
     lua->set_function("createTorus", [](float radius, float tubeRadius, int sides, int rings){ return trussc::createTorus(radius, tubeRadius, sides, rings); });
-    // TrussC.h, LINE 2570
-    // TrussC.h, LINE 2579
-    // TrussC.h, LINE 2583
-    // TrussC.h, LINE 2590
-    // TrussC.h, LINE 2594
-    // TrussC.h, LINE 2598
+    // TrussC.h, LINE 2704
+    // TrussC.h, LINE 2713
+    // TrussC.h, LINE 2717
+    // TrussC.h, LINE 2724
+    // TrussC.h, LINE 2728
+    // TrussC.h, LINE 2732
     lua->set_function("drawBox", sol::overload(
         [](float w, float h, float d){  trussc::drawBox(w, h, d); },
         [](float size){  trussc::drawBox(size); },
@@ -533,17 +581,17 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua){
         [](Vec3 pos, float size){  trussc::drawBox(pos, size); },
         [](float x, float y, float z, float size){  trussc::drawBox(x, y, z, size); }
     ));
-    // TrussC.h, LINE 2602
-    // TrussC.h, LINE 2611
-    // TrussC.h, LINE 2618
+    // TrussC.h, LINE 2736
+    // TrussC.h, LINE 2745
+    // TrussC.h, LINE 2752
     lua->set_function("drawSphere", sol::overload(
         [](float radius, int resolution){  trussc::drawSphere(radius, resolution); },
         [](Vec3 pos, float radius, int resolution){  trussc::drawSphere(pos, radius, resolution); },
         [](float x, float y, float z, float radius, int resolution){  trussc::drawSphere(x, y, z, radius, resolution); }
     ));
-    // TrussC.h, LINE 2622
-    // TrussC.h, LINE 2631
-    // TrussC.h, LINE 2638
+    // TrussC.h, LINE 2756
+    // TrussC.h, LINE 2765
+    // TrussC.h, LINE 2772
     lua->set_function("drawCone", sol::overload(
         [](float radius, float height, int resolution){  trussc::drawCone(radius, height, resolution); },
         [](Vec3 pos, float radius, float height, int resolution){  trussc::drawCone(pos, radius, height, resolution); },

--- a/addons/tcxLua/src/tcxLua.cpp
+++ b/addons/tcxLua/src/tcxLua.cpp
@@ -1501,7 +1501,12 @@ void tcxLua::setTypeBindings(const std::shared_ptr<sol::state>& lua){
 
     lua->new_usertype<AudioEngine>("AudioEngine",
         "getInstance", sol::var(&AudioEngine::getInstance),
-        "init", &AudioEngine::init,
+        // init() is overloaded — no-arg uses defaults, AudioSettings-arg
+        // configures the engine. Resolve both for Lua.
+        "init", sol::overload(
+            static_cast<bool (AudioEngine::*)()>(&AudioEngine::init),
+            static_cast<bool (AudioEngine::*)(const AudioSettings&)>(&AudioEngine::init)
+        ),
         "shutdown", &AudioEngine::shutdown,
         "getAnalysisBuffer", &AudioEngine::getAnalysisBuffer,
         // play() now has two overloads (SoundSource and SoundBuffer);

--- a/addons/tcxLua/tools/bindgen/README.md
+++ b/addons/tcxLua/tools/bindgen/README.md
@@ -1,12 +1,41 @@
 # bindgen
 
-Python script using libclang
+libclang (Python binding) で `core/include/TrussC.h` 等のフリー関数を解析し、Lua バインディング (`trussc_generated.cpp`) を生成するスクリプト。
+
+クラスやメソッドのバインディング (`AudioEngine`, `Image`, `Fbo` …) は対象外で、これらは `addons/tcxLua/src/tcxLua.cpp` の `setBindings()` で手書きする。
 
 ## Generate
 
 ```bash
-$ pip install uv
-$ uv sync
-$ uv run main.py ../../../../core/include/TrussC.h
-$ cp trussc_generated.cpp ../../src/generated
+pip install uv         # 初回のみ
+uv sync                # 初回 / 依存更新時
+uv run main.py ../../../../core/include/TrussC.h
+cp trussc_generated.cpp ../../src/generated
 ```
+
+## 対象ヘッダ
+
+- `TrussC.h` (グローバル関数)
+- `tcMath.h`, `tcPrimitives.h`, `tc3DGraphics.h`, `tcLog.h`
+
+新しい無視ルール (`ignore_functions`, `ignore_namespaces`, `ignore_classes`) や手動オーバーロード (`additional_overloads`) は `main.py` 冒頭の定数を編集。
+
+## libclang のシステムヘッダ依存
+
+`<string>` などの C++ 標準ライブラリ参照を解決させるため、`discoverCompileArgs()` で
+- macOS: `xcrun --show-sdk-path` + `clang++ -print-resource-dir`
+- Linux: `clang++ -print-resource-dir`
+
+を渡している。WindowsはCIで未検証。
+
+**注意**: libclang 18 (PyPI で取得可能な最新版) と clang 21 (Xcode 16+ の system clang) の組み合わせでは、C++20 stdlib 内部のテンプレート (`__builtin_ctzg` 等) を理解できず、`std::vector<Vec3>` のような型解決が失敗して `int` にフォールバックする場合がある。スクリプトはこれを検知して、ソーストークンから型を復元するフォールバック (`getParamType`) を行う。
+
+regen 後は **diff を必ず確認**して、見覚えのない `const int &` への置換が無いことをチェックすること。
+
+## 開発時のチェックフロー
+
+1. C++ ヘッダで新規 free function を追加
+2. `uv run main.py ...` を再実行
+3. `cp` でコピー
+4. `git diff` で意図した差分か確認
+5. 必要なら `ignore_functions` や `additional_overloads` を調整して再生成

--- a/addons/tcxLua/tools/bindgen/main.py
+++ b/addons/tcxLua/tools/bindgen/main.py
@@ -1,8 +1,106 @@
 import argparse
 import json
 import os
+import platform
+import subprocess
 
 from clang.cindex import CursorKind, Index, TokenKind
+
+
+# libclang only sees standard headers (and therefore can only resolve
+# `std::string` and friends) if we pass it the same sysroot / resource-dir
+# / include paths that the system compiler would use. Without these, the
+# parser silently falls back to `int` for any unresolved type — which
+# results in trussc_generated.cpp binding `const int & path` instead of
+# `const std::string & path`. See issue: bindgen had been silently broken.
+def discoverCompileArgs():
+    args = ["-x", "c++", "-std=c++20"]
+
+    system = platform.system()
+    if system == "Darwin":
+        try:
+            sdk = subprocess.check_output(
+                ["xcrun", "--show-sdk-path"], text=True
+            ).strip()
+            clangxx = subprocess.check_output(
+                ["xcrun", "-find", "clang++"], text=True
+            ).strip()
+            res = subprocess.check_output(
+                [clangxx, "-print-resource-dir"], text=True
+            ).strip()
+            args += [
+                "-isysroot", sdk,
+                "-resource-dir", res,
+                "-I", f"{sdk}/usr/include/c++/v1",
+                "-I", f"{res}/include",
+            ]
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            print(f"WARN: failed to probe Xcode toolchain: {e}")
+    elif system == "Linux":
+        # Best-effort. CI / contributors may need to set CPLUS_INCLUDE_PATH.
+        try:
+            res = subprocess.check_output(
+                ["clang++", "-print-resource-dir"], text=True
+            ).strip()
+            args += ["-resource-dir", res, "-I", f"{res}/include"]
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+
+    return args
+
+
+# libclang 18 occasionally fails to resolve template-instantiated parameter
+# types (e.g. `const std::vector<Vec3>&`) when the inline body calls into a
+# class whose definition needs newer C++ stdlib features. When that happens
+# `param.type.spelling` silently returns `"const int &"`, which would corrupt
+# the generated lambda signatures. Fall back to extracting the type from the
+# raw source tokens, which libclang always exposes correctly.
+def _extractParamTypeFromTokens(param):
+    tokens = list(param.get_tokens())
+    if not tokens:
+        return None
+    spellings = [t.spelling for t in tokens]
+    name = param.spelling
+    if name and spellings and spellings[-1] == name:
+        spellings = spellings[:-1]
+    # Drop default-value clauses ("= 1.0f", "= nullptr"). Anything from
+    # the first '=' onward isn't part of the type.
+    if "=" in spellings:
+        spellings = spellings[: spellings.index("=")]
+    if not spellings:
+        return None
+
+    # Reassemble C++ type spelling with minimal spacing. The default
+    # `" ".join` produces `const std :: vector < Vec3 > &` which compiles
+    # but looks noisy and inflates the diff every regen.
+    out = []
+    no_space_after = {"::", "<", "&", "*"}
+    no_space_before = {"::", ">", ",", "&", "*"}
+    for i, tok in enumerate(spellings):
+        if i == 0:
+            out.append(tok)
+            continue
+        prev = spellings[i - 1]
+        if prev in no_space_after or tok in no_space_before:
+            out.append(tok)
+        else:
+            out.append(" " + tok)
+    return "".join(out).strip()
+
+
+def getParamType(param):
+    spelled = param.type.spelling
+    token_type = _extractParamTypeFromTokens(param)
+    if token_type is None:
+        return spelled
+    # If libclang gave us `int` (or `const int &`, etc.) but the source
+    # tokens contain `::` or angle brackets, the libclang type is wrong.
+    looks_resolved = ("::" in token_type) or ("<" in token_type)
+    if looks_resolved and "int" in spelled:
+        return token_type
+    # Prefer the spelled type when it looks sensible (it correctly handles
+    # cv-qualifiers, references, decayed arrays, etc).
+    return spelled
 
 genfile = "trussc_generated.cpp"
 
@@ -107,9 +205,20 @@ additional_overloads = {
 functions_map = {}
 
 def visitNode(node, ns="", clazz=""):
-    if node.kind.name == 'FUNCTION_DECL':
+    # libclang 18 + clang 21 system headers occasionally yields CursorKind
+    # ids it doesn't recognise (e.g. 437 inside C++20 stdlib templates).
+    # Skip the offending subtree instead of crashing the whole run.
+    try:
+        node_kind_name = node.kind.name
+    except ValueError:
+        return
+
+    if node_kind_name == 'FUNCTION_DECL':
         is_ignore = False
 
+        # The translation unit's own root cursor has no location.file.
+        if node.location.file is None:
+            return
         filepath = node.location.file.name
         filename = os.path.basename(filepath)
         if not (filename in target_filenames):
@@ -122,7 +231,7 @@ def visitNode(node, ns="", clazz=""):
         params = []
         for param in node.get_arguments():
             param_name = param.spelling
-            param_type = param.type.spelling
+            param_type = getParamType(param)
 
             params.append({
                 "name": param_name,
@@ -177,17 +286,17 @@ def visitNode(node, ns="", clazz=""):
             else:
                 functions_map[id][line_number] = obj
 
-    elif node.kind.name == 'NAMESPACE':
+    elif node_kind_name =='NAMESPACE':
         if ns == "":
             ns = node.spelling
         else:
             ns = ns + "::" + node.spelling
-    elif node.kind.name == 'CALL_EXPR':
+    elif node_kind_name =='CALL_EXPR':
         # print(declared_function_name, node.location.line)
         pass
-    elif node.kind.name == 'CLASS_TEMPLATE':
+    elif node_kind_name =='CLASS_TEMPLATE':
         pass
-    elif node.kind.name == 'CLASS_DECL':
+    elif node_kind_name =='CLASS_DECL':
         if clazz == "":
             clazz = node.spelling
         else:
@@ -196,7 +305,11 @@ def visitNode(node, ns="", clazz=""):
         # print("kind_name:", node.kind.name)
         pass
 
-    for c in node.get_children():
+    try:
+        children = list(node.get_children())
+    except ValueError:
+        return
+    for c in children:
         visitNode(c, ns, clazz)
 
 
@@ -309,8 +422,32 @@ def main():
 
     input_filename = os.path.basename(args.filename)
 
+    # Also add the TrussC core include dirs so files like #include "tc/..."
+    # resolve, otherwise types declared in headers next to TrussC.h
+    # (Vec2, Color, Sound, etc.) appear unresolved.
+    truss_root = os.path.abspath(
+        os.path.dirname(args.filename)  # e.g. core/include/
+    )
+    compile_args = discoverCompileArgs() + [
+        "-I", truss_root,
+        "-I", os.path.join(truss_root, "sokol"),
+    ]
+
     index = Index.create()
-    tree = index.parse(args.filename, args=["-x", "c++"])
+    tree = index.parse(args.filename, args=compile_args)
+
+    # Surface any fatal parse errors so silent type-fallbacks (e.g. unresolved
+    # `std::string` becoming `int`) get noticed instead of silently corrupting
+    # the generated bindings.
+    fatal = [d for d in tree.diagnostics if d.severity >= 3]  # 3 = error
+    if fatal:
+        print(f"WARN: libclang reported {len(fatal)} error(s) while parsing:")
+        for d in fatal[:5]:
+            print(f"  {d.spelling} at {d.location}")
+        if len(fatal) > 5:
+            print(f"  ... and {len(fatal) - 5} more")
+        print("Continuing — generation may still be correct if errors are "
+              "inside stdlib template internals, but verify the output.")
 
     visitNode(tree.cursor)
 


### PR DESCRIPTION
## Summary

Promotes PR #105 from `dev` to `main` so the failing CI on `main` (which has been red since the #104 merge) goes green again.

Brings in:
- **bindgen restoration** — libclang sysroot probing + token-fallback for unresolved template types; surfaces fatal parse errors. The tool was silently producing `const int &` lambdas in place of `const std::string &` since libclang couldn't find `<stdint.h>` / `<string>`. Regen had been blocked for ~2 months as a result.
- **Regenerated `trussc_generated.cpp`** — picks up the free functions added over the last several weeks: `isShiftPressed / isControlPressed / isAltPressed / isSuperPressed`, `drawArc / drawBezier / drawCurve` (incl. `std::vector<Vec3>&` overloads), `setCurveTolerance / setCurveResolution / getCurveMode`, `ensureFontAtlas / ensureFontAtlasForText`, `getFrameCount` overload.
- **`AudioEngine::init` overload fix** — the immediate cause of CI failure on #104; `&AudioEngine::init` became ambiguous when `init(const AudioSettings&)` was added. Wrapped in `sol::overload + static_cast` matching the existing `play()` pattern.

Class / method bindings still missing for the v0.5.x sound / image / font / path / fbo additions (AudioSettings, listDevices, Fbo mipmap overload, Image transforms, Path subpath APIs, font tategaki…) will land in follow-up PRs.

## Test plan
- [x] PR #105 CI green on `dev`
- [x] Full CI matrix re-runs on this main-targeted PR (mac / linux / windows / web / android)