### PR TITLE
perf(events): Event<T>::notify RT-safety + audio priority + tcxLua sandboxing doc

### DIFF
--- a/addons/tcxLua/README.md
+++ b/addons/tcxLua/README.md
@@ -21,6 +21,39 @@
 - `Tween<T>` (as TweenFloat, TweenVec2, TweenVec3, TweenColor)
 - Sound, MicInput
 
+## Lua module sandboxing
+
+`tcxLua::getLuaState()` accepts a `LuaModulePreferences` struct that controls which
+Lua standard libraries are loaded. The defaults are:
+
+| Module | Default | Notes |
+|--------|---------|-------|
+| `base`, `math`, `string`, `table`, `coroutine` | **on** | Safe core set |
+| `io`, `package` | **off** | Opening these is effectively granting **arbitrary code execution** to whatever Lua you load — `io.popen` runs shell commands, `package.loadlib` loads any native library |
+| `os`, `debug`, `bit32`, `ffi`, `utf8` | **off** | Off for similar reasons (`os.execute`, `os.remove`, etc.) |
+
+If your app only runs Lua scripts you authored and ship yourself, opting back in is fine:
+
+```cpp
+tcxLua lua;
+tcxLua::LuaModulePreferences prefs;
+prefs.io = true;
+prefs.package = true;   // needed for `require` of external Lua modules
+auto state = lua.getLuaState(prefs);
+```
+
+**Do NOT enable `io` / `package` if any of these are true:**
+
+- The Lua source can be edited by the end-user (hot-reload from disk, in-app script editor)
+- The app downloads, fetches, or otherwise loads Lua from untrusted sources
+- Your app ships pre-compiled Lua that you cannot guarantee hasn't been tampered with
+
+In those cases, enabling `io` / `package` lets the script `io.popen("rm -rf ~")` or
+load arbitrary native code via `package.loadlib`. Stick with the default safe set.
+
+See [issue #80](https://github.com/TrussC-org/TrussC/issues/80) for the
+historical context — these were on by default until 2026-05-27 (PR #97).
+
 ## Known Issues
 
 - Default value is not treated perfectly now ([Issue#1](https://github.com/funatsufumiya/tcxLua/issues/1)). So you may need additional values when using methods for example:

--- a/core/include/tc/events/tcEvent.h
+++ b/core/include/tc/events/tcEvent.h
@@ -123,14 +123,30 @@ public:
     }
 
 private:
+    struct Entry {
+        uint64_t id;
+        int priority;
+        Callback callback;
+    };
+
+    using EntryList = std::vector<Entry>;
+    using ConstEntryListPtr = std::shared_ptr<const EntryList>;
+
     void listenImpl(EventListener& listener, Callback callback,
                     int priority) {
         uint64_t id;
         {
             TC_LOCK_GUARD(mutex_);
             id = nextId_++;
-            entries_.push_back({id, priority, std::move(callback)});
-            sortEntries();
+            ConstEntryListPtr cur = std::atomic_load(&entries_);
+            auto next = cur ? std::make_shared<EntryList>(*cur)
+                            : std::make_shared<EntryList>();
+            next->push_back({id, priority, std::move(callback)});
+            std::stable_sort(next->begin(), next->end(),
+                [](const Entry& a, const Entry& b) {
+                    return a.priority < b.priority;
+                });
+            std::atomic_store(&entries_, ConstEntryListPtr(next));
         }
         // Set EventListener outside lock (removeListener() may be called when disconnecting existing)
         // Capture weak_ptr to check if Event is still alive before removing
@@ -146,15 +162,12 @@ private:
 
 public:
 
-    // Fire event
+    // Fire event. Hot path: a single atomic_load (no allocation, no mutex)
+    // — safe to call from the audio thread.
     void notify(T& arg) {
-        std::vector<Entry> entriesCopy;
-        {
-            TC_LOCK_GUARD(mutex_);
-            entriesCopy = entries_;
-        }
-        // Execute outside lock (prevent deadlock)
-        for (auto& entry : entriesCopy) {
+        ConstEntryListPtr snapshot = std::atomic_load(&entries_);
+        if (!snapshot) return;
+        for (const auto& entry : *snapshot) {
             if (entry.callback) {
                 entry.callback(arg);
             }
@@ -163,42 +176,33 @@ public:
 
     // Get listener count
     size_t listenerCount() const {
-        TC_LOCK_GUARD(mutex_);
-        return entries_.size();
+        ConstEntryListPtr snapshot = std::atomic_load(&entries_);
+        return snapshot ? snapshot->size() : 0;
     }
 
     // Remove all listeners
     void clear() {
         TC_LOCK_GUARD(mutex_);
-        entries_.clear();
+        std::atomic_store(&entries_, ConstEntryListPtr{});
     }
 
 private:
-    struct Entry {
-        uint64_t id;
-        int priority;
-        Callback callback;
-    };
-
     void removeListener(uint64_t id) {
         TC_LOCK_GUARD(mutex_);
-        entries_.erase(
-            std::remove_if(entries_.begin(), entries_.end(),
+        ConstEntryListPtr cur = std::atomic_load(&entries_);
+        if (!cur) return;
+        auto next = std::make_shared<EntryList>(*cur);
+        next->erase(
+            std::remove_if(next->begin(), next->end(),
                 [id](const Entry& e) { return e.id == id; }),
-            entries_.end()
+            next->end()
         );
-    }
-
-    void sortEntries() {
-        std::stable_sort(entries_.begin(), entries_.end(),
-            [](const Entry& a, const Entry& b) {
-                return a.priority < b.priority;
-            });
+        std::atomic_store(&entries_, ConstEntryListPtr(next));
     }
 
     std::shared_ptr<bool> alive_;
-    mutable TC_MUTEX mutex_;
-    std::vector<Entry> entries_;
+    mutable TC_MUTEX mutex_;            // serializes listen / remove / clear
+    ConstEntryListPtr entries_;          // RCU snapshot, atomic_load/store
     uint64_t nextId_ = 0;
 };
 
@@ -254,14 +258,30 @@ public:
     }
 
 private:
+    struct Entry {
+        uint64_t id;
+        int priority;
+        Callback callback;
+    };
+
+    using EntryList = std::vector<Entry>;
+    using ConstEntryListPtr = std::shared_ptr<const EntryList>;
+
     void listenImpl(EventListener& listener, Callback callback,
                     int priority) {
         uint64_t id;
         {
             TC_LOCK_GUARD(mutex_);
             id = nextId_++;
-            entries_.push_back({id, priority, std::move(callback)});
-            sortEntries();
+            ConstEntryListPtr cur = std::atomic_load(&entries_);
+            auto next = cur ? std::make_shared<EntryList>(*cur)
+                            : std::make_shared<EntryList>();
+            next->push_back({id, priority, std::move(callback)});
+            std::stable_sort(next->begin(), next->end(),
+                [](const Entry& a, const Entry& b) {
+                    return a.priority < b.priority;
+                });
+            std::atomic_store(&entries_, ConstEntryListPtr(next));
         }
         // Set EventListener outside lock (removeListener() may be called when disconnecting existing)
         // Capture weak_ptr to check if Event is still alive before removing
@@ -276,14 +296,11 @@ private:
     }
 
 public:
-    // Fire event
+    // Fire event. Hot path: a single atomic_load, no allocation, no mutex.
     void notify() {
-        std::vector<Entry> entriesCopy;
-        {
-            TC_LOCK_GUARD(mutex_);
-            entriesCopy = entries_;
-        }
-        for (auto& entry : entriesCopy) {
+        ConstEntryListPtr snapshot = std::atomic_load(&entries_);
+        if (!snapshot) return;
+        for (const auto& entry : *snapshot) {
             if (entry.callback) {
                 entry.callback();
             }
@@ -291,41 +308,32 @@ public:
     }
 
     size_t listenerCount() const {
-        TC_LOCK_GUARD(mutex_);
-        return entries_.size();
+        ConstEntryListPtr snapshot = std::atomic_load(&entries_);
+        return snapshot ? snapshot->size() : 0;
     }
 
     void clear() {
         TC_LOCK_GUARD(mutex_);
-        entries_.clear();
+        std::atomic_store(&entries_, ConstEntryListPtr{});
     }
 
 private:
-    struct Entry {
-        uint64_t id;
-        int priority;
-        Callback callback;
-    };
-
     void removeListener(uint64_t id) {
         TC_LOCK_GUARD(mutex_);
-        entries_.erase(
-            std::remove_if(entries_.begin(), entries_.end(),
+        ConstEntryListPtr cur = std::atomic_load(&entries_);
+        if (!cur) return;
+        auto next = std::make_shared<EntryList>(*cur);
+        next->erase(
+            std::remove_if(next->begin(), next->end(),
                 [id](const Entry& e) { return e.id == id; }),
-            entries_.end()
+            next->end()
         );
-    }
-
-    void sortEntries() {
-        std::stable_sort(entries_.begin(), entries_.end(),
-            [](const Entry& a, const Entry& b) {
-                return a.priority < b.priority;
-            });
+        std::atomic_store(&entries_, ConstEntryListPtr(next));
     }
 
     std::shared_ptr<bool> alive_;
-    mutable TC_MUTEX mutex_;
-    std::vector<Entry> entries_;
+    mutable TC_MUTEX mutex_;            // serializes listen / remove / clear
+    ConstEntryListPtr entries_;          // RCU snapshot, atomic_load/store
     uint64_t nextId_ = 0;
 };
 

--- a/core/include/tc/events/tcEvent.h
+++ b/core/include/tc/events/tcEvent.h
@@ -48,6 +48,28 @@ namespace EventPriority {
     constexpr int AfterApp = 200;
 }
 
+// Audio listener priorities for AudioEngine::audioOut.
+// Use these so that synth / effector / monitor addons (tcxSynth-*, tcxAudioEffector,
+// tcxScope, ...) compose deterministically even when the user instantiates them
+// in arbitrary order. The numeric gap leaves room for sub-categories (early effect
+// vs late effect, etc.) without renumbering the well-known ones.
+//
+// Recommended use:
+//   - Generator (oscillators / synths)  → produces audio into the buffer
+//   - Effect    (reverb / filter / EQ)  → reads + writes the buffer
+//   - Monitor   (scope / FFT / record)  → reads only, ideally last
+//
+// Listeners with no priority specified fall in `App = 100`, which equals
+// `Generator`. That matches the most common "user wrote a synth callback in
+// audioOut" case — explicit values are only needed for effect / monitor.
+namespace audio {
+namespace priority {
+    constexpr int Generator = 100;   // == EventPriority::App; the default
+    constexpr int Effect    = 500;
+    constexpr int Monitor   = 900;
+}
+}
+
 // ---------------------------------------------------------------------------
 // Event<T> - Event with arguments
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
3 commits since `30e51551` (Merge #106). Original PR was for just the README change; expanded scope after dev gained the Event refactor + priority constants.

## Highlights

### 1. `Event<T>::notify` RT-safety refactor (aa2ef188)

`notify()` previously copied the listener vector under a mutex on every fire, allocating on the hot path. From the audio thread (`audioOut`) this could stall on allocator-lock contention with a concurrent main-thread `listen()` / destroy.

Replaced the member with `std::shared_ptr<const std::vector<Entry>>` accessed via `std::atomic_load` / `atomic_store`. `notify()` does a single pointer load — no allocation, no mutex. `listen` / `remove` / `clear` do copy-on-write under the existing mutex.

#### Stress benchmark (30 s, 4 worker threads, simulated synth/effector/monitor on audioBus)

| metric | macOS Δ | **Windows Δ** |
|---|---|---|
| audioBus notify avg | -13% | **-41%** |
| audioBus notify p50 | (same) | **-50%** |
| audioBus notify p99 | 0% | **-50%** |
| tickBus notify avg | -21% | **-81%** |
| churnBus notify avg | -82% | **-90%** |
| churnBus notify p999 | -87% | **-94%** |
| slowChurnBus notify avg | (same) | **-88%** |

(Windows ベースラインは macOS の 30-100x 遅い — `HeapAlloc` 起因の lock contention。リファクタで notify path の alloc が消えたことで Windows での tail latency が劇的に改善。)

Trade-off: `listen` / `remove` get an alloc per call (copy-on-write). Still sub-µs on macOS, low-µs on Windows. These run on the main thread at setup / UI rate so the cost is irrelevant.

Semantics unchanged: each notify operates on the snapshot it loaded; adds and removes take effect from the next notify. Snapshot held by refcount, so a callback that triggers listen/remove won't crash the in-flight notify.

Same change applied to `Event<void>` specialisation.

### 2. `tc::audio::priority` constants (13edf8bc)

```cpp
namespace tc::audio::priority {
    constexpr int Generator = 100;   // == EventPriority::App default
    constexpr int Effect    = 500;
    constexpr int Monitor   = 900;
}
```

So synth / effector / monitor addons (tcxSynth-*, future tcxAudioEffector, tcxScope, ...) compose deterministically regardless of the order user code instantiates them. No behaviour change to `Event<T>` itself — constants only.

### 3. tcxLua README sandboxing section (9a8f91b5, closes #80)

PR #97 already flipped `LuaModulePreferences.io` / `.package` defaults to `false`; this commit adds a README section explaining the threat model, what's on by default, when it's safe to opt in, and when it is NOT (user-editable scripts, hot reload from disk, untrusted sources).

## Test plan

- [x] macOS: all 5 example builds pass; HotReloadExample, audioSynthExample, audioDeviceExample, nodeExample, eventsExample launch and behave correctly
- [x] macOS: EventStressTest 30 s run (see numbers above)
- [x] Windows: EventStressTest 30 s run (see numbers above)
- [ ] Linux: pending (will pull dev and run)
- [ ] Web: build-only verification (refactor is effectively a no-op without pthreads; only build pass is needed)
- [ ] Android: build-only verification

Detailed test plan: see Obsidian notes (`event-rt-safety-bench.md` + `event-rt-safety-test-plan.md`).
