### PR TITLE
dev → main: tcxOsc namespace fix, Windows trusscli cmake detection, MIDI/PBR fixes

### DIFF
--- a/addons/tcxMidi/CMakeLists.txt
+++ b/addons/tcxMidi/CMakeLists.txt
@@ -31,6 +31,11 @@ set(LIBREMIDI_TESTS        OFF CACHE BOOL "" FORCE)
 # URL (release tarball) instead of GIT_REPOSITORY: works even without git
 # installed, and the archive caches/extracts faster than a clone. URL_HASH
 # guards against a corrupted or tampered download.
+#
+# Pinned to the v5.4.3 release. Our WebMIDI fixes are upstreamed
+# (celtera/libremidi PR #216) but not yet in a tagged release, so we keep the
+# small export workaround below. (Pinning master directly is not viable yet -
+# its emscripten backend currently fails to compile, unrelated to our PR.)
 FetchContent_Declare(
     libremidi
     URL      https://github.com/celtera/libremidi/archive/refs/tags/v5.4.3.tar.gz
@@ -38,12 +43,12 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(libremidi)
 
-# libremidi's WebMIDI (Emscripten) backend calls Module._malloc / _free / HEAPU8
-# / UTF8ToString / stringToUTF8 / lengthBytesUTF8 from JS, but its own CMake only
+# v5.4.3's WebMIDI (Emscripten) backend calls Module._malloc / _free / HEAPU8 /
+# UTF8ToString / stringToUTF8 / lengthBytesUTF8 from JS, but its own CMake only
 # exports _free (forgetting _malloc) and no runtime methods - so receiving a MIDI
 # message throws "Module._malloc is not a function". Re-declare a complete export
-# list on the libremidi target (the last -sEXPORTED_FUNCTIONS wins) so the web
-# build actually works at runtime.
+# list on the libremidi target (the last -sEXPORTED_FUNCTIONS wins). Fixed
+# upstream in PR #216; remove this once we move to a release that includes it.
 if(EMSCRIPTEN)
     target_link_options(libremidi PUBLIC
         "SHELL:-sEXPORTED_FUNCTIONS=_main,_malloc,_free,_libremidi_devices_poll,_libremidi_devices_input"

--- a/addons/tcxMidi/README.md
+++ b/addons/tcxMidi/README.md
@@ -12,14 +12,14 @@ libremidi is fetched automatically at configure time via CMake `FetchContent`
 
 Per-platform system requirements:
 
-| Platform | Backend  | Extra install / notes |
-|----------|----------|-----------------------|
-| macOS    | CoreMIDI | none (bundled with the OS) |
-| iOS      | CoreMIDI | none (auto-enabled; BLE MIDI needs a Bluetooth usage description) |
-| Windows  | WinMM    | none |
-| Linux    | ALSA     | `libasound2-dev` |
-| Web      | WebMIDI  | Chromium + https, input only, **no sysex** |
-| Android  | AMidi    | **API level 31+** + manifest entries — see the Android section |
+| Platform | Backend  | Status | Extra install / notes |
+|----------|----------|--------|-----------------------|
+| macOS    | CoreMIDI | ✅ tested (in/out on a real device) | none (bundled with the OS) |
+| Web      | WebMIDI  | ✅ tested in Chrome (input; **no sysex**) | Chromium + https |
+| Windows  | WinMM    | ⚠️ untested (expected to work) | none |
+| Linux    | ALSA     | ⚠️ untested (expected to work) | `libasound2-dev` |
+| iOS      | CoreMIDI | ⚠️ untested (auto-enabled; BLE MIDI needs a Bluetooth usage description) | none |
+| Android  | AMidi    | 🧪 experimental — enumerates but open is broken (see Android note) | **API 31+** + manifest entries |
 
 JACK / PipeWire / network backends are disabled by default to keep the
 dependency footprint small (toggle the `LIBREMIDI_NO_*` options in

--- a/addons/tcxMidi/README.md
+++ b/addons/tcxMidi/README.md
@@ -16,7 +16,7 @@ Per-platform system requirements:
 |----------|----------|--------|-----------------------|
 | macOS    | CoreMIDI | ✅ tested (in/out on a real device) | none (bundled with the OS) |
 | Web      | WebMIDI  | ✅ tested in Chrome (input; **no sysex**) | Chromium + https |
-| Windows  | WinMM    | ⚠️ untested (expected to work) | none |
+| Windows  | WinMM    | ✅ tested (in/out + sysex on a real device) | none |
 | Linux    | ALSA     | ⚠️ untested (expected to work) | `libasound2-dev` |
 | iOS      | CoreMIDI | ⚠️ untested (auto-enabled; BLE MIDI needs a Bluetooth usage description) | none |
 | Android  | AMidi    | 🧪 experimental — enumerates but open is broken (see Android note) | **API 31+** + manifest entries |
@@ -108,6 +108,17 @@ Channel numbers are **1-16** throughout.
 `MidiIn::onMessage` is invoked on libremidi's input thread, **not** the main
 (update/draw) thread. Guard any shared data with a mutex, or use the polling
 API and drain `getNextMessage()` from `update()` (what the examples do).
+
+## Windows note
+
+The backend is **WinMM**. A USB device that exposes several MIDI ports (e.g. the
+Launchpad Mini Mk3's *DAW* + *MIDI* ports) appears as one port per jack, and
+WinMM renames every port after the first to `MIDIIN2 (<name>)` /
+`MIDIOUT2 (<name>)`. The index and parentheses are added by **Windows, not the
+device**, and the original jack labels (e.g. "DAW" / "MIDI") are lost — so
+`openPort(name)` matching that works on macOS/Linux may need a different string
+on Windows. WinMM also truncates port names to **31 characters**. When in doubt,
+print `listDevices()` and match on what you actually see.
 
 ## Web (Emscripten) note
 

--- a/addons/tcxMidi/src/tcxMidiTimecode.h
+++ b/addons/tcxMidi/src/tcxMidiTimecode.h
@@ -118,6 +118,10 @@ private:
     };
 
     bool decodeQuarterFrame(const std::vector<unsigned char>& message) {
+        // A well-formed MTC quarter frame is 0xF1 + 1 data byte. Reject a bare
+        // 0xF1 (or anything shorter) so we never read message[1] out of bounds.
+        if (message.size() < 2) return false;
+
         bool complete = false;
         unsigned char dataByte = message[1];
         unsigned char msgType = dataByte & 0xF0;

--- a/addons/tcxOsc/README.md
+++ b/addons/tcxOsc/README.md
@@ -1,0 +1,201 @@
+# tcxOsc
+
+OSC (Open Sound Control) send/receive for [TrussC](https://github.com/TrussC-org/TrussC).
+Talk to other OSC apps — TouchDesigner, Max/MSP, Pure Data, Processing, VJ/lighting
+software, phones — straight from a TrussC app over UDP. No external library; it's a
+self-contained encoder/decoder on top of the core `UdpSocket`.
+
+Supports the common OSC 1.0 types: `int32` (`i`), `float32` (`f`), `string` (`s`),
+`blob` (`b`), and the booleans `T`/`F`. Bundles (with NTP timetags) can nest messages
+and other bundles.
+
+> **Namespace:** the classes live in **`tcx`** (`tcx::OscSender`, `tcx::OscMessage`, …),
+> like every other addon. They used to live in the core `trussc` (`tc`) namespace by
+> mistake; `tc::OscSender` still compiles as a deprecated alias so existing code keeps
+> working, but it **will be removed in v1.0.0**. Migrate to `tcx::` — in practice just
+> add `using namespace tcx;` and the unqualified names (`OscSender`, …) keep working.
+
+## Features
+
+- **Sender** — multi-destination (`send()` fans out to every connected host), or
+  one-off `sendTo(host, port, …)`. Broadcast is enabled automatically for a `.255`
+  address.
+- **Receiver** — two ways to consume incoming messages:
+  - **Event style** (`onMessageReceived`, `onBundleReceived`, `onParseError`):
+    callbacks fire on the receive thread the moment a packet arrives.
+  - **Polling style** (`hasNewMessage()` / `getNextMessage()`): drain a queue from
+    `update()` on the main thread — no threading to think about.
+- **Bundles** — build nested `OscBundle`s with a timetag; the receiver dispatches each
+  contained message individually (and also emits `onBundleReceived`).
+- **Robust parser** — malformed packets are rejected (reported via `onParseError`)
+  rather than crashing.
+
+## Install
+
+Add it to your project's `addons.make`:
+
+```
+tcxOsc
+```
+
+…then `trusscli update`. There's no build config to write — it's header-only (plus two
+small `.cpp` files that TrussC auto-collects from `src/`).
+
+## Quick start
+
+```cpp
+#include <TrussC.h>
+#include <tcxOsc.h>
+using namespace tc;
+using namespace tcx;
+
+class tcApp : public App {
+    OscSender   sender_;
+    OscReceiver receiver_;
+    EventListener msgListener_;
+
+    void setup() override {
+        sender_.setup("127.0.0.1", 9000);   // send to host:port
+        receiver_.setup(9000);              // listen on port
+
+        // Event style: callback runs on the RECEIVE THREAD (see note below)
+        msgListener_ = receiver_.onMessageReceived.listen([](OscMessage& m) {
+            logNotice("osc") << "got " << m.toString();
+        });
+    }
+
+    void update() override {
+        OscMessage m("/wek/inputs");
+        m.addFloat(getMouseX() / (float)getWidth());
+        m.addFloat(getMouseY() / (float)getHeight());
+        sender_.send(m);
+    }
+};
+```
+
+## Threading: event vs polling
+
+Reception happens on a **background thread**, so the two consume styles differ in where
+your code runs:
+
+| | Event style | Polling style |
+|---|---|---|
+| Where your code runs | receive thread | main thread (your `update()`) |
+| Mutex needed for shared data | **yes** | no |
+| Setup | store an `EventListener` | just call `hasNewMessage()` |
+| Latency | lowest (fires on arrival) | one frame |
+
+Polling enables an internal buffer on the first `hasNewMessage()` call. Pick polling
+unless you specifically need lowest latency — it's the simpler, footgun-free path.
+
+```cpp
+// Polling style — all on the main thread, no locks:
+void update() override {
+    while (receiver_.hasNewMessage()) {
+        OscMessage m;
+        if (receiver_.getNextMessage(m)) {
+            logNotice("osc") << m.toString();
+        }
+    }
+}
+```
+
+## API
+
+### OscMessage
+
+```cpp
+OscMessage msg("/address");
+msg.addInt(42).addFloat(1.5f).addString("hi").addBool(true);
+msg.addBlob(data, size);
+
+string addr   = msg.getAddress();
+size_t n      = msg.getArgCount();
+string tags   = msg.getTypeTags();        // e.g. "ifs"
+char   t0     = msg.getArgType(0);        // 'i' / 'f' / 's' / 'b' / 'T' / 'F'
+int    i      = msg.getArgAsInt(0);       // int/float coerce to each other
+float  f      = msg.getArgAsFloat(1);
+string s      = msg.getArgAsString(2);
+vector<uint8_t> b = msg.getArgAsBlob(0);
+bool   flag   = msg.getArgAsBool(0);
+string debug  = msg.toString();           // "/address i:42 f:1.5 s:\"hi\""
+```
+
+### OscBundle
+
+```cpp
+OscBundle bundle;                  // immediate timetag by default
+bundle.addMessage(msg);
+bundle.addBundle(inner);           // bundles can nest
+bundle.setTimetag(ntp);            // optional scheduled execution (NTP format)
+
+size_t count = bundle.getElementCount();
+if (bundle.isMessage(i)) OscMessage m = bundle.getMessageAt(i);
+if (bundle.isBundle(i))  OscBundle  b = bundle.getBundleAt(i);
+```
+
+### OscSender
+
+```cpp
+bool setup(host, port);            // clear destinations + add one (convenience)
+bool connect(host, port);          // add a destination (auto-broadcast for ".255")
+void disconnect(host, port);       // remove one
+void disconnect();                 // remove all (socket stays open)
+void close();                      // close socket + clear destinations
+
+bool send(const OscMessage&);      // send to every connected destination
+bool send(const OscBundle&);
+bool sendTo(host, port, const OscMessage&);   // one-off, ignores destination list
+bool sendTo(host, port, const OscBundle&);
+
+bool isConnected() const;
+const vector<Destination>& getConnectedAddresses() const;
+```
+
+### OscReceiver
+
+```cpp
+bool setup(port);                  // bind + start the receive thread
+void close();
+int  getPort() const;
+bool isListening() const;
+
+// Events (fire on the receive thread)
+Event<OscMessage> onMessageReceived;
+Event<OscBundle>  onBundleReceived;
+Event<string>     onParseError;
+
+// Polling (call from update(); buffer turns on at first hasNewMessage())
+bool   hasNewMessage();
+bool   getNextMessage(OscMessage& out);
+void   setBufferSize(size_t);      // default 100; oldest dropped when full
+size_t getBufferSize() const;
+```
+
+## Examples
+
+Both examples are self-contained ImGui apps that send to **and** receive from
+themselves on `127.0.0.1`, so you can try OSC without a second machine. Type an address,
+toggle int/float/string args, and watch them arrive in the receive pane.
+
+- **`example-osc-event/`** (port 9000) — the **event** style. Registers
+  `onMessageReceived` / `onParseError` listeners and shows the key gotcha: callbacks run
+  on the receive thread, so the log buffer is guarded with a `mutex`. Also demonstrates
+  building and sending a **bundle**.
+- **`example-osc-polling/`** (port 9001) — the **polling** style. Drains messages with
+  `hasNewMessage()` / `getNextMessage()` inside `update()` on the main thread — no mutex,
+  simpler code. Start here if you're new to OSC.
+
+```bash
+cd example-osc-polling
+trusscli update
+trusscli run
+```
+
+To poke it from outside, send from any OSC tool (or another TrussC app) to the port the
+example prints in its title bar.
+
+## License
+
+MIT (author: tettou771). No third-party dependencies — the OSC codec is implemented
+here directly on top of the core `UdpSocket`.

--- a/addons/tcxOsc/src/tcxOscBundle.cpp
+++ b/addons/tcxOsc/src/tcxOscBundle.cpp
@@ -1,6 +1,6 @@
 #include "tcxOscBundle.h"
 
-namespace trussc {
+namespace tcx {
 
 using namespace osc_internal;
 
@@ -102,4 +102,4 @@ OscBundle OscBundle::fromBytes(const uint8_t* data, size_t size, bool& ok) {
     return bundle;
 }
 
-}  // namespace trussc
+}  // namespace tcx

--- a/addons/tcxOsc/src/tcxOscBundle.h
+++ b/addons/tcxOsc/src/tcxOscBundle.h
@@ -3,7 +3,7 @@
 #include "tcxOscMessage.h"
 #include <variant>
 
-namespace trussc {
+namespace tcx {
 
 // =============================================================================
 // OscBundle - OSC bundle class
@@ -99,4 +99,11 @@ private:
     std::vector<Element> elements_;
 };
 
+}  // namespace tcx
+
+// -----------------------------------------------------------------------------
+// Backward compatibility: see tcxOscMessage.h. DEPRECATED — removed in v1.0.0.
+// -----------------------------------------------------------------------------
+namespace trussc {
+using tcx::OscBundle;
 }  // namespace trussc

--- a/addons/tcxOsc/src/tcxOscMessage.cpp
+++ b/addons/tcxOsc/src/tcxOscMessage.cpp
@@ -1,7 +1,7 @@
 #include "tcxOscMessage.h"
 #include <sstream>
 
-namespace trussc {
+namespace tcx {
 
 using namespace osc_internal;
 
@@ -186,4 +186,4 @@ std::string OscMessage::toString() const {
     return oss.str();
 }
 
-}  // namespace trussc
+}  // namespace tcx

--- a/addons/tcxOsc/src/tcxOscMessage.h
+++ b/addons/tcxOsc/src/tcxOscMessage.h
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <cstring>
 
-namespace trussc {
+namespace tcx {
 
 // =============================================================================
 // Endian conversion utilities
@@ -185,4 +185,15 @@ private:
     std::vector<ArgVariant> args_;
 };
 
+}  // namespace tcx
+
+// -----------------------------------------------------------------------------
+// Backward compatibility: tcxOsc historically lived in `trussc` (tc).
+// The canonical namespace is now `tcx`; this alias keeps existing
+// `tc::OscMessage` code compiling. DEPRECATED — will be removed in v1.0.0.
+// (No [[deprecated]] attribute: under the usual `using namespace tc;` it would
+//  warn on idiomatic unqualified use too. See tcxOsc README for migration.)
+// -----------------------------------------------------------------------------
+namespace trussc {
+using tcx::OscMessage;
 }  // namespace trussc

--- a/addons/tcxOsc/src/tcxOscReceiver.h
+++ b/addons/tcxOsc/src/tcxOscReceiver.h
@@ -9,7 +9,7 @@
 #include <mutex>
 #include <atomic>
 
-namespace trussc {
+namespace tcx {
 
 // =============================================================================
 // OscReceiver - OSC receiver class
@@ -17,9 +17,9 @@ namespace trussc {
 class OscReceiver {
 public:
     // Events
-    Event<OscMessage> onMessageReceived;   // Message received
-    Event<OscBundle> onBundleReceived;     // Bundle received
-    Event<std::string> onParseError;       // Parse error (for robustness)
+    tc::Event<OscMessage> onMessageReceived;   // Message received
+    tc::Event<OscBundle> onBundleReceived;     // Bundle received
+    tc::Event<std::string> onParseError;       // Parse error (for robustness)
 
     OscReceiver() = default;
     ~OscReceiver() { close(); }
@@ -37,11 +37,11 @@ public:
         port_ = port;
 
         // Set receive event handler
-        receiveListener_ = socket_.onReceive.listen([this](UdpReceiveEventArgs& args) {
+        receiveListener_ = socket_.onReceive.listen([this](tc::UdpReceiveEventArgs& args) {
             handleReceive(args);
         });
 
-        errorListener_ = socket_.onError.listen([this](UdpErrorEventArgs& args) {
+        errorListener_ = socket_.onError.listen([this](tc::UdpErrorEventArgs& args) {
             std::string msg = "Socket error: " + args.message;
             onParseError.notify(msg);
         });
@@ -101,7 +101,7 @@ public:
     size_t getBufferSize() const { return bufferMax_; }
 
 private:
-    void handleReceive(UdpReceiveEventArgs& args) {
+    void handleReceive(tc::UdpReceiveEventArgs& args) {
         if (args.data.empty()) return;
 
         const uint8_t* data = reinterpret_cast<const uint8_t*>(args.data.data());
@@ -175,10 +175,10 @@ private:
         }
     }
 
-    UdpSocket socket_;
+    tc::UdpSocket socket_;
     int port_ = 0;
-    EventListener receiveListener_;
-    EventListener errorListener_;
+    tc::EventListener receiveListener_;
+    tc::EventListener errorListener_;
 
     // Polling buffer
     std::queue<OscMessage> messageQueue_;
@@ -187,4 +187,11 @@ private:
     size_t bufferMax_ = 100;
 };
 
+}  // namespace tcx
+
+// -----------------------------------------------------------------------------
+// Backward compatibility: see tcxOscMessage.h. DEPRECATED — removed in v1.0.0.
+// -----------------------------------------------------------------------------
+namespace trussc {
+using tcx::OscReceiver;
 }  // namespace trussc

--- a/addons/tcxOsc/src/tcxOscSender.h
+++ b/addons/tcxOsc/src/tcxOscSender.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <algorithm>
 
-namespace trussc {
+namespace tcx {
 
 // =============================================================================
 // OscSender - OSC sender class (multi-destination, sendTo-based)
@@ -130,8 +130,15 @@ public:
     bool isConnected() const { return !destinations_.empty(); }
 
 private:
-    UdpSocket socket_;
+    tc::UdpSocket socket_;
     std::vector<Destination> destinations_;
 };
 
+}  // namespace tcx
+
+// -----------------------------------------------------------------------------
+// Backward compatibility: see tcxOscMessage.h. DEPRECATED — removed in v1.0.0.
+// -----------------------------------------------------------------------------
+namespace trussc {
+using tcx::OscSender;
 }  // namespace trussc

--- a/core/include/tc/3d/tcMeshPbrPipeline.h
+++ b/core/include/tc/3d/tcMeshPbrPipeline.h
@@ -18,19 +18,37 @@
 // v1 limitations:
 //   - Swapchain target only. Drawing PBR mesh inside an Fbo pass will trigger
 //     a sokol_gfx pipeline format mismatch. Phase 4 will add per-target cache.
-//   - Immediate-mode sg_draw; ordering with sokol_gl is "PBR below 2D overlay".
-//     See plan for the deferred-layer optimization (Phase later).
+//   - Swapchain PBR draws are deferred into the per-layer flush
+//     (flushDeferredShaderDraws) so they composite with sokol_gl 2D in
+//     submission order — a 2D background drawn before a PBR mesh now stays
+//     behind it. FBO-pass PBR draws remain immediate.
 //
 // =============================================================================
 
 #include <cstring>
 #include <map>
+#include <vector>
 
 #include "tc/gpu/shaders/meshPbr.glsl.h"
 #include "tc/gpu/shaders/shadowDepth.glsl.h"
 
 namespace trussc {
 namespace internal {
+
+// A fully-resolved PBR mesh draw, captured at submission time (pipeline +
+// bindings + packed uniforms) so it can be replayed later. Used to defer
+// swapchain PBR draws into the same per-layer flush as sokol_gl 2D and deferred
+// shaders, so everything composites in submission order. See PbrPipeline::drawMesh.
+struct PbrDrawCommand {
+    sg_pipeline        pip;
+    sg_bindings        bind;
+    tc_pbr_vs_params_t vsp;
+    tc_pbr_fs_params_t fsp;
+    int                indexCount;
+    int                vertexCount;
+};
+struct DeferredPbrDraw { int layerId; PbrDrawCommand cmd; };
+inline std::vector<DeferredPbrDraw> deferredPbrDraws;
 
 class PbrPipeline {
 public:
@@ -91,17 +109,10 @@ public:
             sampleCount = sapp_sample_count();
         }
 
-        // Ensure we are inside a render pass
-        if (!internal::inFboPass) {
-            ensureSwapchainPass();
-        }
-
-        // Flush any pending sokol_gl commands so they are drawn *before* this
-        // PBR mesh. This preserves "drawBox → mesh.draw() → drawBox" intent
-        // where the first drawBox should appear beneath the PBR mesh.
-        sgl_draw();
-
-        sg_apply_pipeline(getPipeline(colorFmt, sampleCount));
+        // Resolve the pipeline now; GPU submission happens at the end of this
+        // function — deferred for the swapchain (so it composites with sokol_gl
+        // in submission order), immediate inside an FBO pass.
+        sg_pipeline pip = getPipeline(colorFmt, sampleCount);
 
         // --- Bindings -------------------------------------------------------
         sg_bindings bind = {};
@@ -206,7 +217,7 @@ public:
             bind.samplers[SMP_tc_pbr_shadowMapSmp] = fallbackSampler_;
         }
 
-        sg_apply_bindings(&bind);
+        // (bindings applied later, in executePbrDraw)
 
         // --- vs_params ------------------------------------------------------
         tc_pbr_vs_params_t vsp = {};
@@ -223,9 +234,6 @@ public:
         std::memcpy(vsp.model,     modelT.m,     sizeof(vsp.model));
         std::memcpy(vsp.viewProj,  viewProjT.m,  sizeof(vsp.viewProj));
         std::memcpy(vsp.normalMat, normalMatT.m, sizeof(vsp.normalMat));
-
-        sg_range vsRange = { &vsp, sizeof(vsp) };
-        sg_apply_uniforms(UB_tc_pbr_vs_params, &vsRange);
 
         // --- fs_params ------------------------------------------------------
         tc_pbr_fs_params_t fsp = {};
@@ -340,15 +348,34 @@ public:
             fsp.shadowParams[0] = -1.0f;
         }
 
-        sg_range fsRange = { &fsp, sizeof(fsp) };
-        sg_apply_uniforms(UB_tc_pbr_fs_params, &fsRange);
-
-        // --- Draw -----------------------------------------------------------
-        if (mesh.getGpuIndexCount() > 0) {
-            sg_draw(0, mesh.getGpuIndexCount(), 1);
+        // --- Submit ---------------------------------------------------------
+        // Package the fully-resolved draw. Inside an FBO pass we submit it
+        // immediately (that pass is self-contained). For the swapchain we DEFER
+        // it: append to deferredPbrDraws and bump the sokol_gl layer so any 2D
+        // drawn after this mesh composites on top of it (same trick the deferred
+        // shaders use). flushDeferredShaderDraws() replays it per layer.
+        PbrDrawCommand cmd{ pip, bind, vsp, fsp,
+                            mesh.getGpuIndexCount(), mesh.getGpuVertexCount() };
+        if (internal::inFboPass) {
+            sgl_draw();   // keep prior sokol_gl beneath this mesh in the FBO pass
+            executePbrDraw(cmd);
         } else {
-            sg_draw(0, mesh.getGpuVertexCount(), 1);
+            internal::deferredPbrDraws.push_back({ internal::sglLayerNext, cmd });
+            internal::sglLayerNext++;
+            sgl_layer(internal::sglLayerNext);
         }
+    }
+
+    // Submit a packaged PBR draw to the GPU. Used immediately for FBO passes and
+    // replayed from flushDeferredShaderDraws() for the swapchain.
+    void executePbrDraw(const PbrDrawCommand& c) {
+        sg_apply_pipeline(c.pip);
+        sg_apply_bindings(&c.bind);
+        sg_range vr{ &c.vsp, sizeof(c.vsp) };
+        sg_apply_uniforms(UB_tc_pbr_vs_params, &vr);
+        sg_range fr{ &c.fsp, sizeof(c.fsp) };
+        sg_apply_uniforms(UB_tc_pbr_fs_params, &fr);
+        sg_draw(0, c.indexCount > 0 ? c.indexCount : c.vertexCount, 1);
     }
 
 private:

--- a/core/include/tc/gpu/tcShader.h
+++ b/core/include/tc/gpu/tcShader.h
@@ -496,10 +496,20 @@ inline void flushDeferredShaderDraws() {
                 draw.shader->executeDeferredDraw(draw.vertices, draw.type);
             }
         }
+
+        // Deferred PBR mesh draws — same per-layer ordering, so PBR composites
+        // with sokol_gl 2D in submission order (a 2D background drawn first
+        // stays behind the meshes).
+        for (auto& d : internal::deferredPbrDraws) {
+            if (d.layerId == layer) {
+                internal::getPbrPipeline().executePbrDraw(d.cmd);
+            }
+        }
     }
 
     // Clear deferred draws for next frame
     internal::deferredShaderDraws.clear();
+    internal::deferredPbrDraws.clear();
 
     // Reset layer for next frame
     internal::sglLayerNext = 0;

--- a/docs/ADDONS.md
+++ b/docs/ADDONS.md
@@ -304,7 +304,7 @@ namespace tcx::addonname {
 |-------|-----------|
 | tcxBox2d | `tcx::box2d` |
 | tcxGui | `tcx::gui` |
-| tcxOsc | `tcx::osc` |
+| tcxOsc | `tcx` (classes are `Osc`-prefixed: `OscSender`, `OscMessage`, …) |
 
 **Note:** TrussC core uses `tc::`. Addons use `tcx::`.
 

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -56,6 +56,17 @@ trusscli new path/to/myNewApp
 
 TrussC uses **CMake Presets** to ensure consistent build configurations across platforms (macOS, Windows, Linux, Web).
 
+> **CMake on Windows.** Installing CMake is recommended (`winget install
+> Kitware.CMake`) — without it the build may fail in some cases. It is not
+> strictly required, though: the CMake MSI ships with Visual Studio *inside* the
+> VS install (not on `PATH`), and `trusscli` (`build`/`run`/`upgrade`/`doctor`)
+> auto-detects the CMake bundled with the newest installed Visual Studio (or
+> Build Tools) that has the "C++ CMake tools" component, prepending it to `PATH`
+> for the build. So a `trusscli build` can succeed even when `cmake --version`
+> reports "not found" in a plain shell. Raw `cmake --preset` invocations (below)
+> still need cmake on `PATH` yourself. Run `trusscli doctor` to see which CMake
+> is detected.
+
 ### Using VSCode (Recommended)
 1. Install **CMake Tools** extension.
 2. Open the project folder.

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1237,10 +1237,18 @@ void tcApp::setup() {
 - Verify: `cmake --version`
 - If not installed:
   - macOS: `brew install cmake` or download from cmake.org
-  - Windows: Download from cmake.org, check "Add to PATH" during install
+  - Windows: `winget install Kitware.CMake` (or download from cmake.org, check "Add to PATH")
   - Linux: `sudo apt install cmake`
 - CMake installation is a common stumbling block — provide careful support here
 - Confirm cmake is working before proceeding to next step
+- **Windows — keep recommending the install, but don't be surprised if it builds
+  without one:** Still tell the user to install CMake as above (without it the
+  build can fail in some cases). It is *not* strictly required, though: if Visual
+  Studio was installed with the "C++ CMake tools" component, trusscli auto-detects
+  the CMake bundled with VS and adds it to PATH for the build. So `cmake --version`
+  in a plain shell may say "not found" while `trusscli build`/`run` still succeed.
+  On Windows, treat **`trusscli doctor`** (which reports the CMake trusscli will
+  actually use) as the source of truth rather than a bare `cmake --version`.
 
 ### Getting Started
 - If user says they already have cmake + compiler, skip to building trusscli

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1243,12 +1243,20 @@ void tcApp::setup() {
 - Confirm cmake is working before proceeding to next step
 - **Windows — keep recommending the install, but don't be surprised if it builds
   without one:** Still tell the user to install CMake as above (without it the
-  build can fail in some cases). It is *not* strictly required, though: if Visual
-  Studio was installed with the "C++ CMake tools" component, trusscli auto-detects
-  the CMake bundled with VS and adds it to PATH for the build. So `cmake --version`
-  in a plain shell may say "not found" while `trusscli build`/`run` still succeed.
-  On Windows, treat **`trusscli doctor`** (which reports the CMake trusscli will
-  actually use) as the source of truth rather than a bare `cmake --version`.
+  build can fail in some cases). It is *not* strictly required, though. How it
+  works: the CMake MSI ships *inside* the Visual Studio install, not on `PATH`.
+  When `cmake` isn't on `PATH`, trusscli locates that bundled cmake — it queries
+  `vswhere` for installed VS/Build Tools (with the "C++ CMake tools" component),
+  takes the newest one's `...\CommonExtensions\Microsoft\CMake\...\cmake.exe`, and
+  prepends its folder to **its own process `PATH`**, which the cmake/ninja/compiler
+  it spawns then inherit. Two consequences to remember:
+    - This is *process-local*: it does **not** add cmake to the user's shell
+      `PATH`, so a bare `cmake` typed in the terminal (or a raw `cmake --preset`)
+      still won't resolve — only `trusscli`-driven builds benefit.
+    - So `cmake --version` in a plain shell may say "not found" while
+      `trusscli build`/`run` succeed. Treat **`trusscli doctor`** (it reports the
+      cmake trusscli will actually use) as the source of truth on Windows, not a
+      bare `cmake --version`.
 
 ### Getting Started
 - If user says they already have cmake + compiler, skip to building trusscli

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -27,7 +27,8 @@ Built on C++20 + sokol, it's simple to write and runs cross-platform.
 | Windows | Visual Studio 2022 |
 | Linux | GCC 10+ or Clang 10+ |
 
-**CMake** is also required:
+**CMake** is also required. Please install it — without it the build may fail
+in some cases:
 ```bash
 # macOS
 brew install cmake
@@ -38,6 +39,13 @@ winget install Kitware.CMake
 # Linux
 sudo apt install cmake
 ```
+
+> **Windows note:** If you installed Visual Studio with the "C++ CMake tools"
+> component (part of the "Desktop development with C++" workload), TrussC
+> automatically picks up the CMake bundled with Visual Studio, so the build may
+> succeed even without the `winget` install above. Installing it anyway is still
+> recommended as a reliable fallback. Run `trusscli doctor` to see which CMake
+> is detected.
 
 ### Linux Dependencies
 

--- a/docs/GET_STARTED_jp.md
+++ b/docs/GET_STARTED_jp.md
@@ -27,7 +27,7 @@ C++20 + sokol で構築されており、シンプルに書けてクロスプラ
 | Windows | Visual Studio 2022 |
 | Linux | GCC 10+ または Clang 10+ |
 
-**CMake** も必要です:
+**CMake** も必要です。インストールしてください（入れない場合、ビルドが通らないことがあります）:
 ```bash
 # macOS
 brew install cmake
@@ -38,6 +38,12 @@ winget install Kitware.CMake
 # Linux
 sudo apt install cmake
 ```
+
+> **Windows での補足:** Visual Studio を「C++ によるデスクトップ開発」ワークロード
+> （「C++ CMake tools」コンポーネントを含む）でインストールしている場合、TrussC は
+> Visual Studio 同梱の CMake を自動的に見つけるため、上記の `winget` を入れなくても
+> ビルドが通ることがあります。とはいえ確実なフォールバックとして入れておくことを推奨
+> します。どの CMake が検出されているかは `trusscli doctor` で確認できます。
 
 ### Linux の依存パッケージ
 

--- a/examples/tests/AllFeaturesExample/src/tcApp.h
+++ b/examples/tests/AllFeaturesExample/src/tcApp.h
@@ -35,8 +35,8 @@ public:
 
     // Addon instances to verify linking
     tcx::box2d::World box2d;
-    tc::OscSender oscSender;
-    tc::OscReceiver oscReceiver;
+    tcx::OscSender oscSender;
+    tcx::OscReceiver oscReceiver;
 
     // LUT addon
     tcx::lut::Lut3D lut;

--- a/examples/windowing/noWindowModeExample/src/tcApp.cpp
+++ b/examples/windowing/noWindowModeExample/src/tcApp.cpp
@@ -13,7 +13,7 @@
 // Available features in headless mode:
 //   - Serial communication (tc::Serial)
 //   - Network: TCP/UDP sockets (tc::TcpClient, TcpServer, UdpSocket)
-//   - OSC: Open Sound Control (tc::OscSender, OscReceiver)
+//   - OSC: Open Sound Control (tcx::OscSender, tcx::OscReceiver)
 //   - File I/O: read/write files (tc::loadFile, saveFile, etc.)
 //   - JSON/XML parsing (tc::Json, tc::Xml)
 //   - Math utilities (tc::Vec2, Vec3, Mat4, noise, etc.)

--- a/tools/src/VsDetector.cpp
+++ b/tools/src/VsDetector.cpp
@@ -32,7 +32,10 @@ vector<VsVersionInfo> VsDetector::detectInstalledVersions() {
         vswherePath = "vswhere.exe";
     }
 
-    string vswhereCmd = "\"" + vswherePath + "\" -all -format json";
+    // -products * so standalone "Build Tools for Visual Studio" (no IDE) is
+    // enumerated too, not just Community/Professional/Enterprise. cmd.exe does
+    // not glob-expand the '*', so it reaches vswhere literally ("all products").
+    string vswhereCmd = "\"" + vswherePath + "\" -all -products * -format json";
 
     FILE* pipe = _popen(vswhereCmd.c_str(), "r");
     if (pipe) {

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -2943,6 +2943,32 @@ static string findCMake() {
     return "cmake";
 }
 
+// Ensure a `cmake` executable is resolvable on this process's PATH.
+//
+// On Windows the Azure Kinect-style situation is common: cmake.exe ships
+// *inside* the Visual Studio install (Common7\IDE\CommonExtensions\...\CMake),
+// not on the system PATH. The GUI/configure path runs cmake through a VS
+// developer prompt (vcvarsall) so it is found there, but `trusscli
+// build`/`run`/`upgrade` spawn `cmake` directly — and `doctor` probes it via
+// the shell — so without cmake on PATH those all fail ("CMake not found" /
+// build exit -1). When cmake is not already resolvable, prepend the newest
+// installed VS's cmake bin dir to this process's PATH (inherited by every
+// child we spawn). No-op when cmake is already on PATH, so existing,
+// properly-configured setups are completely unaffected.
+static void ensureCMakeOnPath() {
+#ifdef _WIN32
+    if (captureCommand("where cmake 2>NUL").exitCode == 0) return;  // already on PATH
+    for (const auto& vs : VsDetector::detectInstalledVersions()) {
+        if (vs.cmakePath.empty() || !fs::exists(vs.cmakePath)) continue;
+        string binDir = fs::path(vs.cmakePath).parent_path().string();
+        const char* cur = getenv("PATH");
+        string newPath = binDir + ";" + (cur ? cur : "");
+        _putenv_s("PATH", newPath.c_str());
+        return;
+    }
+#endif
+}
+
 static void printBuildHelp() {
     cout << "Usage: trusscli build [options]\n"
          << "\n"
@@ -3683,6 +3709,10 @@ int main(int argc, char* argv[]) {
         printVersion();
         return 0;
     }
+
+    // On Windows, make sure `cmake` is resolvable before any subcommand that
+    // spawns or probes it (build/run/upgrade/doctor). No-op if already on PATH.
+    ensureCMakeOnPath();
 
     // Dispatch
     vector<string> subArgs(args.begin() + 1, args.end());


### PR DESCRIPTION
## Summary

Integrates the current `dev` into `main`.

### trusscli (Windows)
- **fix: locate VS-bundled cmake on Windows when not on PATH** + detect standalone VS Build Tools via `vswhere -products *`. `build`/`run`/`upgrade`/`doctor` previously failed with "CMake not found" when cmake shipped inside the VS install. Fully `#ifdef _WIN32` and a no-op when cmake is already on PATH — Mac/Linux and existing setups are unaffected. (+docs in BUILD_SYSTEM / FOR_AI_ASSISTANT / GET_STARTED)

### OSC (tcxOsc)
- **refactor: move tcxOsc from `trussc` to the `tcx` namespace**, matching every other addon. Backward compatible via silent `using tcx::X;` aliases (`tc::OscX` still compiles, types verified identical, no warnings; not `[[deprecated]]` because that would warn on idiomatic unqualified use under `using namespace tc;`). Removal in v1.0.0 documented in the new README.
- **add: tcxOsc README** (usage, event-vs-polling threading, full API).
- **fix: docs/ADDONS.md** namespace table; examples use `tcx::`.

### MIDI (tcxMidi)
- **fix: guard MTC quarter-frame against a 1-byte `0xF1`** (out-of-bounds read).
- **doc: Windows verified on WinMM** (Launchpad Mini Mk3, in/out+sysex) + multi-port rename / 31-char note; libremidi workaround upstreamed (PR #216).

### Graphics (core)
- **feat: defer swapchain PBR draws** so they composite with sokol_gl in draw order (`tcMeshPbrPipeline.h`, `tcShader.h`).

## Testing
- tcxOsc: both examples build on macOS, zero deprecation warnings; `static_assert(__is_same(...))` confirms `tcx::` / `trussc::` identical.
- trusscli: builds on macOS after the merge (Windows path is `#ifdef`'d out); Windows behavior verified on the contributor's machine.
- MIDI/PBR: prior `dev` work.