### PR TITLE
Promote dev → main: async timers, MouseEventArgs slimming, addon CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    timeout-minutes: 120
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +83,13 @@ jobs:
              echo "Running quick build (AllFeaturesExample only)..."
              ./examples/build_all.py --test-only --verbose
           fi
+
+      # Behavioral test harnesses bundled with monorepo addons (addons/*/tests/):
+      # built AND run (non-zero exit fails the job). Runs on every build, not just
+      # [full] - the tests are small console projects. No-op when none exist.
+      - name: Build & run addon tests
+        shell: bash
+        run: ./examples/build_all.py --addon-tests-only --verbose
 
       - name: Build HotReloadExample (host/guest split smoke test)
         shell: bash

--- a/addons/tcxDepthCamera/example-synthetic/src/tcApp.cpp
+++ b/addons/tcxDepthCamera/example-synthetic/src/tcApp.cpp
@@ -39,17 +39,45 @@ void tcApp::draw() {
     popMatrix();
     view.end();
 
+    // 2D stream previews along the bottom: color + depth thumbnails. Each is the
+    // camera's cached getXxxImage() - no per-app upload code. Drawn one after
+    // another, advancing tx. (Synthetic has no IR stream, so no IR thumbnail.)
+    const float th = 130.0f, pad = 10.0f;
+    const float ty = getWindowHeight() - th - pad;
+    float tx = pad;
+    setColor(1.0f);
+
+    if (camera->hasColor()) {
+        Image& color = camera->getColorImage();
+        if (color.isAllocated()) {
+            float tw = th * color.getWidth() / (float)color.getHeight();
+            color.draw(tx, ty, tw, th);
+            drawBitmapString("color", tx + 4, ty - 6);
+            tx += tw + pad;
+        }
+    }
+
+    Image& depth = camera->getDepthImage({.nearM = 1.5f, .farM = 3.5f, .repeat = repeatDepth});
+    if (depth.isAllocated()) {
+        float tw = th * depth.getWidth() / (float)depth.getHeight();
+        depth.draw(tx, ty, tw, th);
+        drawBitmapString(repeatDepth ? "depth [repeat]" : "depth", tx + 4, ty - 6);
+        tx += tw + pad;
+    }
+
     setColor(1.0f);
     string hud = "SyntheticDepthCamera (no hardware)\n";
     hud += to_string(cloud.getNumVertices()) + " points";
     hud += colored ? "  [colored]" : "  [plain]";
-    hud += "\nC: toggle color    1-4: decimation    drag: orbit";
+    hud += "\nC: toggle color    R: depth repeat    1-4: decimation    drag: orbit";
     drawBitmapString(hud, 20, 20);
 }
 
 void tcApp::keyPressed(int key) {
     if (key == 'c' || key == 'C') {
         colored = !colored;
+    } else if (key == 'r' || key == 'R') {
+        repeatDepth = !repeatDepth;
     } else if (key >= '1' && key <= '4') {
         step = key - '0';
     }

--- a/addons/tcxDepthCamera/example-synthetic/src/tcApp.h
+++ b/addons/tcxDepthCamera/example-synthetic/src/tcApp.h
@@ -23,4 +23,5 @@ private:
     Mesh cloud;
     bool colored = false;   // uniform color by default (clearer shape); C toggles depth-keyed
     int step = 1;
+    bool repeatDepth = false;   // R toggles the depth preview's repeating band
 };

--- a/addons/tcxDepthCamera/src/tcxDepthCamera.h
+++ b/addons/tcxDepthCamera/src/tcxDepthCamera.h
@@ -35,6 +35,7 @@
 // Headers:
 //   tcxDepthTypes.h           - DepthSensorType, DepthIntrinsics, DepthFrame,
 //                               StreamFreshness, DepthMeshOptions
+//   tcxDepthImage.h           - colorToImage/depthToImage/irToImage converters
 //   tcxDepthCameraBase.h      - DepthCamera (the concrete, thread-safe base)
 //   tcxDepthCapabilities.h    - IStereoRaw, IConfidenceMap (device-specific)
 //   tcxDepthCast.h            - as<>() / is<>() / isStereoCam() capability queries
@@ -43,6 +44,7 @@
 // =============================================================================
 
 #include "tcxDepthTypes.h"
+#include "tcxDepthImage.h"
 #include "tcxDepthCameraBase.h"
 #include "tcxDepthCapabilities.h"
 #include "tcxDepthCast.h"

--- a/addons/tcxDepthCamera/src/tcxDepthCameraBase.h
+++ b/addons/tcxDepthCamera/src/tcxDepthCameraBase.h
@@ -34,6 +34,7 @@
 // =============================================================================
 
 #include "tcxDepthTypes.h"
+#include "tcxDepthImage.h"
 #include <mutex>
 #include <utility>
 
@@ -94,6 +95,10 @@ public:
             if (f.any()) std::swap(back_, front_);
             freshness_ = f;
         }
+        // Mark preview Images for re-upload on the next getXxxImage() call.
+        if (freshness_.color)    colorImageDirty_    = true;
+        if (freshness_.depth)    depthImageDirty_    = true;
+        if (freshness_.infrared) irImageDirty_       = true;
     }
 
     // -------------------------------------------------------------------------
@@ -267,6 +272,36 @@ public:
     }
 
     // -------------------------------------------------------------------------
+    // Preview Images (cached, uploaded once per new frame)
+    // -------------------------------------------------------------------------
+    // Convenience wrappers over the tcxDepthImage.h converters: a ready-to-draw
+    // Image of each stream, cached and re-uploaded only when that stream gets a
+    // new frame. For the common "just show it" case - no per-app boilerplate:
+    //
+    //   if (cam->hasColor()) cam->getColorImage().draw(0, 0);
+    //   cam->getDepthImage({.nearM = 0.3f, .farM = 4.0f}).draw(0, 0);
+    //
+    // The returned Image is non-const (draw() needs the texture); it stays valid
+    // until the next call. If you own the Image yourself (e.g. a DepthFrame from
+    // playback), use the free colorToImage()/depthToImage()/irToImage() instead.
+    Image& getColorImage() {
+        if (colorImageDirty_) { colorToImage(front_->color, colorImage_); colorImageDirty_ = false; }
+        return colorImage_;
+    }
+    Image& getDepthImage(const DepthImageView& view = {}) {
+        if (depthImageDirty_ || view != depthImageLastView_) {
+            depthToImage(*front_, depthImage_, view);
+            depthImageLastView_ = view;
+            depthImageDirty_ = false;
+        }
+        return depthImage_;
+    }
+    Image& getInfraredImage() {
+        if (irImageDirty_) { irToImage(front_->ir, irImage_); irImageDirty_ = false; }
+        return irImage_;
+    }
+
+    // -------------------------------------------------------------------------
     // Mesh / point cloud
     // -------------------------------------------------------------------------
 
@@ -354,6 +389,11 @@ private:
     mutable bool warnedDepth_ = false;
     mutable bool warnedColor_ = false;
     mutable bool warnedInfrared_ = false;
+
+    // Cached preview Images (uploaded lazily, once per new frame; see getXxxImage()).
+    Image colorImage_, depthImage_, irImage_;
+    bool colorImageDirty_ = false, depthImageDirty_ = false, irImageDirty_ = false;
+    DepthImageView depthImageLastView_{};
 };
 
 } // namespace tcx

--- a/addons/tcxDepthCamera/src/tcxDepthImage.h
+++ b/addons/tcxDepthCamera/src/tcxDepthImage.h
@@ -1,0 +1,111 @@
+#pragma once
+
+// =============================================================================
+// tcxDepthImage.h - turn raw depth-camera streams into displayable Images
+// =============================================================================
+//
+// Stateless converters that fill a caller-owned Image from a DepthFrame's raw
+// streams (color / depth / IR). They operate on frame data, so they work on a
+// live camera frame OR one obtained from playback. The camera offers cached
+// getColorImage()/getDepthImage()/getInfraredImage() wrappers (see
+// tcxDepthCameraBase.h) for the common "just show it" case; reach for these
+// free functions when you own the Image yourself (e.g. a DepthFrame in hand).
+//
+// Each (re)allocates the Image only when the source size/shape changes, fills
+// its pixels, then setDirty() + update() to upload. update() touches the GPU,
+// so call these on the main thread (inside update()/draw()), not on a grabber.
+//
+// =============================================================================
+
+#include "tcxDepthTypes.h"
+
+#include <cmath>
+#include <cstring>
+
+namespace tcx {
+
+using namespace tc;
+
+// How depthToImage() maps depth to grayscale.
+struct DepthImageView {
+    float nearM  = 0.3f;   // distance mapped to bright
+    float farM   = 4.0f;   // distance mapped to dark
+    bool  repeat = false;  // wrap the near..far band repeatedly (contour-like)
+
+    bool operator==(const DepthImageView& o) const {
+        return nearM == o.nearM && farM == o.farM && repeat == o.repeat;
+    }
+    bool operator!=(const DepthImageView& o) const { return !(*this == o); }
+};
+
+namespace tcd_detail {
+inline void ensureRGBA(Image& img, int w, int h) {
+    if (!img.isAllocated() || img.getWidth() != w || img.getHeight() != h) {
+        img.allocate(w, h, 4);
+    }
+}
+} // namespace tcd_detail
+
+// Color is already native RGBA (8-bit); copy it straight across. No-op unless
+// the source is allocated 4-channel U8.
+inline void colorToImage(const Pixels& c, Image& out) {
+    if (!c.isAllocated() || c.getChannels() != 4 || c.isFloat()) return;
+    tcd_detail::ensureRGBA(out, c.getWidth(), c.getHeight());
+    std::memcpy(out.getPixelsData(), c.getData(),
+                static_cast<size_t>(c.getWidth()) * c.getHeight() * 4);
+    out.setDirty();
+    out.update();
+}
+
+// Depth (uint16 * depthScale, meters) -> grayscale. near = bright, invalid (0)
+// = black. With view.repeat the near..far band repeats (each band fades bright
+// ->dark again), which reads like depth contours.
+inline void depthToImage(const DepthFrame& f, Image& out, const DepthImageView& view = {}) {
+    if (f.w <= 0 || f.h <= 0 || f.depth.empty()) return;
+    tcd_detail::ensureRGBA(out, f.w, f.h);
+    unsigned char* d = out.getPixelsData();
+    const float span = (view.farM > view.nearM) ? (view.farM - view.nearM) : 1.0f;
+    const int n = f.w * f.h;
+    for (int i = 0; i < n; ++i) {
+        unsigned char g = 0;
+        if (f.depth[i] != 0) {
+            float rel = f.depth[i] * f.depthScale - view.nearM;
+            float t;
+            if (view.repeat) {
+                rel = std::fmod(rel, span);
+                if (rel < 0.0f) rel += span;   // handle samples nearer than nearM
+                t = rel / span;
+            } else {
+                t = rel / span;
+                t = t < 0.0f ? 0.0f : (t > 1.0f ? 1.0f : t);
+            }
+            g = static_cast<unsigned char>((1.0f - t) * 255.0f);
+        }
+        d[i * 4 + 0] = g; d[i * 4 + 1] = g; d[i * 4 + 2] = g; d[i * 4 + 3] = 255;
+    }
+    out.setDirty();
+    out.update();
+}
+
+// IR is single-channel F32 active brightness; auto-normalize by the frame max
+// and sqrt-gamma so low returns stay visible.
+inline void irToImage(const Pixels& ir, Image& out) {
+    if (!ir.isAllocated() || !ir.isFloat()) return;
+    const int w = ir.getWidth(), h = ir.getHeight(), n = w * h;
+    tcd_detail::ensureRGBA(out, w, h);
+    const float* s = ir.getDataF32();
+    float mx = 1.0f;
+    for (int i = 0; i < n; ++i) if (s[i] > mx) mx = s[i];
+    const float inv = 1.0f / mx;
+    unsigned char* d = out.getPixelsData();
+    for (int i = 0; i < n; ++i) {
+        float t = s[i] * inv;
+        t = t < 0.0f ? 0.0f : (t > 1.0f ? 1.0f : t);
+        const unsigned char g = static_cast<unsigned char>(std::sqrt(t) * 255.0f);
+        d[i * 4 + 0] = g; d[i * 4 + 1] = g; d[i * 4 + 2] = g; d[i * 4 + 3] = 255;
+    }
+    out.setDirty();
+    out.update();
+}
+
+} // namespace tcx

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -2046,8 +2046,8 @@ namespace internal {
     inline void (*appKeyReleasedFunc)(const KeyEventArgs&) = nullptr;
     inline void (*appMousePressedFunc)(const MouseEventArgs&) = nullptr;
     inline void (*appMouseReleasedFunc)(const MouseEventArgs&) = nullptr;
-    inline void (*appMouseMovedFunc)(const MouseEventArgs&) = nullptr;
-    inline void (*appMouseDraggedFunc)(const MouseEventArgs&) = nullptr;
+    inline void (*appMouseMovedFunc)(const MouseEventRaw&) = nullptr;
+    inline void (*appMouseDraggedFunc)(const MouseEventRaw&) = nullptr;
     inline void (*appMouseScrolledFunc)(const ScrollEventArgs&) = nullptr;
     inline void (*appWindowResizedFunc)(int, int) = nullptr;
     inline void (*appFilesDroppedFunc)(const std::vector<std::string>&) = nullptr;
@@ -2349,16 +2349,15 @@ namespace internal {
                 mouseX = ev->mouse_x * scale;
                 mouseY = ev->mouse_y * scale;
 
-                // Rich carrier (MouseEventArgs); the per-kind public type is
+                // Rich carrier (MouseEventRaw); the per-kind public type is
                 // built from it at the boundary (toDragArgs / toMoveArgs).
-                MouseEventArgs args;
+                MouseEventRaw args;
                 args.pos = args.globalPos = Vec2(mouseX, mouseY);
                 args.delta = args.globalDelta = Vec2(mouseX - prevX, mouseY - prevY);
                 args.shift = hasModShift;
                 args.ctrl = hasModCtrl;
                 args.alt = hasModAlt;
                 args.super = hasModSuper;
-                args.syncLegacy();
 
                 if (currentMouseButton >= 0) {
                     args.button = currentMouseButton;
@@ -2434,11 +2433,10 @@ namespace internal {
                         float prevX = mouseX, prevY = mouseY;
                         mouseX = tx; mouseY = ty;
 
-                        MouseEventArgs margs;
+                        MouseEventRaw margs;
                         margs.pos = margs.globalPos = Vec2(tx, ty);
                         margs.delta = margs.globalDelta = Vec2(tx - prevX, ty - prevY);
                         margs.button = MOUSE_BUTTON_LEFT;
-                        margs.syncLegacy();
                         MouseDragEventArgs dragArgs = toDragArgs(margs);
                         events().mouseDragged.notify(dragArgs);
                         if (appMouseDraggedFunc) appMouseDraggedFunc(margs);
@@ -2565,10 +2563,10 @@ sapp_desc buildAppDescriptor(const WindowSettings& settings = WindowSettings()) 
     internal::appMouseReleasedFunc = [](const MouseEventArgs& e) {
         if (app) app->handleMouseReleased(e);
     };
-    internal::appMouseMovedFunc = [](const MouseEventArgs& e) {
+    internal::appMouseMovedFunc = [](const MouseEventRaw& e) {
         if (app) app->handleMouseMoved(e);
     };
-    internal::appMouseDraggedFunc = [](const MouseEventArgs& e) {
+    internal::appMouseDraggedFunc = [](const MouseEventRaw& e) {
         if (app) app->handleMouseDragged(e);
     };
     internal::appMouseScrolledFunc = [](const ScrollEventArgs& e) {

--- a/core/include/tc/app/tcHotReloadHost.h
+++ b/core/include/tc/app/tcHotReloadHost.h
@@ -588,11 +588,11 @@ inline int runHotReloadApp(const WindowSettings& settings) {
         App* app = g_host.getApp();
         if (app) app->handleMouseReleased(e);
     };
-    internal::appMouseMovedFunc = [](const MouseEventArgs& e) {
+    internal::appMouseMovedFunc = [](const MouseEventRaw& e) {
         App* app = g_host.getApp();
         if (app) app->handleMouseMoved(e);
     };
-    internal::appMouseDraggedFunc = [](const MouseEventArgs& e) {
+    internal::appMouseDraggedFunc = [](const MouseEventRaw& e) {
         App* app = g_host.getApp();
         if (app) app->handleMouseDragged(e);
     };

--- a/core/include/tc/events/tcEventArgs.h
+++ b/core/include/tc/events/tcEventArgs.h
@@ -68,11 +68,9 @@ struct MouseEventArgs {
     // Rich (canonical)
     Vec2 pos;                 // Local position (== globalPos at app level)
     Vec2 globalPos;           // Screen position
-    // Note: press/release carry no movement; `delta`/`globalDelta` exist only
-    // because this struct doubles as the internal dispatch carrier and are
-    // always (0,0) on a press/release.
-    Vec2 delta;
-    Vec2 globalDelta;
+    // No delta here: a press/release has no movement of its own (the cursor's
+    // travel is delivered by the preceding mouseMoved/mouseDragged). Movement
+    // lives on MouseMoveEventArgs / MouseDragEventArgs.
 
     // Sync legacy scalar mirrors from the canonical Vec2 fields.
     void syncLegacy() { x = pos.x; y = pos.y; }
@@ -139,11 +137,28 @@ struct ScrollEventArgs {
 };
 
 // ---------------------------------------------------------------------------
+// Internal mouse-move carrier
+// ---------------------------------------------------------------------------
+// move/drag dispatch flows a single rich carrier through the plumbing (OS ->
+// App -> node tree); the public move/drag boundary builds the specific type
+// from it. This is internal: press/release never carry movement, so they use
+// the lean public MouseEventArgs directly and never touch this type.
+struct MouseEventRaw {
+    Vec2 pos;                 // Local position (== globalPos at app level)
+    Vec2 globalPos;           // Screen position
+    Vec2 delta;               // Movement since last event, local space
+    Vec2 globalDelta;         // Movement since last event, screen space
+    int button = 0;           // MOUSE_BUTTON_* held during a drag (0 on a move)
+    bool shift = false;
+    bool ctrl = false;
+    bool alt = false;
+    bool super = false;
+};
+
+// ---------------------------------------------------------------------------
 // Carrier -> per-event converters
 // ---------------------------------------------------------------------------
-// The dispatch plumbing flows a single rich MouseEventArgs "carrier"; the
-// move/drag public boundaries build their specific type from it here.
-inline MouseMoveEventArgs toMoveArgs(const MouseEventArgs& m) {
+inline MouseMoveEventArgs toMoveArgs(const MouseEventRaw& m) {
     MouseMoveEventArgs a;
     a.pos = m.pos; a.globalPos = m.globalPos;
     a.delta = m.delta; a.globalDelta = m.globalDelta;
@@ -152,7 +167,7 @@ inline MouseMoveEventArgs toMoveArgs(const MouseEventArgs& m) {
     return a;
 }
 
-inline MouseDragEventArgs toDragArgs(const MouseEventArgs& m) {
+inline MouseDragEventArgs toDragArgs(const MouseEventRaw& m) {
     MouseDragEventArgs a;
     a.pos = m.pos; a.globalPos = m.globalPos;
     a.delta = m.delta; a.globalDelta = m.globalDelta;

--- a/core/include/tc/utils/tcAsyncScheduler.h
+++ b/core/include/tc/utils/tcAsyncScheduler.h
@@ -1,0 +1,181 @@
+#pragma once
+
+// =============================================================================
+// tcAsyncScheduler.h - precise off-thread timers
+// =============================================================================
+// A single background thread that fires scheduled callbacks at precise times,
+// independent of the render frame rate. Backs Node::callAfterAsync /
+// callEveryAsync (the frame-driven callAfter / callEvery are quantized to the
+// update loop, ~16 ms, and drift; these are not).
+//
+// IMPORTANT: callbacks run ON THE SCHEDULER THREAD, not the update/draw thread.
+//   - Guard any state shared with update()/draw() behind a mutex.
+//   - Never draw or touch GPU resources from a callback.
+//   - Sound (AudioEngine::play) is safe; serialize MIDI/other output so the
+//     main thread isn't sending at the same time.
+//
+// Repeating timers reschedule at absolute time (period never drifts); if a tick
+// falls behind by more than one interval it resyncs to "now" instead of
+// bursting. Each owner (a Node) can cancel all of its timers at once.
+// =============================================================================
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace trussc {
+
+class AsyncScheduler {
+public:
+    using Clock    = std::chrono::steady_clock;
+    using Callback = std::function<void()>;
+
+    static AsyncScheduler& get() {
+        static AsyncScheduler instance;
+        return instance;
+    }
+
+    // A unique, non-zero owner token so a Node can group + cancel its timers.
+    static uint64_t newOwner() {
+        static std::atomic<uint64_t> next{1};
+        return next.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Fire `cb` once after `seconds`. Returns a task id (for cancel()).
+    uint64_t after(uint64_t owner, double seconds, Callback cb) {
+        return schedule(owner, seconds, /*interval=*/0.0, std::move(cb));
+    }
+
+    // Fire `cb` every `seconds`, starting one interval from now.
+    uint64_t every(uint64_t owner, double seconds, Callback cb) {
+        if (seconds < 0.0) seconds = 0.0;
+        return schedule(owner, seconds, /*interval=*/seconds, std::move(cb));
+    }
+
+    // Cancel one task. Blocks until its callback finishes if it is executing
+    // right now (unless called from inside the callback itself).
+    void cancel(uint64_t id) {
+        std::unique_lock<std::mutex> lk(mtx_);
+        eraseIf([id](const Task& t) { return t.id == id; });
+        waitInFlight(lk, [&] { return executingId_ == id; });
+    }
+
+    // Cancel every task belonging to `owner` (node destroy / mode change).
+    void cancelOwner(uint64_t owner) {
+        if (owner == 0) return;
+        std::unique_lock<std::mutex> lk(mtx_);
+        eraseIf([owner](const Task& t) { return t.owner == owner; });
+        waitInFlight(lk, [&] { return executingOwner_ == owner; });
+    }
+
+private:
+    struct Task {
+        uint64_t          id;
+        uint64_t          owner;
+        Clock::time_point when;
+        double            interval;   // 0 = one-shot
+        Callback          cb;
+    };
+
+    AsyncScheduler() : worker_([this] { run(); }) {}
+    ~AsyncScheduler() {
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            stop_ = true;
+        }
+        cv_.notify_all();
+        if (worker_.joinable()) worker_.join();
+    }
+    AsyncScheduler(const AsyncScheduler&)            = delete;
+    AsyncScheduler& operator=(const AsyncScheduler&) = delete;
+
+    static Clock::duration toDuration(double seconds) {
+        return std::chrono::duration_cast<Clock::duration>(
+            std::chrono::duration<double>(seconds));
+    }
+
+    uint64_t schedule(uint64_t owner, double delay, double interval, Callback cb) {
+        if (delay < 0.0) delay = 0.0;
+        uint64_t id   = nextId_.fetch_add(1, std::memory_order_relaxed);
+        auto     when = Clock::now() + toDuration(delay);
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            tasks_.push_back({id, owner, when, interval, std::move(cb)});
+        }
+        cv_.notify_all();   // wake the worker to recompute its sleep target
+        return id;
+    }
+
+    template <typename Pred>
+    void eraseIf(Pred pred) {   // caller holds mtx_
+        tasks_.erase(std::remove_if(tasks_.begin(), tasks_.end(), pred), tasks_.end());
+    }
+
+    // Wait until no in-flight callback matches. No-op on the worker thread (a
+    // callback cancelling its own timer) so it can't deadlock on itself.
+    template <typename Match>
+    void waitInFlight(std::unique_lock<std::mutex>& lk, Match isExecuting) {
+        if (std::this_thread::get_id() == workerId_) return;
+        doneCv_.wait(lk, [&] { return !isExecuting(); });
+    }
+
+    void run() {
+        workerId_ = std::this_thread::get_id();
+        std::unique_lock<std::mutex> lk(mtx_);
+        while (!stop_) {
+            if (tasks_.empty()) {
+                cv_.wait(lk, [&] { return stop_ || !tasks_.empty(); });
+                continue;
+            }
+
+            auto next = std::min_element(tasks_.begin(), tasks_.end(),
+                [](const Task& a, const Task& b) { return a.when < b.when; });
+            auto when = next->when;
+            if (Clock::now() < when) {
+                cv_.wait_until(lk, when);   // wakes early if a task is added/removed
+                continue;                  // re-evaluate the earliest task
+            }
+
+            uint64_t id    = next->id;
+            uint64_t owner = next->owner;
+            Callback cb    = next->cb;      // copy so reschedule/erase can't dangle it
+
+            if (next->interval > 0.0) {
+                // Absolute reschedule -> no drift; resync to now if we fell behind.
+                auto due = when + toDuration(next->interval);
+                auto now = Clock::now();
+                next->when = (due < now) ? now : due;
+            } else {
+                eraseIf([id](const Task& t) { return t.id == id; });
+            }
+
+            executingId_    = id;
+            executingOwner_ = owner;
+            lk.unlock();
+            cb();                           // run the callback WITHOUT the lock
+            lk.lock();
+            executingId_    = 0;
+            executingOwner_ = 0;
+            doneCv_.notify_all();
+        }
+    }
+
+    std::mutex              mtx_;
+    std::condition_variable cv_;       // worker sleep / wake
+    std::condition_variable doneCv_;   // callback-finished signal for cancel()
+    std::vector<Task>       tasks_;
+    std::atomic<uint64_t>   nextId_{1};
+    uint64_t                executingId_    = 0;
+    uint64_t                executingOwner_ = 0;
+    std::thread::id         workerId_;
+    bool                    stop_ = false;
+    std::thread             worker_;    // declared last: starts after the rest
+};
+
+} // namespace trussc

--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -86,19 +86,17 @@ inline void registerDebuggerTools() {
         .bind<float, float, int>([](float x, float y, int button) {
             // If button is pressed, treat as drag
             if (button >= 0) {
-                MouseEventArgs args;
+                MouseEventRaw args;
                 args.pos = args.globalPos = Vec2(x, y);
                 args.button = button;
-                args.syncLegacy();
                 MouseDragEventArgs dragArgs = toDragArgs(args);
                 events().mouseDragged.notify(dragArgs);
 
                 if (::trussc::internal::appMouseDraggedFunc)
                     ::trussc::internal::appMouseDraggedFunc(args);
             } else {
-                MouseEventArgs args;
+                MouseEventRaw args;
                 args.pos = args.globalPos = Vec2(x, y);
-                args.syncLegacy();
                 MouseMoveEventArgs moveArgs = toMoveArgs(args);
                 events().mouseMoved.notify(moveArgs);
 

--- a/core/include/tcBaseApp.h
+++ b/core/include/tcBaseApp.h
@@ -185,12 +185,12 @@ public:
         dispatchMouseRelease(e);
     }
 
-    void handleMouseMoved(const MouseEventArgs& e) {
+    void handleMouseMoved(const MouseEventRaw& e) {
         mouseMoved(toMoveArgs(e));
         dispatchMouseMove(e);
     }
 
-    void handleMouseDragged(const MouseEventArgs& e) {
+    void handleMouseDragged(const MouseEventRaw& e) {
         mouseDragged(toDragArgs(e));
         dispatchMouseMove(e);  // drag + hover share the node-tree move dispatch
     }

--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -2,6 +2,7 @@
 
 #include "TrussC.h"
 #include "tc/types/tcMod.h"
+#include "tc/utils/tcAsyncScheduler.h"
 #include <memory>
 #include <vector>
 #include <functional>
@@ -43,7 +44,10 @@ public:
     using WeakPtr = std::weak_ptr<Node>;
 
     Node() { internal::nodeCount++; }
-    virtual ~Node() { internal::nodeCount--; }
+    virtual ~Node() {
+        cancelAllAsyncTimers();  // stop + await any in-flight async callbacks
+        internal::nodeCount--;
+    }
 
     // -------------------------------------------------------------------------
     // Lifecycle (overridable)
@@ -959,7 +963,41 @@ protected:
         timers_.clear();
     }
 
+    // -------------------------------------------------------------------------
+    // Async timers (off-thread, precise)
+    // -------------------------------------------------------------------------
+    // Like callAfter / callEvery, but fired by a background scheduler thread at
+    // precise times instead of the frame-quantized update loop - use these when
+    // timing jitter matters (sequencer clocks, LED/MIDI output, ...).
+    //
+    // The callback runs ON THE SCHEDULER THREAD: guard state shared with
+    // update()/draw() behind a mutex, never draw from it (AudioEngine::play is
+    // fine). Cancel them before the members the callback touches are destroyed
+    // (e.g. in cleanup() / on mode change); ~Node cancels any leftovers and
+    // waits for an in-flight callback to finish.
+    uint64_t callAfterAsync(double delay, std::function<void()> callback) {
+        return AsyncScheduler::get().after(asyncOwner(), delay, std::move(callback));
+    }
+
+    uint64_t callEveryAsync(double interval, std::function<void()> callback) {
+        return AsyncScheduler::get().every(asyncOwner(), interval, std::move(callback));
+    }
+
+    void cancelAsyncTimer(uint64_t id) {
+        AsyncScheduler::get().cancel(id);
+    }
+
+    void cancelAllAsyncTimers() {
+        if (asyncOwner_) AsyncScheduler::get().cancelOwner(asyncOwner_);
+    }
+
 private:
+    uint64_t asyncOwner_ = 0;   // lazily assigned scheduler owner token
+    uint64_t asyncOwner() {
+        if (!asyncOwner_) asyncOwner_ = AsyncScheduler::newOwner();
+        return asyncOwner_;
+    }
+
     bool setupCalled_ = false;    // Ensures setup() is called only once
     bool dead_ = false;           // Marked for removal by destroy()
     WeakPtr parent_;

--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -616,16 +616,24 @@ private:
     // Event dispatch (called by App only via friend access)
     // -------------------------------------------------------------------------
 
-    // Build a copy of `s` with pos / delta expressed in THIS node's local space.
-    // globalPos / globalDelta / button / modifiers are preserved.
+    // Press/release: lean args carry no movement, so only pos is localized.
     MouseEventArgs localizeMouse(const MouseEventArgs& s) {
         MouseEventArgs a = s;
+        Vec3 lp = globalToLocal(Vec3(s.globalPos.x, s.globalPos.y, 0));
+        a.pos = Vec2(lp.x, lp.y);
+        a.syncLegacy();
+        return a;
+    }
+
+    // Move/drag carrier: localize pos AND the movement delta into this node's
+    // local space. globalPos / globalDelta / button / modifiers are preserved.
+    MouseEventRaw localizeMouse(const MouseEventRaw& s) {
+        MouseEventRaw a = s;
         Vec3 lp = globalToLocal(Vec3(s.globalPos.x, s.globalPos.y, 0));
         Vec3 lpPrev = globalToLocal(Vec3(s.globalPos.x - s.globalDelta.x,
                                          s.globalPos.y - s.globalDelta.y, 0));
         a.pos = Vec2(lp.x, lp.y);
         a.delta = Vec2(lp.x - lpPrev.x, lp.y - lpPrev.y);
-        a.syncLegacy();
         return a;
     }
 
@@ -687,10 +695,10 @@ private:
         return nullptr;
     }
 
-    Ptr dispatchMouseMove(const MouseEventArgs& e) {
+    Ptr dispatchMouseMove(const MouseEventRaw& e) {
         // Send drag event to grabbed node
         if (internal::grabbedNode) {
-            MouseEventArgs local = internal::grabbedNode->localizeMouse(e);
+            MouseEventRaw local = internal::grabbedNode->localizeMouse(e);
             local.button = internal::grabbedButton;
             internal::grabbedNode->onMouseDrag(toDragArgs(local));
         }
@@ -700,7 +708,7 @@ private:
         HitResult result = findHitNode(globalRay);
 
         if (result.hit()) {
-            MouseEventArgs local = result.node->localizeMouse(e);
+            MouseEventRaw local = result.node->localizeMouse(e);
             if (result.node->onMouseMove(toMoveArgs(local))) {
                 return result.node;
             }

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -443,6 +443,37 @@ There is one struct per event kind so no field is ever meaningless. Fields:
 > kept for source compatibility and slated for removal at v1.0 — prefer the
 > Vec2 fields in new code.
 
+### Timers
+Any Node (the App is one) can schedule callbacks. Two flavours:
+
+```cpp
+// Frame-driven: fired from the update loop. Simple, main-thread, but quantized
+// to the frame rate (~16 ms) and slightly drifty. Good for most UI/gameplay.
+uint64_t id = callEvery(0.5, [this]() { spawnEnemy(); });
+callAfter(2.0, [this]() { fadeOut(); });
+cancelTimer(id);
+cancelAllTimers();
+```
+
+```cpp
+// Async: fired by a precise background scheduler thread - no frame jitter,
+// no drift. Use when timing matters: sequencer clocks, LED/MIDI output, etc.
+uint64_t id = callEveryAsync(0.14, [this]() { sequencerStep(); });
+callAfterAsync(1.0, [this]() { done(); });
+cancelAsyncTimer(id);
+cancelAllAsyncTimers();          // e.g. on mode change
+```
+
+**The async callback runs on the scheduler thread, not update/draw.** So:
+- Guard any state shared with update()/draw() behind a `std::mutex`.
+- **Never draw or touch GPU resources** from the callback (state only).
+- `AudioEngine::play()` is thread-safe; serialize MIDI/other output.
+- **Call `cancelAsyncTimer`/`cancelAllAsyncTimers` WITHOUT holding that mutex** —
+  cancel waits for an in-flight callback, which itself needs the mutex, so
+  holding it deadlocks. Cancel before the members the callback touches are
+  destroyed (e.g. in `cleanup()` / on mode change); `~Node` cancels leftovers.
+- Native only — it uses a real thread (not for the single-threaded web build).
+
 ## GPU Resources
 
 ### Image

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -7379,6 +7379,102 @@ categories:
         description_ko: "LUT를 적용하여 부분을 그림"
         sketch: false
 
+  # ==========================================================================
+  # Timers (Node methods)
+  # ==========================================================================
+  - id: timers
+    name: "Timers"
+    name_ja: "タイマー"
+    name_ko: "타이머"
+    functions:
+      - name: callAfter
+        return: "uint64_t"
+        signatures:
+          - params: "double delay, std::function<void()> callback"
+            params_simple: "delay, callback"
+        description: "Run callback once after delay seconds. Fired from the update loop (frame-quantized). Returns a timer id."
+        description_ja: "delay秒後にcallbackを1回実行。更新ループから発火（フレーム単位）。タイマーidを返す"
+        description_ko: "delay초 후 callback을 한 번 실행. 업데이트 루프에서 발생(프레임 단위). 타이머 id를 반환"
+        sketch: false
+        snippet: "callAfter(1.0, [this]() {\n\t$0\n});"
+
+      - name: callEvery
+        return: "uint64_t"
+        signatures:
+          - params: "double interval, std::function<void()> callback"
+            params_simple: "interval, callback"
+        description: "Run callback repeatedly every interval seconds. Fired from the update loop (frame-quantized). Returns a timer id."
+        description_ja: "interval秒ごとにcallbackを繰り返し実行。更新ループから発火（フレーム単位）。タイマーidを返す"
+        description_ko: "interval초마다 callback을 반복 실행. 업데이트 루프에서 발생(프레임 단위). 타이머 id를 반환"
+        sketch: false
+        snippet: "callEvery(0.5, [this]() {\n\t$0\n});"
+
+      - name: callAfterAsync
+        return: "uint64_t"
+        signatures:
+          - params: "double delay, std::function<void()> callback"
+            params_simple: "delay, callback"
+        description: "Like callAfter, but fired by a precise background scheduler thread (no frame jitter). The callback runs OFF the main thread: guard shared state with a mutex, never draw from it, and don't cancel while holding that mutex. Native only (uses a real thread). Returns a timer id."
+        description_ja: "callAfterの精密版。バックグラウンドのスケジューラスレッドが正確な時刻に発火（フレームジッタなし）。コールバックはメインスレッド外で走る：共有状態はmutexで保護、描画は禁止、そのmutexを保持したままcancelしない。ネイティブ専用（実スレッド使用）。タイマーidを返す"
+        description_ko: "callAfter의 정밀 버전. 백그라운드 스케줄러 스레드가 정확한 시각에 실행(프레임 지터 없음). 콜백은 메인 스레드 밖에서 실행됨: 공유 상태는 mutex로 보호, 그리기 금지, 해당 mutex를 들고 cancel하지 말 것. 네이티브 전용(실제 스레드 사용). 타이머 id를 반환"
+        sketch: false
+        snippet: "callAfterAsync(1.0, [this]() {\n\t$0\n});"
+
+      - name: callEveryAsync
+        return: "uint64_t"
+        signatures:
+          - params: "double interval, std::function<void()> callback"
+            params_simple: "interval, callback"
+        description: "Like callEvery, but fired by a precise background scheduler thread with no drift (reschedules at absolute times). Ideal for sequencer clocks and LED/MIDI output timing. Same threading rules as callAfterAsync. Native only. Returns a timer id."
+        description_ja: "callEveryの精密版。バックグラウンドのスケジューラスレッドがドリフトなく発火（絶対時刻で再スケジュール）。シーケンサのクロックやLED/MIDI出力のタイミングに最適。スレッドの注意点はcallAfterAsyncと同じ。ネイティブ専用。タイマーidを返す"
+        description_ko: "callEvery의 정밀 버전. 백그라운드 스케줄러 스레드가 드리프트 없이 실행(절대 시각으로 재예약). 시퀀서 클럭이나 LED/MIDI 출력 타이밍에 적합. 스레드 주의사항은 callAfterAsync와 동일. 네이티브 전용. 타이머 id를 반환"
+        sketch: false
+        snippet: "callEveryAsync(0.5, [this]() {\n\t$0\n});"
+
+      - name: cancelTimer
+        return: "void"
+        signatures:
+          - params: "uint64_t id"
+            params_simple: "id"
+        description: "Cancel a frame timer (callAfter/callEvery) by id."
+        description_ja: "id指定でフレームタイマー（callAfter/callEvery）をキャンセル"
+        description_ko: "id로 프레임 타이머(callAfter/callEvery)를 취소"
+        sketch: false
+        snippet: "cancelTimer(id);"
+
+      - name: cancelAllTimers
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Cancel all frame timers on this node."
+        description_ja: "このノードのフレームタイマーを全てキャンセル"
+        description_ko: "이 노드의 모든 프레임 타이머를 취소"
+        sketch: false
+        snippet: "cancelAllTimers();"
+
+      - name: cancelAsyncTimer
+        return: "void"
+        signatures:
+          - params: "uint64_t id"
+            params_simple: "id"
+        description: "Cancel an async timer by id. Blocks until its callback finishes if it is running now (unless called from inside the callback). Do not call while holding the mutex the callback uses."
+        description_ja: "id指定で非同期タイマーをキャンセル。実行中なら完了を待つ（コールバック内から呼ぶ場合を除く）。コールバックが使うmutexを保持したまま呼ばないこと"
+        description_ko: "id로 비동기 타이머를 취소. 실행 중이면 완료를 기다림(콜백 내부에서 호출하는 경우 제외). 콜백이 쓰는 mutex를 들고 호출하지 말 것"
+        sketch: false
+        snippet: "cancelAsyncTimer(id);"
+
+      - name: cancelAllAsyncTimers
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Cancel all async timers on this node (e.g. on mode change). Waits out any in-flight callback. Call it WITHOUT holding the callback's mutex to avoid a deadlock."
+        description_ja: "このノードの非同期タイマーを全てキャンセル（モード変更時など）。実行中のコールバックの完了を待つ。デッドロック回避のため、コールバックのmutexを保持せずに呼ぶこと"
+        description_ko: "이 노드의 모든 비동기 타이머를 취소(모드 전환 등). 실행 중인 콜백의 완료를 기다림. 데드락 방지를 위해 콜백의 mutex를 들지 않고 호출할 것"
+        sketch: false
+        snippet: "cancelAllAsyncTimers();"
+
 # ==========================================================================
 # Constants
 # ==========================================================================

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -107,6 +107,29 @@ def find_examples(root_dir):
 
     return sorted(list(set(example_paths)))
 
+def find_addon_tests(root_dir):
+    # Behavioral test harnesses bundled with monorepo addons: addons/*/tests/
+    # (a console TrussC project whose main() returns non-zero on failure). Same
+    # convention as standalone addon repos (ci-actions runs tests/ if present).
+    addons_dir = os.path.join(root_dir, "addons")
+    test_paths = []
+    if os.path.exists(addons_dir):
+        for addon in sorted(os.listdir(addons_dir)):
+            tdir = os.path.join(addons_dir, addon, "tests")
+            if os.path.isdir(tdir) and os.path.exists(os.path.join(tdir, "src")):
+                test_paths.append(tdir)
+    return test_paths
+
+def find_test_binary(test_dir, platform_info):
+    # trusscli names the binary after the dir (tests). On macOS a TrussC app is
+    # tests.app/Contents/MacOS/tests; on Windows tests.exe. Search the project tree.
+    names = ["tests.exe"] if platform_info["os"] == "windows" else ["tests", "tests_debug"]
+    for name in names:
+        for p in glob.glob(os.path.join(test_dir, "**", name), recursive=True):
+            if os.path.isfile(p) and (platform_info["os"] == "windows" or os.access(p, os.X_OK)):
+                return p
+    return None
+
 def run_command(cmd, cwd, verbose=False):
     try:
         if verbose:
@@ -120,6 +143,37 @@ def run_command(cmd, cwd, verbose=False):
                 print(e.stdout.decode('utf-8', errors='replace'))
         return False
 
+def build_and_run_test(test_dir, pg_bin, platform_info, args):
+    # Build a native console test project, then RUN it (non-zero exit = failure).
+    # Returns (ok, stage) where stage names what failed for the summary.
+    pg_cmd = [str(pg_bin), "update", "-p", test_dir, "--tc-root", ROOT_DIR, "--ide", "cmake"]
+    if not run_command(pg_cmd, cwd=ROOT_DIR, verbose=args.verbose):
+        return False, "update"
+
+    build_dir_name = platform_info["build_dir"]
+    cmd_config = ["cmake", "-S", ".", "-B", build_dir_name]
+    if platform_info["cmake_generator"]:
+        cmd_config.extend(["-G", platform_info["cmake_generator"]])
+    if not run_command(cmd_config, cwd=test_dir, verbose=args.verbose):
+        return False, "configure"
+
+    cmd_build = ["cmake", "--build", build_dir_name, "--config", "Release"]
+    if "Visual Studio" not in (platform_info["cmake_generator"] or ""):
+        import multiprocessing
+        cmd_build.extend(["-j", str(multiprocessing.cpu_count())])
+    if not run_command(cmd_build, cwd=test_dir, verbose=args.verbose):
+        return False, "build"
+
+    binary = find_test_binary(test_dir, platform_info)
+    if not binary:
+        Colors.print("  Test binary 'tests' not found after build!", Colors.RED)
+        return False, "binary-missing"
+
+    Colors.print(f"  Running {os.path.relpath(binary, test_dir)} ...", Colors.YELLOW)
+    if not run_command([binary], cwd=test_dir, verbose=True):  # always stream test output
+        return False, "run"
+    return True, None
+
 # =============================================================================
 # Main
 # =============================================================================
@@ -131,6 +185,7 @@ def main():
     parser.add_argument('--web-only', action='store_true', help="Build for WebAssembly only (skip native build)")
     parser.add_argument('--test-only', action='store_true', help="Build ONLY AllFeaturesExample for quick CI check")
     parser.add_argument('--test-hot-reload', action='store_true', help="Build ONLY HotReloadExample (exercises the host/guest split + addon includes)")
+    parser.add_argument('--addon-tests-only', action='store_true', help="Build AND RUN every addons/*/tests/ harness (console, non-zero exit fails). No-op if none exist.")
     parser.add_argument('--verbose', action='store_true', help="Show detailed build output")
     args = parser.parse_args()
 
@@ -149,7 +204,41 @@ def main():
         Colors.print("Mode: AllFeaturesExample Only", Colors.YELLOW)
     if args.test_hot_reload:
         Colors.print("Mode: HotReloadExample Only", Colors.YELLOW)
+    if args.addon_tests_only:
+        Colors.print("Mode: Addon tests (build + run)", Colors.YELLOW)
     print("")
+
+    # Addon test harnesses (addons/*/tests/): build AND run each. A cheap,
+    # behavioral gate meant to run on every CI, separate from the [full]-gated
+    # example builds. No-op (exit 0) when no addon ships a tests/ dir.
+    if args.addon_tests_only:
+        tests = find_addon_tests(ROOT_DIR)
+        if not tests:
+            Colors.print("No addon tests found (addons/*/tests/); nothing to do.", Colors.YELLOW)
+            sys.exit(0)
+        Colors.print(f"Found {len(tests)} addon test harness(es)", Colors.YELLOW)
+        print("")
+        failed = []
+        for i, tdir in enumerate(tests):
+            name = os.path.relpath(tdir, ROOT_DIR)
+            Colors.print(f"[{i+1}/{len(tests)}] Building & running: {name}", Colors.YELLOW)
+            ok, stage = build_and_run_test(tdir, pg_bin, platform_info, args)
+            if ok:
+                Colors.print("  Passed!", Colors.GREEN)
+            else:
+                Colors.print(f"  FAILED ({stage})", Colors.RED)
+                failed.append(f"{name} ({stage})")
+        print("")
+        Colors.print("=== Addon Test Summary ===", Colors.BLUE)
+        print(f"Total:  {len(tests)}")
+        Colors.print(f"Passed: {len(tests) - len(failed)}", Colors.GREEN)
+        if failed:
+            Colors.print(f"Failed: {len(failed)}", Colors.RED)
+            for f in failed:
+                print(f"  - {f}")
+            sys.exit(1)
+        Colors.print("All addon tests passed!", Colors.GREEN)
+        sys.exit(0)
 
     if args.test_only:
         test_example = os.path.join(ROOT_DIR, "examples", "tests", "AllFeaturesExample")


### PR DESCRIPTION
Promotes `dev` → `main`.

## feat(core): callAfterAsync / callEveryAsync — precise off-thread timers
`Node::callAfterAsync` / `callEveryAsync` fire from a shared background
scheduler thread (`tc/utils/tcAsyncScheduler.h`) at precise times — no frame
jitter, no drift — unlike the frame-driven `callAfter` / `callEvery`. Per-node
cancel, in-flight-aware cancellation, `~Node` cleanup. Verified with an
ASan/UBSan unit test and live in the launchkey / launchpad demos. Docs:
`api-definition.yaml` Timers category + `FOR_AI_ASSISTANT.md`. Native only
(real thread; not the single-threaded web build).

## refactor(core): slim MouseEventArgs (drop delta)
A press/release has no movement of its own, so `MouseEventArgs` no longer
carries an always-zero `delta`/`globalDelta`. Move/drag dispatch now flows
through a dedicated internal `MouseEventRaw` carrier; the public
`MouseMoveEventArgs` / `MouseDragEventArgs` are built from it at the boundary.
**Public handler signatures are unchanged — non-breaking for user code and
addons.**

## ci: build & run bundled-addon tests/ harnesses
Bundled addons' `tests/` harnesses are now built and run in CI, and the
example tests run as part of the matrix.

## also included from dev
- feat(tcxDepthCamera): cached preview Images + stream→Image converters

Verified: full CI matrix green on dev HEAD (macOS / Windows / Linux / Android /
Web).
