### PR TITLE
feat(EasyCam): add setAzimuth/setElevation orbit-angle setters

### DIFF
--- a/addons/tcxImGui/src/tcImGuiTools.h
+++ b/addons/tcxImGui/src/tcImGuiTools.h
@@ -115,6 +115,11 @@ inline std::string classifyWidget(ImGuiItemStatusFlags flags) {
 inline void registerImGuiTools() {
     using json = nlohmann::json;
 
+    // Idempotent: safe to call from imguiSetup() and/or the app.
+    static bool registered = false;
+    if (registered) return;
+    registered = true;
+
     // Activate collection
     enableCollection();
 

--- a/addons/tcxImGui/src/tcxImGui.h
+++ b/addons/tcxImGui/src/tcxImGui.h
@@ -9,6 +9,8 @@
 #include "sokol_imgui.h"
 #include "tcImGuiHooks.h"
 #include "tcImGuiTools.h"
+#include <cstdlib>
+#include <string>
 
 namespace tcx {
 
@@ -95,6 +97,11 @@ private:
 
 inline void imguiSetup() {
     ImGuiManager::instance().setup();
+    // Auto-register the ImGui MCP tools when MCP is enabled, so ImGui-based
+    // UIs are AI-drivable without an explicit registerImGuiTools() call.
+    if (const char* m = std::getenv("TRUSSC_MCP"); m && std::string(m) == "1") {
+        trussc::imgui_tools::registerImGuiTools();
+    }
 }
 
 inline void imguiShutdown() {

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -1980,6 +1980,7 @@ struct WindowSettings {
     bool pixelPerfect = false;  // true: coords = framebuffer size, false: coords = logical size
     int sampleCount = 4;  // MSAA (default 4x, 8x not supported on some devices)
     bool fullscreen = false;
+    bool decorated = true;  // false: borderless/chromeless window (no title bar)
     int clipboardSize = 65536;  // Clipboard buffer size (default 64KB)
     int swapInterval = 1;  // VSync: 1 = on (default), 0 = off
     // bool headless = false;  // For future use
@@ -2018,6 +2019,13 @@ struct WindowSettings {
         return *this;
     }
 
+    // false = borderless/chromeless window (no title bar, no buttons) that can
+    // still take keyboard focus and be closed programmatically (exitApp()).
+    WindowSettings& setDecorated(bool enabled) {
+        decorated = enabled;
+        return *this;
+    }
+
     WindowSettings& setClipboardSize(int size) {
         clipboardSize = size;
         return *this;
@@ -2032,6 +2040,10 @@ namespace internal {
     // App instance (held as void*)
     inline void* appInstance = nullptr;
     inline int currentMouseButton = -1;
+
+    // Window decoration requested via WindowSettings; applied in _setup_cb once
+    // the platform window exists (sokol has no decoration flag in sapp_desc).
+    inline bool windowDecorated = true;
 
     // Callback function pointers
     inline void (*appSetupFunc)() = nullptr;
@@ -2097,6 +2109,12 @@ namespace internal {
         // Install the standard application menu on macOS so Cmd+Q etc. work
         // out of the box. No-op on other platforms.
         internal::installAppMenu();
+
+        // Apply borderless/chromeless decoration if requested (the window now
+        // exists). Kept key-focusable and closable so exitApp() still works.
+        if (!internal::windowDecorated) {
+            setWindowDecorated(false);
+        }
 
         // Bring window to front on startup
         bringWindowToFront();
@@ -2515,6 +2533,9 @@ template<typename AppClass>
 sapp_desc buildAppDescriptor(const WindowSettings& settings = WindowSettings()) {
     // Set pixel perfect mode
     internal::pixelPerfectMode = settings.pixelPerfect;
+
+    // Remember the requested decoration; applied after the window is created.
+    internal::windowDecorated = settings.decorated;
 
     // Create app instance (shared_ptrで管理してNodeのweak_from_thisを有効にする)
     static std::shared_ptr<AppClass> app = nullptr;

--- a/core/include/tc/3d/tcEasyCam.h
+++ b/core/include/tc/3d/tcEasyCam.h
@@ -128,6 +128,31 @@ public:
         return distance_;
     }
 
+    // ---------------------------------------------------------------------------
+    // Orbit angles
+    // ---------------------------------------------------------------------------
+    // The camera orbits the target on a sphere, placed by two angles:
+    //   azimuth   - horizontal angle (yaw): which side you view from, spinning
+    //               around the up axis. 0 looks along the forward axis.
+    //   elevation - vertical angle (pitch): how high above the target you look
+    //               down from. 0 = level (side-on); positive looks downward.
+    // Both in radians. Set them to frame an oblique 3/4 view at startup instead
+    // of the default head-on side view. (These are exactly what mouse-drag moves;
+    // elevation is clamped to ~±80° like the drag handler.)
+    void setAzimuth(float radians) {
+        rotationY_ = radians;
+    }
+
+    void setElevation(float radians) {
+        const float maxAngle = 80.0f * 3.14159265358979f / 180.0f;
+        if (radians >  maxAngle) radians =  maxAngle;
+        if (radians < -maxAngle) radians = -maxAngle;
+        rotationX_ = radians;
+    }
+
+    float getAzimuth() const   { return rotationY_; }
+    float getElevation() const { return rotationX_; }
+
     // Set field of view (FOV) in radians
     void setFov(float fov) {
         fov_ = fov;

--- a/core/include/tc/3d/tcPrimitives.h
+++ b/core/include/tc/3d/tcPrimitives.h
@@ -250,6 +250,95 @@ inline Mesh createCylinder(float radius, float height, int resolution = 16) {
 }
 
 // ---------------------------------------------------------------------------
+// Capsule (Y-up, centered): a cylinder of `cylinderHeight` capped by two
+// hemispheres of `radius`. Total height = cylinderHeight + 2*radius. The
+// convention matches Jolt's CapsuleShape, so this draws what addCapsule(radius,
+// cylinderHeight) simulates.
+// ---------------------------------------------------------------------------
+inline Mesh createCapsule(float radius, float cylinderHeight, int resolution = 16) {
+    Mesh mesh;
+    mesh.setMode(PrimitiveMode::Triangles);
+
+    const float halfCyl = cylinderHeight * 0.5f;
+    const float halfPi  = HALF_TAU * 0.5f;          // PI/2
+    const int sectors   = resolution;
+    int hemiRings = resolution / 2;                  // rings per hemisphere
+    if (hemiRings < 2) hemiRings = 2;
+
+    // --- cylindrical side (radial normals) ---
+    int sideBase = mesh.getNumVertices();
+    for (int i = 0; i <= sectors; i++) {
+        float u = (float)i / sectors;
+        float angle = TAU * i / sectors;
+        float nx = cos(angle);
+        float nz = sin(angle);
+        mesh.addVertex(nx * radius, -halfCyl, nz * radius);   // bottom of cylinder
+        mesh.addNormal(nx, 0, nz);
+        mesh.addTexCoord(u, 0.66f);
+        mesh.addTangent(-sin(angle), 0.0f, cos(angle), 1.0f);
+
+        mesh.addVertex(nx * radius,  halfCyl, nz * radius);   // top of cylinder
+        mesh.addNormal(nx, 0, nz);
+        mesh.addTexCoord(u, 0.34f);
+        mesh.addTangent(-sin(angle), 0.0f, cos(angle), 1.0f);
+    }
+    for (int i = 0; i < sectors; i++) {
+        int i0 = sideBase + i * 2;
+        int i1 = i0 + 1, i2 = i0 + 2, i3 = i0 + 3;
+        mesh.addTriangle(i0, i2, i1);
+        mesh.addTriangle(i1, i2, i3);
+    }
+
+    // --- top hemisphere (phi 0=pole .. PI/2=equator, centre at +halfCyl) ---
+    int topBase = mesh.getNumVertices();
+    for (int r = 0; r <= hemiRings; r++) {
+        float phi = (float)r / hemiRings * halfPi;
+        float cphi = cos(phi), sphi = sin(phi);
+        for (int s = 0; s <= sectors; s++) {
+            float theta = TAU * s / sectors;
+            float nx = sphi * cos(theta), ny = cphi, nz = sphi * sin(theta);
+            mesh.addVertex(nx * radius, halfCyl + cphi * radius, nz * radius);
+            mesh.addNormal(nx, ny, nz);
+            mesh.addTexCoord((float)s / sectors, 0.34f - 0.34f * (float)r / hemiRings);
+            mesh.addTangent(-sin(theta), 0.0f, cos(theta), 1.0f);
+        }
+    }
+    for (int r = 0; r < hemiRings; r++) {
+        for (int s = 0; s < sectors; s++) {
+            int i0 = topBase + r * (sectors + 1) + s;
+            int i1 = i0 + 1, i2 = i0 + (sectors + 1), i3 = i2 + 1;
+            if (r != 0) mesh.addTriangle(i0, i2, i1);   // skip degenerate at pole
+            mesh.addTriangle(i1, i2, i3);
+        }
+    }
+
+    // --- bottom hemisphere (phi PI/2=equator .. PI=pole, centre at -halfCyl) ---
+    int botBase = mesh.getNumVertices();
+    for (int r = 0; r <= hemiRings; r++) {
+        float phi = halfPi + (float)r / hemiRings * halfPi;
+        float cphi = cos(phi), sphi = sin(phi);       // cphi: 0 -> -1, sphi: 1 -> 0
+        for (int s = 0; s <= sectors; s++) {
+            float theta = TAU * s / sectors;
+            float nx = sphi * cos(theta), ny = cphi, nz = sphi * sin(theta);
+            mesh.addVertex(nx * radius, -halfCyl + cphi * radius, nz * radius);
+            mesh.addNormal(nx, ny, nz);
+            mesh.addTexCoord((float)s / sectors, 0.66f + 0.34f * (float)r / hemiRings);
+            mesh.addTangent(-sin(theta), 0.0f, cos(theta), 1.0f);
+        }
+    }
+    for (int r = 0; r < hemiRings; r++) {
+        for (int s = 0; s < sectors; s++) {
+            int i0 = botBase + r * (sectors + 1) + s;
+            int i1 = i0 + 1, i2 = i0 + (sectors + 1), i3 = i2 + 1;
+            mesh.addTriangle(i0, i2, i1);
+            if (r != hemiRings - 1) mesh.addTriangle(i1, i2, i3);   // skip degenerate at pole
+        }
+    }
+
+    return mesh;
+}
+
+// ---------------------------------------------------------------------------
 // Cone
 // ---------------------------------------------------------------------------
 inline Mesh createCone(float radius, float height, int resolution = 16) {

--- a/core/include/tc/events/tcEvent.h
+++ b/core/include/tc/events/tcEvent.h
@@ -170,6 +170,12 @@ public:
         for (const auto& entry : *snapshot) {
             if (entry.callback) {
                 entry.callback(arg);
+                // Stop propagation once a listener marks the event consumed.
+                // Only arg types that carry a `consumed` flag (input events)
+                // participate; all others ignore this branch at compile time.
+                if constexpr (requires { arg.consumed; }) {
+                    if (arg.consumed) break;
+                }
             }
         }
     }

--- a/core/include/tc/events/tcEventArgs.h
+++ b/core/include/tc/events/tcEventArgs.h
@@ -30,6 +30,9 @@ struct KeyEventArgs {
     bool ctrl = false;        // Ctrl key
     bool alt = false;         // Alt key
     bool super = false;       // Super/Command key
+    // Set by a listener to stop propagation to lower-priority listeners
+    // (Event<T>::notify breaks once this is true). See tcEvent.h.
+    bool consumed = false;
 };
 
 // ---------------------------------------------------------------------------
@@ -71,6 +74,7 @@ struct MouseEventArgs {
     // No delta here: a press/release has no movement of its own (the cursor's
     // travel is delivered by the preceding mouseMoved/mouseDragged). Movement
     // lives on MouseMoveEventArgs / MouseDragEventArgs.
+    bool consumed = false;    // Stop propagation to lower-priority listeners (see tcEvent.h)
 
     // Sync legacy scalar mirrors from the canonical Vec2 fields.
     void syncLegacy() { x = pos.x; y = pos.y; }
@@ -92,6 +96,7 @@ struct MouseMoveEventArgs {
     Vec2 globalPos;
     Vec2 delta;               // Movement since last event, local space
     Vec2 globalDelta;         // Movement since last event, screen space
+    bool consumed = false;    // Stop propagation to lower-priority listeners (see tcEvent.h)
 
     void syncLegacy() { x = pos.x; y = pos.y; deltaX = delta.x; deltaY = delta.y; }
 };
@@ -113,6 +118,7 @@ struct MouseDragEventArgs {
     Vec2 globalPos;
     Vec2 delta;
     Vec2 globalDelta;
+    bool consumed = false;    // Stop propagation to lower-priority listeners (see tcEvent.h)
 
     void syncLegacy() { x = pos.x; y = pos.y; deltaX = delta.x; deltaY = delta.y; }
 };
@@ -132,6 +138,7 @@ struct ScrollEventArgs {
     Vec2 pos;                 // Local position of the cursor (== globalPos at app level)
     Vec2 globalPos;           // Screen position of the cursor
     Vec2 scroll;              // Scroll amount (x: horizontal, y: vertical)
+    bool consumed = false;    // Stop propagation to lower-priority listeners (see tcEvent.h)
 
     void syncLegacy() { scrollX = scroll.x; scrollY = scroll.y; }
 };
@@ -153,6 +160,7 @@ struct MouseEventRaw {
     bool ctrl = false;
     bool alt = false;
     bool super = false;
+    bool consumed = false;    // Stop propagation to lower-priority listeners (see tcEvent.h)
 };
 
 // ---------------------------------------------------------------------------

--- a/core/include/tc/types/tcMod.h
+++ b/core/include/tc/types/tcMod.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <vector>
 #include <algorithm>
+#include "../events/tcEventArgs.h"
+#include "../math/tcRay.h"
 
 namespace trussc {
 
@@ -37,6 +39,11 @@ public:
     const Node* getOwner() const { return owner_; }
 
 protected:
+    // Remove this mod from its owner (no need to name its own type). Safe to
+    // call from inside a mod's own update/draw/event handler — destruction is
+    // deferred until the current dispatch finishes. Defined in tcNode.h.
+    void removeSelf();
+
     // -------------------------------------------------------------------------
     // Lifecycle (override in derived classes)
     // -------------------------------------------------------------------------
@@ -57,6 +64,33 @@ protected:
 
     // Called when Mod is removed or Node is destroyed
     virtual void onDestroy() {}
+
+    // -------------------------------------------------------------------------
+    // Input events (forwarded from the owner Node)
+    // -------------------------------------------------------------------------
+    // Same args as Node's handlers. Mouse events reach mods on the hit node;
+    // key events broadcast to mods on every node. Return true from a mouse
+    // handler to consume the event (counts as the node consuming it).
+    virtual bool onMousePress(const MouseEventArgs& e)    { (void)e; return false; }
+    virtual bool onMouseRelease(const MouseEventArgs& e)  { (void)e; return false; }
+    virtual bool onMouseMove(const MouseMoveEventArgs& e) { (void)e; return false; }
+    virtual bool onMouseDrag(const MouseDragEventArgs& e) { (void)e; return false; }
+    virtual bool onMouseScroll(const ScrollEventArgs& e)  { (void)e; return false; }
+    virtual bool onKeyPress(const KeyEventArgs& e)        { (void)e; return false; }
+    virtual bool onKeyRelease(const KeyEventArgs& e)      { (void)e; return false; }
+    virtual void onMouseEnter() {}
+    virtual void onMouseLeave() {}
+
+    // -------------------------------------------------------------------------
+    // Hit test (mouse / pointer picking)
+    // -------------------------------------------------------------------------
+    // Screen-space picking only — NOT physics collision (physics colliders are
+    // a separate concept in the tcxPhysics addon). Override to define a hit
+    // shape in the node's LOCAL space. Checked together with Node::hitTest;
+    // if the node's own test OR any mod's returns true, the node is the hit.
+    virtual bool hitTest(const Ray& localRay, float& outDistance) {
+        (void)localRay; (void)outDistance; return false;
+    }
 
     // -------------------------------------------------------------------------
     // Exclusivity

--- a/core/include/tc/utils/tcReflect.h
+++ b/core/include/tc/utils/tcReflect.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// =============================================================================
+// tcReflect.h - explicit member reflection (TC_REFLECT)
+//
+// A type exposes editable members for inspectors / serialization by listing
+// them. Node is the reflection root; subclasses chain automatically with
+// `using Super = Base;`:
+//
+//     struct Sprite : Node {
+//         using Super = Node;          // inherits Node's reflected members
+//         Color color;
+//         float radius = 30;
+//         TC_REFLECT(Sprite)
+//             TC_FIELD(color)          // plain field, edited in place
+//             TC_FIELD(radius)
+//         TC_REFLECT_END
+//     };
+//
+// Backends implement Reflector (one typed visit() per supported type) — e.g.
+// an ImGui inspector, a JSON writer, a binary codec. Plain fields use
+// TC_FIELD; getter/setter pairs use TC_PROPERTY so invariants (dirty flags,
+// clamping, events) run on edit.
+// =============================================================================
+
+#include <string>
+
+namespace trussc {
+
+// Reflected types use references to these (declared in tcMath.h / tcColor.h).
+struct Vec2;
+struct Vec3;
+struct Color;
+
+// Visitor over a type's members. One overload per supported type; each returns
+// true if the value was edited this call.
+struct Reflector {
+    virtual ~Reflector() = default;
+    virtual bool visit(const char* name, float& v) = 0;
+    virtual bool visit(const char* name, int& v) = 0;
+    virtual bool visit(const char* name, bool& v) = 0;
+    virtual bool visit(const char* name, std::string& v) = 0;
+    virtual bool visit(const char* name, Vec2& v) = 0;
+    virtual bool visit(const char* name, Vec3& v) = 0;
+    virtual bool visit(const char* name, Color& v) = 0;
+};
+
+// Chain to the base's members if the type declares `using Super = Base;`.
+// Qualified call -> non-virtual, so no infinite recursion. No Super -> no-op.
+template <class T>
+inline void reflectSuper(T* self, Reflector& r) {
+    if constexpr (requires { typename T::Super; }) {
+        using S = typename T::Super;
+        self->S::reflectMembers(r);
+    }
+}
+
+} // namespace trussc
+
+// Open the member-enumeration function. TC_REFLECT_ROOT declares the virtual
+// (use on the base, e.g. Node); TC_REFLECT overrides it (use on subclasses).
+// Between open and TC_REFLECT_END, list members with TC_FIELD / TC_PROPERTY.
+#define TC_REFLECT_ROOT(Self) \
+    virtual void reflectMembers(::trussc::Reflector& r) { \
+        ::trussc::reflectSuper<Self>(this, r);
+#define TC_REFLECT(Self) \
+    void reflectMembers(::trussc::Reflector& r) override { \
+        ::trussc::reflectSuper<Self>(this, r);
+#define TC_REFLECT_END }
+
+// A plain data member: edited in place.
+#define TC_FIELD(member) r.visit(#member, member);
+
+// A getter/setter property: read via getter; on edit, write via setter so any
+// invariants (dirty flags, clamping, change events) run.
+#define TC_PROPERTY(name, getter, setter) \
+    do { auto _tcv = getter(); if (r.visit(#name, _tcv)) setter(_tcv); } while (0);

--- a/core/include/tc/utils/tcTypeName.h
+++ b/core/include/tc/utils/tcTypeName.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// =============================================================================
+// tcTypeName.h - Human-readable type names from RTTI
+// =============================================================================
+//
+// Turns a std::type_info into a demangled, readable type name (e.g.
+// "trussc::RectNode" instead of the mangled "N6trussc8RectNodeE").
+//
+// The demangled string is cached per type, so the (relatively expensive)
+// demangle runs at most once per type for the whole process — calling this
+// for tens of thousands of instances costs one lookup each, no per-instance
+// storage. Used by Node::getTypeName() for the scene-graph debugger.
+//
+// Requires RTTI (enabled by default). On a polymorphic object,
+// typeName(typeid(*ptr)) yields the dynamic (most-derived) type.
+
+#include <typeinfo>
+#include <typeindex>
+#include <string>
+#include <unordered_map>
+#include <mutex>
+
+#if defined(__GNUG__) || defined(__clang__)
+#include <cxxabi.h>
+#include <cstdlib>
+#endif
+
+namespace trussc {
+
+// Demangle a raw type_info name into a readable string (platform-specific).
+inline std::string demangleTypeName(const char* mangled) {
+#if defined(__GNUG__) || defined(__clang__)
+    int status = 0;
+    char* d = abi::__cxa_demangle(mangled, nullptr, nullptr, &status);
+    std::string result = (status == 0 && d) ? d : mangled;
+    std::free(d);
+    return result;
+#else
+    // MSVC: name() is already readable, e.g. "class trussc::RectNode".
+    // Strip the leading "class "/"struct "/"enum " keyword for cleanliness.
+    std::string s = mangled;
+    for (const char* kw : {"class ", "struct ", "enum "}) {
+        if (s.rfind(kw, 0) == 0) { s.erase(0, std::string(kw).size()); break; }
+    }
+    return s;
+#endif
+}
+
+// Readable name for a type, cached per type (one demangle per type, ever).
+// Returns a reference into a process-wide cache, valid for the program's life.
+inline const std::string& typeName(const std::type_info& ti) {
+    static std::unordered_map<std::type_index, std::string> cache;
+    static std::mutex mutex;  // contended only on first sight of a new type
+    std::lock_guard<std::mutex> lock(mutex);
+    std::type_index key(ti);
+    auto it = cache.find(key);
+    if (it != cache.end()) return it->second;
+    return cache.emplace(key, demangleTypeName(ti.name())).first->second;
+}
+
+// Convenience: readable name for a static type T.
+template <typename T>
+inline const std::string& typeName() {
+    return typeName(typeid(T));
+}
+
+} // namespace trussc

--- a/core/include/tc/utils/tcTypeName.h
+++ b/core/include/tc/utils/tcTypeName.h
@@ -65,4 +65,28 @@ inline const std::string& typeName() {
     return typeName(typeid(T));
 }
 
+// Strip the namespace qualifier from a (possibly templated) type name:
+//   "trussc::RectNode"  -> "RectNode"
+//   "GroupNode"         -> "GroupNode"
+//   "ns::Outer<a::B>"   -> "Outer<a::B>"   (only the outer type is stripped)
+inline std::string unqualifiedTypeName(const std::string& full) {
+    // Look for the namespace separator only before any template arguments,
+    // so we never cut inside "<...>".
+    size_t searchEnd = full.find('<');
+    if (searchEnd == std::string::npos) searchEnd = full.size();
+    size_t sep = full.rfind("::", searchEnd);
+    return sep == std::string::npos ? full : full.substr(sep + 2);
+}
+
+// Short (unqualified) type name, cached per type like typeName().
+inline const std::string& shortTypeName(const std::type_info& ti) {
+    static std::unordered_map<std::type_index, std::string> cache;
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+    std::type_index key(ti);
+    auto it = cache.find(key);
+    if (it != cache.end()) return it->second;
+    return cache.emplace(key, unqualifiedTypeName(typeName(ti))).first->second;
+}
+
 } // namespace trussc

--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -4,6 +4,7 @@
 #include "tc/types/tcMod.h"
 #include "tc/utils/tcAsyncScheduler.h"
 #include "tc/utils/tcTypeName.h"
+#include "tc/utils/tcReflect.h"
 #include <memory>
 #include <string>
 #include <atomic>
@@ -49,6 +50,7 @@ public:
     Node() : instanceId_(nextInstanceId_++) { internal::nodeCount++; }
     virtual ~Node() {
         cancelAllAsyncTimers();  // stop + await any in-flight async callbacks
+        for (auto& [t, m] : mods_) m->onDestroy();  // mod cleanup on node destruction
         internal::nodeCount--;
     }
 
@@ -285,9 +287,10 @@ public:
     // Distinct notions:
     //   - getName()       : optional instance name, set by the user (may be empty)
     //   - getTypeName()   : the C++ class name from RTTI (always available, free)
-    //   - getDisplayName(): type name, with the instance name in parens if set
-    //                       ("RectNode" or "RectNode (play)") — type-anchored so
-    //                       a tree/inspector column stays consistent.
+    //   - getDisplayName(): short type name, with the instance name in parens
+    //                       if set ("RectNode" or "RectNode (play)") — uses the
+    //                       unqualified class name (no "trussc::") for readable
+    //                       trees; getTypeName() keeps the full qualified name.
     //   - getInstanceId() : per-process unique id, fixed at construction.
 
     // Optional instance name. Empty unless setName() was called.
@@ -300,14 +303,32 @@ public:
     const std::string& getTypeName() const { return typeName(typeid(*this)); }
 
     // Type-anchored label for trees / inspectors / logs. Always non-empty.
-    // "RectNode" when unnamed, "RectNode (play)" when named.
+    // Uses the short (unqualified) type name: "RectNode" when unnamed,
+    // "RectNode (play)" when named. For the full "trussc::RectNode", use
+    // getTypeName().
     std::string getDisplayName() const {
-        return hasName() ? getTypeName() + " (" + name_ + ")" : getTypeName();
+        const std::string& type = shortTypeName(typeid(*this));
+        return hasName() ? type + " (" + name_ + ")" : type;
     }
 
     // Per-process unique id, assigned once at construction and never changed
     // (stable across reparenting). Read-only — there is no setter.
     uint64_t getInstanceId() const { return instanceId_; }
+
+    // -------------------------------------------------------------------------
+    // Reflection (TC_REFLECT)
+    // -------------------------------------------------------------------------
+    // Exposes a curated set of editable properties (not the raw private fields).
+    // Transform values go through their setters so the matrix cache / change
+    // events stay correct. Subclasses extend via `using Super = Node;` + their
+    // own TC_REFLECT block.
+    TC_REFLECT_ROOT(Node)
+        TC_PROPERTY(pos,      getPos,    setPos)
+        TC_PROPERTY(rotation, getRotDeg, setRotDeg)
+        TC_PROPERTY(scale,    getScale,  setScale)
+        TC_PROPERTY(visible,  isVisible, setVisible)
+        TC_PROPERTY(active,   isActive,  setActive)
+    TC_REFLECT_END
 
     // -------------------------------------------------------------------------
     // Transform - Position
@@ -496,6 +517,12 @@ public:
         return nullptr;
     }
 
+    // Whether a mod of type T is attached
+    template<typename T>
+    bool hasMod() const {
+        return mods_.count(std::type_index(typeid(T))) > 0;
+    }
+
     // Add a mod to this node (returns pointer for chaining)
     template<typename T, typename... Args>
     T* addMod(Args&&... args) {
@@ -503,16 +530,103 @@ public:
         T* ptr = mod.get();
         mod->owner_ = this;
         mods_[std::type_index(typeid(T))] = std::move(mod);
+        // setup() runs after owner_ is set and the mod is in mods_, so it can
+        // safely call getMod / addChild / etc. on its owner.
+        ptr->setup();
         return ptr;
     }
 
-    // Remove a mod by type
+    // Remove a mod by type. onDestroy() is called, then the mod is freed. If a
+    // mod removes itself (or another) during a dispatch/update, destruction is
+    // deferred until iteration finishes so the in-flight call can't dangle.
+    // (A mod can remove itself without naming its type via Mod::removeSelf().)
     template<typename T>
     void removeMod() {
-        mods_.erase(std::type_index(typeid(T)));
+        removeModByType(std::type_index(typeid(T)));
     }
 
 private:
+    // -------------------------------------------------------------------------
+    // Mod dispatch helpers
+    // -------------------------------------------------------------------------
+
+    // Remove a mod by runtime type (shared by removeMod<T>() and
+    // Mod::removeSelf()). Deferred-safe during iteration; calls onDestroy().
+    void removeModByType(std::type_index key) {
+        auto it = mods_.find(key);
+        if (it == mods_.end()) return;
+        if (modDispatchDepth_ > 0) {
+            modsPendingDestroy_.push_back(std::move(it->second));
+            mods_.erase(it);  // gone from lookups now; destroyed after iteration
+        } else {
+            it->second->onDestroy();
+            mods_.erase(it);
+        }
+    }
+
+    // Visit each attached mod. Iterates a snapshot of type indices (so a
+    // handler may add mods — picked up next round — or remove other mods).
+    // A mod that removes itself stays alive until this returns: removeMod()
+    // defers destruction while modDispatchDepth_ > 0, and we sweep the
+    // pending list (calling onDestroy) once the outermost visit finishes.
+    template<typename F>
+    void forEachMod(F&& f) {
+        ++modDispatchDepth_;
+        std::vector<std::type_index> types;
+        types.reserve(mods_.size());
+        for (auto& [t, m] : mods_) types.push_back(t);
+        for (auto& t : types) {
+            auto it = mods_.find(t);
+            if (it != mods_.end()) f(it->second.get());
+        }
+        if (--modDispatchDepth_ == 0 && !modsPendingDestroy_.empty()) {
+            auto pending = std::move(modsPendingDestroy_);
+            modsPendingDestroy_.clear();
+            for (auto& m : pending) m->onDestroy();
+            // pending mods are freed here, after all in-flight calls returned
+        }
+    }
+
+    // Fire an input event to this node's own handler AND its mods; consumed if
+    // either consumes. Mouse events go to the hit/grabbed node, keys broadcast.
+    bool fireMousePress(const MouseEventArgs& e) {
+        bool consumed = onMousePress(e);
+        forEachMod([&](Mod* m) { if (m->onMousePress(e)) consumed = true; });
+        return consumed;
+    }
+    bool fireMouseRelease(const MouseEventArgs& e) {
+        bool consumed = onMouseRelease(e);
+        forEachMod([&](Mod* m) { if (m->onMouseRelease(e)) consumed = true; });
+        return consumed;
+    }
+    bool fireMouseMove(const MouseMoveEventArgs& e) {
+        bool consumed = onMouseMove(e);
+        forEachMod([&](Mod* m) { if (m->onMouseMove(e)) consumed = true; });
+        return consumed;
+    }
+    bool fireMouseDrag(const MouseDragEventArgs& e) {
+        bool consumed = onMouseDrag(e);
+        forEachMod([&](Mod* m) { if (m->onMouseDrag(e)) consumed = true; });
+        return consumed;
+    }
+    bool fireMouseScroll(const ScrollEventArgs& e) {
+        bool consumed = onMouseScroll(e);
+        forEachMod([&](Mod* m) { if (m->onMouseScroll(e)) consumed = true; });
+        return consumed;
+    }
+    bool fireKeyPress(const KeyEventArgs& e) {
+        bool consumed = onKeyPress(e);
+        forEachMod([&](Mod* m) { if (m->onKeyPress(e)) consumed = true; });
+        return consumed;
+    }
+    bool fireKeyRelease(const KeyEventArgs& e) {
+        bool consumed = onKeyRelease(e);
+        forEachMod([&](Mod* m) { if (m->onKeyRelease(e)) consumed = true; });
+        return consumed;
+    }
+    void fireMouseEnter() { onMouseEnter(); forEachMod([](Mod* m) { m->onMouseEnter(); }); }
+    void fireMouseLeave() { onMouseLeave(); forEachMod([](Mod* m) { m->onMouseLeave(); }); }
+
     // -------------------------------------------------------------------------
     // Recursive update/draw (called by App via friend access)
     // -------------------------------------------------------------------------
@@ -530,33 +644,15 @@ private:
             setup();
         }
 
-        // Mod early update (before Node::update). Snapshot type indices —
-        // a mod's earlyUpdate() may call addMod / removeMod on this node,
-        // and `mods_` is an unordered_map whose iterators would otherwise
-        // invalidate. New mods added during dispatch are picked up next frame.
-        {
-            std::vector<std::type_index> modTypes;
-            modTypes.reserve(mods_.size());
-            for (auto& [t, m] : mods_) modTypes.push_back(t);
-            for (auto& t : modTypes) {
-                auto it = mods_.find(t);
-                if (it != mods_.end()) it->second->earlyUpdate();
-            }
-        }
+        // Mod early update (before Node::update). forEachMod snapshots types
+        // and defers self-removal, so a mod may add/remove mods safely here.
+        forEachMod([](Mod* m) { m->earlyUpdate(); });
 
         processTimers();
         update();  // User code
 
-        // Mod update (after Node::update) — same snapshot rationale as above.
-        {
-            std::vector<std::type_index> modTypes;
-            modTypes.reserve(mods_.size());
-            for (auto& [t, m] : mods_) modTypes.push_back(t);
-            for (auto& t : modTypes) {
-                auto it = mods_.find(t);
-                if (it != mods_.end()) it->second->update();
-            }
-        }
+        // Mod update (after Node::update).
+        forEachMod([](Mod* m) { m->update(); });
 
         // Iterate over a snapshot — a child's update() may add, remove, or
         // reorder siblings (via addChild / removeChild / moveToFront / etc.),
@@ -645,10 +741,12 @@ private:
         // Begin draw hook (for clipping, etc.)
         beginDraw();
 
-        // User drawing
+        // User drawing, then mod draw (mods draw in the node's local space,
+        // after the node's own draw()).
         if (isVisible_) {
             resetStyle();
             draw();
+            forEachMod([](Mod* m) { m->draw(); });
         }
 
         // Draw child nodes (overridable for clipping, etc.)
@@ -703,7 +801,7 @@ private:
 
         if (result.hit()) {
             MouseEventArgs local = result.node->localizeMouse(e);
-            if (result.node->onMousePress(local)) {
+            if (result.node->fireMousePress(local)) {
                 // Set grabbed node for drag tracking
                 internal::grabbedNode = result.node.get();
                 internal::grabbedButton = e.button;
@@ -718,7 +816,7 @@ private:
         // Send release to grabbed node if it exists
         if (internal::grabbedNode && internal::grabbedButton == e.button) {
             MouseEventArgs local = internal::grabbedNode->localizeMouse(e);
-            internal::grabbedNode->onMouseRelease(local);
+            internal::grabbedNode->fireMouseRelease(local);
 
             Ptr result = std::dynamic_pointer_cast<Node>(
                 internal::grabbedNode->shared_from_this());
@@ -736,7 +834,7 @@ private:
 
         if (result.hit()) {
             MouseEventArgs local = result.node->localizeMouse(e);
-            if (result.node->onMouseRelease(local)) {
+            if (result.node->fireMouseRelease(local)) {
                 return result.node;
             }
         }
@@ -749,7 +847,7 @@ private:
         if (internal::grabbedNode) {
             MouseEventRaw local = internal::grabbedNode->localizeMouse(e);
             local.button = internal::grabbedButton;
-            internal::grabbedNode->onMouseDrag(toDragArgs(local));
+            internal::grabbedNode->fireMouseDrag(toDragArgs(local));
         }
 
         // Also send move event to hit node (for hover, etc.)
@@ -758,7 +856,7 @@ private:
 
         if (result.hit()) {
             MouseEventRaw local = result.node->localizeMouse(e);
-            if (result.node->onMouseMove(toMoveArgs(local))) {
+            if (result.node->fireMouseMove(toMoveArgs(local))) {
                 return result.node;
             }
         }
@@ -775,7 +873,7 @@ private:
             Node* current = result.node.get();
             while (current) {
                 ScrollEventArgs local = current->localizeScroll(e);
-                if (current->onMouseScroll(local)) {
+                if (current->fireMouseScroll(local)) {
                     // Event consumed
                     return std::dynamic_pointer_cast<Node>(
                         current->shared_from_this());
@@ -812,10 +910,10 @@ private:
         // Fire Enter/Leave events
         if (internal::prevHoveredNode != internal::hoveredNode) {
             if (internal::prevHoveredNode) {
-                internal::prevHoveredNode->onMouseLeave();
+                internal::prevHoveredNode->fireMouseLeave();
             }
             if (internal::hoveredNode) {
-                internal::hoveredNode->onMouseEnter();
+                internal::hoveredNode->fireMouseEnter();
             }
         }
     }
@@ -825,7 +923,7 @@ private:
         if (!isActive_) return false;
 
         // Process self
-        if (onKeyPress(e)) {
+        if (fireKeyPress(e)) {
             return true;  // Consumed
         }
 
@@ -844,7 +942,7 @@ private:
     bool dispatchKeyReleaseRecursive(const KeyEventArgs& e) {
         if (!isActive_) return false;
 
-        if (onKeyRelease(e)) {
+        if (fireKeyRelease(e)) {
             return true;
         }
 
@@ -887,10 +985,15 @@ protected:
             }
         }
 
-        // If no child hit, check self
+        // If no child hit, check self: the node's own hitTest OR any mod's
+        // hitTest (mouse picking). First true wins (mods short-circuit once hit).
         if (!bestResult.hit()) {
             float distance;
-            if (hitTest(localRay, distance)) {
+            bool hit = hitTest(localRay, distance);
+            if (!hit) {
+                forEachMod([&](Mod* m) { if (!hit && m->hitTest(localRay, distance)) hit = true; });
+            }
+            if (hit) {
                 bestResult.node = std::dynamic_pointer_cast<Node>(shared_from_this());
                 bestResult.distance = distance;
                 bestResult.localPoint = localRay.at(distance);
@@ -1068,6 +1171,8 @@ private:
 
     // Mod system
     std::unordered_map<std::type_index, std::unique_ptr<Mod>> mods_;
+    int modDispatchDepth_ = 0;   // >0 while iterating mods (forEachMod)
+    std::vector<std::unique_ptr<Mod>> modsPendingDestroy_;  // removed mid-iteration
 
     // -------------------------------------------------------------------------
     // Transform data (private)
@@ -1175,5 +1280,11 @@ protected:
         }
     }
 };
+
+// Mod::removeSelf — defined here now that Node is complete. Uses the mod's
+// dynamic type so it removes the right entry without the mod naming its type.
+inline void Mod::removeSelf() {
+    if (owner_) owner_->removeModByType(std::type_index(typeid(*this)));
+}
 
 } // namespace trussc

--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -3,7 +3,10 @@
 #include "TrussC.h"
 #include "tc/types/tcMod.h"
 #include "tc/utils/tcAsyncScheduler.h"
+#include "tc/utils/tcTypeName.h"
 #include <memory>
+#include <string>
+#include <atomic>
 #include <vector>
 #include <functional>
 #include <algorithm>
@@ -43,7 +46,7 @@ public:
     using Ptr = std::shared_ptr<Node>;
     using WeakPtr = std::weak_ptr<Node>;
 
-    Node() { internal::nodeCount++; }
+    Node() : instanceId_(nextInstanceId_++) { internal::nodeCount++; }
     virtual ~Node() {
         cancelAllAsyncTimers();  // stop + await any in-flight async callbacks
         internal::nodeCount--;
@@ -182,6 +185,21 @@ public:
         return children_.size();
     }
 
+    // Index of the given child among this node's children (-1 if not a child)
+    int indexOfChild(const Node* child) const {
+        for (size_t i = 0; i < children_.size(); ++i) {
+            if (children_[i].get() == child) return static_cast<int>(i);
+        }
+        return -1;
+    }
+
+    // This node's index among its parent's children (-1 if it has no parent).
+    // A sibling-order counterpart to getParent().
+    int getChildIndex() const {
+        auto p = getParent();
+        return p ? p->indexOfChild(this) : -1;
+    }
+
     // Reorder this node within its parent's child list.
     //
     // Children are drawn in vector order: the first child is drawn first
@@ -259,6 +277,37 @@ public:
 
     // Whether mouse is over this node (auto-updated each frame, O(1))
     bool isMouseOver() const { return internal::hoveredNode == this; }
+
+    // -------------------------------------------------------------------------
+    // Identity / Name
+    // -------------------------------------------------------------------------
+    //
+    // Distinct notions:
+    //   - getName()       : optional instance name, set by the user (may be empty)
+    //   - getTypeName()   : the C++ class name from RTTI (always available, free)
+    //   - getDisplayName(): type name, with the instance name in parens if set
+    //                       ("RectNode" or "RectNode (play)") — type-anchored so
+    //                       a tree/inspector column stays consistent.
+    //   - getInstanceId() : per-process unique id, fixed at construction.
+
+    // Optional instance name. Empty unless setName() was called.
+    Node& setName(const std::string& name) { name_ = name; return *this; }
+    const std::string& getName() const { return name_; }
+    bool hasName() const { return !name_.empty(); }
+
+    // C++ class name (dynamic / most-derived type) via RTTI. Cached per type,
+    // so this is cheap to call even for many nodes. E.g. "trussc::RectNode".
+    const std::string& getTypeName() const { return typeName(typeid(*this)); }
+
+    // Type-anchored label for trees / inspectors / logs. Always non-empty.
+    // "RectNode" when unnamed, "RectNode (play)" when named.
+    std::string getDisplayName() const {
+        return hasName() ? getTypeName() + " (" + name_ + ")" : getTypeName();
+    }
+
+    // Per-process unique id, assigned once at construction and never changed
+    // (stable across reparenting). Read-only — there is no setter.
+    uint64_t getInstanceId() const { return instanceId_; }
 
     // -------------------------------------------------------------------------
     // Transform - Position
@@ -1008,6 +1057,9 @@ private:
 
     bool setupCalled_ = false;    // Ensures setup() is called only once
     bool dead_ = false;           // Marked for removal by destroy()
+    std::string name_;            // Optional instance name (see getName())
+    const uint64_t instanceId_;   // Per-process unique id, fixed at construction
+    inline static std::atomic<uint64_t> nextInstanceId_{0};  // id source
     WeakPtr parent_;
     std::vector<Ptr> children_;
     bool eventsEnabled_ = false;  // Enabled via enableEvents()

--- a/core/include/tcPlatform.h
+++ b/core/include/tcPlatform.h
@@ -123,6 +123,13 @@ IVec2 getWindowPosition();
 // Linux/Mobile/Web: no-op (stub)
 void setWindowPosition(int x, int y);
 
+// Set whether the window shows standard decorations (title bar, borders,
+// buttons). false = borderless/chromeless, but the window stays key-focusable
+// (keyboard works) and closable (exitApp() works). Usually driven once at
+// startup by WindowSettings::setDecorated(), but can be toggled at runtime.
+// Desktop only; no-op on mobile/web.
+void setWindowDecorated(bool decorated);
+
 // Change window size (specified in logical size)
 // macOS: Uses NSWindow
 void setWindowSizeLogical(int width, int height);

--- a/core/platform/android/tcPlatform_android.cpp
+++ b/core/platform/android/tcPlatform_android.cpp
@@ -198,6 +198,11 @@ void setWindowPosition(int x, int y) {
     (void)x; (void)y;
 }
 
+void setWindowDecorated(bool decorated) {
+    // No window decorations to toggle on Android.
+    (void)decorated;
+}
+
 void setWindowSizeLogical(int width, int height) {
     // Android apps are fullscreen — window size is determined by the device
     (void)width;

--- a/core/platform/ios/tcPlatform_ios.mm
+++ b/core/platform/ios/tcPlatform_ios.mm
@@ -107,6 +107,11 @@ void setWindowPosition(int x, int y) {
     (void)x; (void)y;
 }
 
+void setWindowDecorated(bool decorated) {
+    // No window decorations to toggle on iOS.
+    (void)decorated;
+}
+
 void setWindowSizeLogical(int width, int height) {
     // no-op on iOS (window size is fixed to screen size)
     (void)width;

--- a/core/platform/linux/tcPlatform_linux.cpp
+++ b/core/platform/linux/tcPlatform_linux.cpp
@@ -79,6 +79,29 @@ void setWindowPosition(int x, int y) {
     (void)x; (void)y;
 }
 
+void setWindowDecorated(bool decorated) {
+    Display* display = XOpenDisplay(nullptr);
+    if (!display) return;
+    Window window = (Window)(uintptr_t)sapp_x11_get_window();
+    if (window) {
+        // Motif WM hints: clear the decorations flag to drop the WM-drawn frame.
+        struct {
+            unsigned long flags;
+            unsigned long functions;
+            unsigned long decorations;
+            long          input_mode;
+            unsigned long status;
+        } hints = {0};
+        hints.flags = (1L << 1);                 // MWM_HINTS_DECORATIONS
+        hints.decorations = decorated ? 1 : 0;   // 1 = all, 0 = none
+        Atom prop = XInternAtom(display, "_MOTIF_WM_HINTS", False);
+        XChangeProperty(display, window, prop, prop, 32, PropModeReplace,
+                        (unsigned char*)&hints, 5);
+        XFlush(display);
+    }
+    XCloseDisplay(display);
+}
+
 void setWindowSizeLogical(int width, int height) {
     // TODO: Implement using X11
     // sokol_app handles window creation, so we need to access the X11 window

--- a/core/platform/mac/tcPlatform_mac.mm
+++ b/core/platform/mac/tcPlatform_mac.mm
@@ -108,6 +108,50 @@ void setWindowPosition(int x, int y) {
     [window setFrameOrigin:origin];
 }
 
+void setWindowDecorated(bool decorated) {
+    NSWindow* window = (__bridge NSWindow*)sapp_macos_get_window();
+    if (!window) return;
+
+    const NSWindowStyleMask base = NSWindowStyleMaskTitled |
+                                   NSWindowStyleMaskClosable |
+                                   NSWindowStyleMaskMiniaturizable |
+                                   NSWindowStyleMaskResizable;
+
+    if (decorated) {
+        window.styleMask = base;
+        window.titlebarAppearsTransparent = NO;
+        window.titleVisibility = NSWindowTitleVisible;
+        window.movableByWindowBackground = NO;
+        window.hasShadow = YES;
+        [[window standardWindowButton:NSWindowCloseButton]       setHidden:NO];
+        [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:NO];
+        [[window standardWindowButton:NSWindowZoomButton]        setHidden:NO];
+    } else {
+        // Keep the window *titled* (so it can become key AND stays closable —
+        // sokol's quit path calls performClose:, which no-ops on a borderless
+        // window) but hide all chrome with a transparent, full-size-content
+        // title bar. The result looks borderless yet keyboard + exitApp() work.
+        window.styleMask = base | NSWindowStyleMaskFullSizeContentView;
+        window.titlebarAppearsTransparent = YES;
+        window.titleVisibility = NSWindowTitleHidden;
+        window.movableByWindowBackground = YES;
+        [[window standardWindowButton:NSWindowCloseButton]       setHidden:YES];
+        [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
+        [[window standardWindowButton:NSWindowZoomButton]        setHidden:YES];
+
+        // macOS (Tahoe+) auto-rounds window corners; the Metal layer is square,
+        // so paint the backdrop black and drop the shadow to avoid a glowing
+        // corner/edge highlight.
+        window.backgroundColor = [NSColor blackColor];
+        window.opaque = YES;
+        window.hasShadow = NO;
+    }
+
+    // Re-assert key + first responder so mouse and keyboard keep flowing.
+    [window makeKeyAndOrderFront:nil];
+    [window makeFirstResponder:window.contentView];
+}
+
 void setWindowSizeLogical(int width, int height) {
     // メインウィンドウを取得
     NSWindow* window = [[NSApplication sharedApplication] mainWindow];

--- a/core/platform/web/tcPlatform_web.cpp
+++ b/core/platform/web/tcPlatform_web.cpp
@@ -36,6 +36,11 @@ void setWindowPosition(int x, int y) {
     (void)x; (void)y;
 }
 
+void setWindowDecorated(bool decorated) {
+    // No window decorations to toggle on Web.
+    (void)decorated;
+}
+
 void setWindowSizeLogical(int width, int height) {
     // Emscripten では canvas サイズを変更
     // sokol_app が使用する canvas ID を指定

--- a/core/platform/win/tcPlatform_win.cpp
+++ b/core/platform/win/tcPlatform_win.cpp
@@ -128,6 +128,24 @@ void setWindowPosition(int x, int y) {
     SetWindowPos(hwnd, nullptr, x, y, 0, 0, SWP_NOZORDER | SWP_NOSIZE | SWP_NOACTIVATE);
 }
 
+void setWindowDecorated(bool decorated) {
+    HWND hwnd = (HWND)sapp_win32_get_hwnd();
+    if (!hwnd) return;
+
+    // Toggle the caption/border/system-menu bits. Keyboard focus and the quit
+    // path (PostQuitMessage) are unaffected by this on Windows.
+    const LONG_PTR chrome = WS_CAPTION | WS_THICKFRAME |
+                            WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU;
+    LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
+    if (decorated) style |= chrome;
+    else           style &= ~chrome;
+    SetWindowLongPtr(hwnd, GWL_STYLE, style);
+
+    // SWP_FRAMECHANGED makes the new (non-)client frame take effect.
+    SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+}
+
 void setWindowSizeLogical(int width, int height) {
     HWND hwnd = (HWND)sapp_win32_get_hwnd();
     if (!hwnd) {

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -614,6 +614,7 @@ void drawPolyline(Polyline polyline)     // Draw a polyline
 Mesh createBox(float size)               // Create a box mesh
 Mesh createBox(float w, float h, float d) // Create a box mesh
 Mesh createSphere(float radius, int res = 20) // Create a sphere mesh
+Mesh createCapsule(float radius, float cylinderHeight, int res = 16) // Create a capsule mesh (Y-up: cylinder capped by two hemispheres)
 void drawTexture(const Texture& tex, float x, float y) // Draw a texture
 void drawTexture(const Texture& tex, float x, float y, float w, float h) // Draw a texture
 ```

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -546,6 +546,10 @@ void setTarget(const Vec3 &in target)    // Set camera look-at target
 Vec3 getTarget()                         // Get camera look-at target
 void setDistance(float distance)         // Set distance from target
 float getDistance()                      // Get distance from target
+void setAzimuth(float radians)           // Set orbit azimuth (horizontal angle, radians)
+float getAzimuth()                       // Get orbit azimuth (horizontal angle, radians)
+void setElevation(float radians)         // Set orbit elevation (vertical angle, radians; clamped to ~±80°)
+float getElevation()                     // Get orbit elevation (vertical angle, radians)
 void setFov(float radians)               // Set field of view in radians
 float getFov()                           // Get field of view in radians
 void setFovDeg(float degrees)            // Set field of view in degrees
@@ -575,10 +579,6 @@ void clearMaterial()                     // Clear material (return to default re
 void setCameraPosition(const Vec3& pos)  // Set camera position for specular calculation
 void setCameraPosition(float x, float y, float z) // Set camera position for specular calculation
 void setEnvironment(Environment& env)    // Set IBL environment for PBR ambient lighting
-                                         //   NOTE: IBL is auto-skipped on iOS/iPadOS Safari (wasm) —
-                                         //   cube-face render targets break the canvas there, so PBR
-                                         //   falls back to flat ambient + direct lights. Works on
-                                         //   native, desktop web, and Android web.
 void clearEnvironment()                  // Clear IBL environment
 void beginShadowPass(Light& light)       // Begin shadow depth pass from the light's point of view
 void endShadowPass()                     // End shadow depth pass

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -5939,6 +5939,17 @@ categories:
         sketch: true
         snippet: "createSphere(${1:radius})"
 
+      - name: createCapsule
+        return: "Mesh"
+        signatures:
+          - params: "float radius, float cylinderHeight, int res = 16"
+            params_simple: "radius, cylinderHeight, res"
+        description: "Create a capsule mesh (Y-up: cylinder capped by two hemispheres)"
+        description_ja: "カプセルメッシュを作成（Y軸、円柱の両端を半球で閉じた形）"
+        description_ko: "캡슐 메쉬를 생성 (Y축, 원기둥 양 끝을 반구로 막은 형태)"
+        sketch: true
+        snippet: "createCapsule(${1:radius}, ${2:cylinderHeight})"
+
       - name: drawTexture
         return: "void"
         signatures:

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -5353,6 +5353,50 @@ categories:
         sketch: true
         snippet: "getDistance()"
 
+      - name: setAzimuth
+        return: "void"
+        signatures:
+          - params: "float radians"
+            params_simple: "radians"
+        description: "Set orbit azimuth (horizontal angle, radians)"
+        description_ja: "周回の方位角（水平角・ラジアン）を設定"
+        description_ko: "궤도 방위각(수평각, 라디안)을 설정"
+        sketch: true
+        snippet: "setAzimuth(${1:0.7})"
+
+      - name: getAzimuth
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get orbit azimuth (horizontal angle, radians)"
+        description_ja: "周回の方位角（水平角・ラジアン）を取得"
+        description_ko: "궤도 방위각(수평각, 라디안)을 얻음"
+        sketch: true
+        snippet: "getAzimuth()"
+
+      - name: setElevation
+        return: "void"
+        signatures:
+          - params: "float radians"
+            params_simple: "radians"
+        description: "Set orbit elevation (vertical angle, radians; clamped to ~±80°)"
+        description_ja: "周回の仰角（垂直角・ラジアン、約±80°でクランプ）を設定"
+        description_ko: "궤도 고도각(수직각, 라디안; 약 ±80°로 제한)을 설정"
+        sketch: true
+        snippet: "setElevation(${1:0.5})"
+
+      - name: getElevation
+        return: "float"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Get orbit elevation (vertical angle, radians)"
+        description_ja: "周回の仰角（垂直角・ラジアン）を取得"
+        description_ko: "궤도 고도각(수직각, 라디안)을 얻음"
+        sketch: true
+        snippet: "getElevation()"
+
       - name: setFov
         return: "void"
         signatures:

--- a/examples/graphics/strokeExample/src/tcApp.cpp
+++ b/examples/graphics/strokeExample/src/tcApp.cpp
@@ -56,11 +56,20 @@ void tcApp::draw() {
     drawBitmapString(info, 10, 20);
 }
 
-void tcApp::mouseMoved(const MouseMoveEventArgs& e) {
-    history.push_back(e.pos);
+void tcApp::addPoint(Vec2 pos) {
+    history.push_back(pos);
     if (history.size() > maxHistory) {
         history.erase(history.begin());
     }
+}
+
+// Hover (desktop) and drag (touch / mouse drag) both extend the line
+void tcApp::mouseMoved(const MouseMoveEventArgs& e) {
+    addPoint(e.pos);
+}
+
+void tcApp::mouseDragged(const MouseDragEventArgs& e) {
+    addPoint(e.pos);
 }
 
 void tcApp::mousePressed(const MouseEventArgs& e) {

--- a/examples/graphics/strokeExample/src/tcApp.h
+++ b/examples/graphics/strokeExample/src/tcApp.h
@@ -8,10 +8,12 @@ public:
     void setup() override;
     void draw() override;
     void mouseMoved(const MouseMoveEventArgs& e) override;
+    void mouseDragged(const MouseDragEventArgs& e) override;
     void mousePressed(const MouseEventArgs& e) override;
     void keyPressed(int key) override;
 
 private:
+    void addPoint(Vec2 pos);
     vector<Vec2> history;
     static constexpr int maxHistory = 100;
     bool useStroke = true;


### PR DESCRIPTION
**Summary**
- Add `EasyCam::setAzimuth(rad)` / `setElevation(rad)` (+ `getAzimuth`/`getElevation`) so an oblique 3/4 view can be framed at startup — previously only the default head-on side view was reachable (the orbit angles `rotationX_`/`rotationY_` had no public setter).
- `setElevation` is clamped to ~±80°, matching the mouse-drag handler.
- Registered in `docs/api-definition.yaml`; `docs/REFERENCE.md` regenerated.

**Why**
3D scenes (and the tcxPhysics examples in particular) usually want a non-head-on default camera. This is a small, additive, header-only API.

Details below — single commit, no behaviour change to existing code.