### PR TITLE
feat(input): overlay input arbitration via consume + capture

### DIFF
--- a/addons/tcxImGui/src/tcxImGui.h
+++ b/addons/tcxImGui/src/tcxImGui.h
@@ -42,6 +42,39 @@ public:
             simgui_handle_event(&ev);
         }, tc::EventPriority::BeforeApp);
 
+        // Overlay capture queries — tell the framework when imgui owns the
+        // pointer / keyboard so node-tree hover is suppressed under panels and
+        // user code can guard raw input (isOverlayHovered/isOverlayFocused).
+        tc::internal::overlayHoveredQuery = []() { return ImGui::GetIO().WantCaptureMouse; };
+        tc::internal::overlayFocusedQuery = []() { return ImGui::GetIO().WantCaptureKeyboard; };
+
+        // Consume input before it reaches the node tree (BeforeApp). Pointer
+        // capture follows the press: a gesture imgui claims on press stays
+        // imgui's until release, so a drag begun on the canvas is never stolen
+        // mid-way, and a press over a panel owns the whole gesture. Move/scroll
+        // and keys are stateless — consumed whenever imgui wants them.
+        mousePressConsume_ = tc::events().mousePressed.listen([this](tc::MouseEventArgs& e) {
+            if (ImGui::GetIO().WantCaptureMouse) { pointerCaptured_ = true; e.consumed = true; }
+        }, tc::EventPriority::BeforeApp);
+        mouseReleaseConsume_ = tc::events().mouseReleased.listen([this](tc::MouseEventArgs& e) {
+            if (pointerCaptured_) { e.consumed = true; pointerCaptured_ = false; }
+        }, tc::EventPriority::BeforeApp);
+        mouseDragConsume_ = tc::events().mouseDragged.listen([this](tc::MouseDragEventArgs& e) {
+            if (pointerCaptured_) e.consumed = true;
+        }, tc::EventPriority::BeforeApp);
+        mouseMoveConsume_ = tc::events().mouseMoved.listen([](tc::MouseMoveEventArgs& e) {
+            if (ImGui::GetIO().WantCaptureMouse) e.consumed = true;
+        }, tc::EventPriority::BeforeApp);
+        mouseScrollConsume_ = tc::events().mouseScrolled.listen([](tc::ScrollEventArgs& e) {
+            if (ImGui::GetIO().WantCaptureMouse) e.consumed = true;
+        }, tc::EventPriority::BeforeApp);
+        keyPressConsume_ = tc::events().keyPressed.listen([](tc::KeyEventArgs& e) {
+            if (ImGui::GetIO().WantCaptureKeyboard) e.consumed = true;
+        }, tc::EventPriority::BeforeApp);
+        keyReleaseConsume_ = tc::events().keyReleased.listen([](tc::KeyEventArgs& e) {
+            if (ImGui::GetIO().WantCaptureKeyboard) e.consumed = true;
+        }, tc::EventPriority::BeforeApp);
+
         tc::logVerbose() << "ImGui initialized";
     }
 
@@ -50,6 +83,16 @@ public:
         if (!initialized_) return;
         renderListener_ = {};
         eventListener_ = {};
+        mousePressConsume_ = {};
+        mouseReleaseConsume_ = {};
+        mouseDragConsume_ = {};
+        mouseMoveConsume_ = {};
+        mouseScrollConsume_ = {};
+        keyPressConsume_ = {};
+        keyReleaseConsume_ = {};
+        tc::internal::overlayHoveredQuery = nullptr;
+        tc::internal::overlayFocusedQuery = nullptr;
+        pointerCaptured_ = false;
         simgui_shutdown();
         initialized_ = false;
         tc::logVerbose() << "ImGui shutdown";
@@ -89,6 +132,16 @@ private:
     bool renderPending_ = false;
     tc::EventListener renderListener_;
     tc::EventListener eventListener_;
+
+    // Input arbitration: consume listeners (BeforeApp) + pointer-gesture capture.
+    bool pointerCaptured_ = false;  // imgui owns the current press→release gesture
+    tc::EventListener mousePressConsume_;
+    tc::EventListener mouseReleaseConsume_;
+    tc::EventListener mouseDragConsume_;
+    tc::EventListener mouseMoveConsume_;
+    tc::EventListener mouseScrollConsume_;
+    tc::EventListener keyPressConsume_;
+    tc::EventListener keyReleaseConsume_;
 };
 
 // ---------------------------------------------------------------------------

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -2377,10 +2377,14 @@ namespace internal {
                     args.button = currentMouseButton;
                     MouseDragEventArgs dragArgs = toDragArgs(args);
                     events().mouseDragged.notify(dragArgs);
+                    // The public typed arg carries `consumed`; copy it back to the
+                    // raw carrier so handleMouseDragged can gate the tree dispatch.
+                    args.consumed = dragArgs.consumed;
                     if (appMouseDraggedFunc) appMouseDraggedFunc(args);
                 } else {
                     MouseMoveEventArgs moveArgs = toMoveArgs(args);
                     events().mouseMoved.notify(moveArgs);
+                    args.consumed = moveArgs.consumed;
                     if (appMouseMovedFunc) appMouseMovedFunc(args);
                 }
                 break;
@@ -2453,6 +2457,7 @@ namespace internal {
                         margs.button = MOUSE_BUTTON_LEFT;
                         MouseDragEventArgs dragArgs = toDragArgs(margs);
                         events().mouseDragged.notify(dragArgs);
+                        margs.consumed = dragArgs.consumed;
                         if (appMouseDraggedFunc) appMouseDraggedFunc(margs);
                     } else {
                         currentMouseButton = -1;

--- a/core/include/tcBaseApp.h
+++ b/core/include/tcBaseApp.h
@@ -165,39 +165,45 @@ public:
     // Event handlers (called by TrussC.h, dispatches to scene graph)
     // -------------------------------------------------------------------------
 
+    // Each handler fires the user-facing App virtual unconditionally (so the
+    // raw App::mouseXxx/keyXxx override stays an always-on escape hatch), then
+    // dispatches to the node tree ONLY if the event was not already consumed.
+    // A higher-priority consumer (e.g. tcxImGui, a BeforeApp listener) sets
+    // `consumed` during events().xxx.notify() to claim the event before it
+    // reaches the tree. See _event_cb in TrussC.h.
     void handleKeyPressed(const KeyEventArgs& e) {
         keyPressed(e);
-        dispatchKeyPress(e);
+        if (!e.consumed) dispatchKeyPress(e);
     }
 
     void handleKeyReleased(const KeyEventArgs& e) {
         keyReleased(e);
-        dispatchKeyRelease(e);
+        if (!e.consumed) dispatchKeyRelease(e);
     }
 
     void handleMousePressed(const MouseEventArgs& e) {
         mousePressed(e);
-        dispatchMousePress(e);
+        if (!e.consumed) dispatchMousePress(e);
     }
 
     void handleMouseReleased(const MouseEventArgs& e) {
         mouseReleased(e);
-        dispatchMouseRelease(e);
+        if (!e.consumed) dispatchMouseRelease(e);
     }
 
     void handleMouseMoved(const MouseEventRaw& e) {
         mouseMoved(toMoveArgs(e));
-        dispatchMouseMove(e);
+        if (!e.consumed) dispatchMouseMove(e);
     }
 
     void handleMouseDragged(const MouseEventRaw& e) {
         mouseDragged(toDragArgs(e));
-        dispatchMouseMove(e);  // drag + hover share the node-tree move dispatch
+        if (!e.consumed) dispatchMouseMove(e);  // drag + hover share the node-tree move dispatch
     }
 
     void handleMouseScrolled(const ScrollEventArgs& e) {
         mouseScrolled(e);
-        dispatchMouseScroll(e);
+        if (!e.consumed) dispatchMouseScroll(e);
     }
 
     void handleWindowResized(int width, int height) {

--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -33,7 +33,20 @@ namespace internal {
     inline Node* grabbedNode = nullptr;      // Node grabbed by mouse press
     inline int grabbedButton = -1;           // Mouse button that caused the grab
     inline Node* selectedNode = nullptr;     // Last node clicked (selection)
+
+    // Overlay (e.g. tcxImGui) capture queries. An overlay registers these so the
+    // framework knows when the pointer is over it / it owns keyboard focus. Null
+    // when no overlay is present, so plain apps are unaffected.
+    inline std::function<bool()> overlayHoveredQuery;
+    inline std::function<bool()> overlayFocusedQuery;
 }
+
+// True when an overlay currently has the pointer over it (e.g. cursor is over a
+// tcxImGui panel) / owns keyboard focus (e.g. an InputText is active). The node
+// tree's hover honors isOverlayHovered() automatically; guard raw input in user
+// code with these (e.g. `if (isOverlayFocused()) return;` in a key handler).
+inline bool isOverlayHovered() { return internal::overlayHoveredQuery && internal::overlayHoveredQuery(); }
+inline bool isOverlayFocused() { return internal::overlayFocusedQuery && internal::overlayFocusedQuery(); }
 
 // =============================================================================
 // Node - Scene graph base class
@@ -907,10 +920,17 @@ private:
         // Save previous frame's hovered node
         internal::prevHoveredNode = internal::hoveredNode;
 
-        // Search for new hovered node
-        Ray globalRay = Ray::fromScreenPoint2D(screenX, screenY);
-        HitResult result = findHitNode(globalRay);
-        internal::hoveredNode = result.hit() ? result.node.get() : nullptr;
+        // Search for new hovered node. When an overlay (e.g. a tcxImGui panel)
+        // has the pointer, the tree hovers nothing — so a node under the panel
+        // is not highlighted, and a previously-hovered node still gets its
+        // Leave below (this is a per-frame recompute, so no stale hover).
+        Node* hit = nullptr;
+        if (!isOverlayHovered()) {
+            Ray globalRay = Ray::fromScreenPoint2D(screenX, screenY);
+            HitResult result = findHitNode(globalRay);
+            hit = result.hit() ? result.node.get() : nullptr;
+        }
+        internal::hoveredNode = hit;
 
         // Fire Enter/Leave events
         if (internal::prevHoveredNode != internal::hoveredNode) {
@@ -924,42 +944,37 @@ private:
     }
 
     // Recursive dispatch of key events
+    // Key dispatch mirrors findHitNodeRecursive: deepest / front-most node gets
+    // the key first (children in reverse draw order), then self last. The first
+    // node to consume (fireKeyXxx returns true) short-circuits the rest.
     bool dispatchKeyPressRecursive(const KeyEventArgs& e) {
         if (!isActive_) return false;
 
-        // Process self
-        if (fireKeyPress(e)) {
-            return true;  // Consumed
-        }
-
-        // Snapshot — handlers may mutate the tree.
+        // Children first, reverse draw order (snapshot — handlers may mutate the tree)
         auto childrenSnapshot = children_;
-        for (auto& child : childrenSnapshot) {
-            if (child->isDead()) continue;
-            if (child->dispatchKeyPressRecursive(e)) {
+        for (auto it = childrenSnapshot.rbegin(); it != childrenSnapshot.rend(); ++it) {
+            if ((*it)->isDead()) continue;
+            if ((*it)->dispatchKeyPressRecursive(e)) {
                 return true;
             }
         }
 
-        return false;
+        // Self last
+        return fireKeyPress(e);
     }
 
     bool dispatchKeyReleaseRecursive(const KeyEventArgs& e) {
         if (!isActive_) return false;
 
-        if (fireKeyRelease(e)) {
-            return true;
-        }
-
         auto childrenSnapshot = children_;
-        for (auto& child : childrenSnapshot) {
-            if (child->isDead()) continue;
-            if (child->dispatchKeyReleaseRecursive(e)) {
+        for (auto it = childrenSnapshot.rbegin(); it != childrenSnapshot.rend(); ++it) {
+            if ((*it)->isDead()) continue;
+            if ((*it)->dispatchKeyReleaseRecursive(e)) {
                 return true;
             }
         }
 
-        return false;
+        return fireKeyRelease(e);
     }
 
 protected:

--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -32,6 +32,7 @@ namespace internal {
     inline Node* prevHoveredNode = nullptr;  // Previously hovered node
     inline Node* grabbedNode = nullptr;      // Node grabbed by mouse press
     inline int grabbedButton = -1;           // Mouse button that caused the grab
+    inline Node* selectedNode = nullptr;     // Last node clicked (selection)
 }
 
 // =============================================================================
@@ -708,6 +709,7 @@ private:
             internal::grabbedNode = nullptr;
             internal::grabbedButton = -1;
         }
+        if (internal::selectedNode == this) internal::selectedNode = nullptr;
 
         dead_ = true;
         cleanup();
@@ -798,6 +800,9 @@ private:
     Ptr dispatchMousePress(const MouseEventArgs& e) {
         Ray globalRay = Ray::fromScreenPoint2D(e.globalPos.x, e.globalPos.y);
         HitResult result = findHitNode(globalRay);
+
+        // Selection: clicking a node selects it; clicking empty space clears it.
+        internal::selectedNode = result.hit() ? result.node.get() : nullptr;
 
         if (result.hit()) {
             MouseEventArgs local = result.node->localizeMouse(e);
@@ -1286,5 +1291,11 @@ protected:
 inline void Mod::removeSelf() {
     if (owner_) owner_->removeModByType(std::type_index(typeid(*this)));
 }
+
+// Selection — the last-clicked node, held by the Node system (set in
+// dispatchMousePress, cleared when the node is destroyed). A tool such as an
+// inspector can both read it and drive it via setSelectedNode().
+inline Node* getSelectedNode() { return internal::selectedNode; }
+inline void setSelectedNode(Node* n) { internal::selectedNode = n; }
 
 } // namespace trussc


### PR DESCRIPTION
## Problem
Clicking the imgui inspector panel cleared the scene selection: imgui isn't
in the node tree, so `dispatchMousePress` still ran under the panel, hit
nothing, and reset `selectedNode`. More broadly, the event pipeline had no
way for an overlay to claim input before the node tree.

## Solution — consume + capture on the Event chain
Input arg structs carry `bool consumed`; `Event<T>::notify` stops at the
first listener that sets it. tcxImGui becomes a **BeforeApp consumer**; the
node tree is the **base consumer** — `App::handleMouseXxx/handleKeyXxx` fire
the user virtual unconditionally, then dispatch to the tree only `if (!e.consumed)`.

Pointer capture follows the press: a gesture imgui claims on press stays
imgui's until release, so a drag begun on the canvas is never stolen
mid-way, and a press over a panel owns the whole gesture. Move/scroll/keys
are stateless (consumed whenever imgui wants them).

The inspector-clears-selection bug then vanishes structurally — a consumed
press never reaches `dispatchMousePress`, so `selectedNode` is untouched.

## Also in this PR
- **Overlay queries** `isOverlayHovered()` / `isOverlayFocused()` (backed by
  WantCaptureMouse / WantCaptureKeyboard). `updateHoverState` hovers nothing
  while overlay-hovered — no background highlight under panels, and Leave
  still fires (per-frame recompute, no stale hover). User code can guard raw
  input with these.
- **Key dispatch now deepest/front-first** (mirrors `findHitNodeRecursive`),
  first to consume wins — was ancestor-first. Global behavior change.
- **Selection API** `getSelectedNode()` / `setSelectedNode()`.
- Raw `App::mousePressed/keyPressed` overrides always fire (escape hatch).

## Verification
- macOS build green (core + tcxImGui).
- Headless test through the real event path — 7/7: click-selects, **overlay
  click preserves selection (bug fix)**, empty-click clears, overlay-aware
  hover + Leave, key deepest-first.
- Live-confirmed in `apps/hierarchyReflect`: inspector is operable and scene
  selection is preserved while editing.

## Notes
- The key dispatch order change affects all apps (deepest-first / DOM-bubble-like).
