### PR TITLE
refactor!: unify reflection macros into TC_REFLECT + TC_VALUE (breaking)

### DIFF
--- a/addons/tcxNodeInspector/README.md
+++ b/addons/tcxNodeInspector/README.md
@@ -55,7 +55,6 @@ clicking them on the canvas.
 
 ```cpp
 struct Sprite : Node {
-    using Super = Node;             // inherit Node's pos/rotation/scale/... fields
     Color color{1, 1, 1, 1};
     float radius = 30;
 
@@ -68,22 +67,25 @@ struct Sprite : Node {
         return false;
     }
 
-    TC_REFLECT(Sprite)
-        TC_FIELD(color)
-        TC_FIELD(radius)
-    TC_REFLECT_END
+    TC_REFLECT(Sprite, Node) {      // list the direct base: Node's pos/rotation/... chain in
+        TC_VALUE(color)
+        TC_VALUE(radius)
+        TC_VALUE(alive, isAlive)              // getter only = read-only (greyed out)
+        TC_VALUE(speed, getSpeed, setSpeed)   // getter + setter = editable
+    }
 };
 ```
 
 The Inspector renders each reflected type with the matching ImGui widget
-(`float`/`int`/`bool`/`Vec2`/`Vec3`/`Color`/`string`). Enum members declared with
-`TC_ENUM` render as a combo of their labels (`TC_ENUM_LABELS`), and getter-only
-properties (`TC_PROPERTY_RO`) render greyed out. Want a custom widget for a
-type? Subclass `tcx::ImGuiReflector` and override the relevant `visit()`.
+(`float`/`int`/`bool`/`Vec2`/`Vec3`/`Color`/`string`). Enum values render as a
+combo of their labels when the enum declares them (`TC_ENUM_LABELS`, optional —
+without labels an enum edits as a plain int), and getter-only values render
+greyed out. Want a custom widget for a type? Subclass `tcx::ImGuiReflector`
+and override the relevant `visit()`.
 
 ## Mods
 
-Mods reflect too (`using Super = Mod;` + a `TC_REFLECT` block) — the Inspector
+Mods reflect too (a `TC_REFLECT` block with `Mod` as the base) — the Inspector
 shows one section per attached mod under the node's members, edited through the
 same reflector. Core's `LayoutMod` and `TweenMod` ship reflected, so e.g.
 flipping a LayoutMod's `direction` combo re-stacks its children live, while a

--- a/addons/tcxNodeInspector/example-basic/src/scene.h
+++ b/addons/tcxNodeInspector/example-basic/src/scene.h
@@ -7,16 +7,15 @@ using namespace tc;
 
 // =============================================================================
 // Demo node types. Node is the reflection root (it reflects pos / rotation /
-// scale / visible / active), so a subclass only adds `using Super = Node;` plus
-// its own TC_FIELDs. Each VisualNode is also clickable on the canvas: it
-// enables events and provides a circle hit-test, so a canvas click selects it —
-// the same selection the inspector tree drives.
+// scale / visible / active), so a subclass just opens a TC_REFLECT block that
+// lists its direct base and its own TC_VALUEs. Each VisualNode is also
+// clickable on the canvas: it enables events and provides a circle hit-test,
+// so a canvas click selects it — the same selection the inspector tree drives.
 // =============================================================================
 
 // A circle. Reflects a color, a radius and a filled flag (on top of Node's
 // transform), and picks via a circle hit shape.
 struct VisualNode : public Node {
-    using Super = Node;
     Color color{0.35f, 0.62f, 0.92f, 1.0f};
     float radius = 30.0f;
     bool  filled = true;
@@ -36,16 +35,15 @@ struct VisualNode : public Node {
         return false;
     }
 
-    TC_REFLECT(VisualNode)         // pos / rotation / scale / ... come from Node
-        TC_FIELD(color)
-        TC_FIELD(radius)
-        TC_FIELD(filled)
-    TC_REFLECT_END
+    TC_REFLECT(VisualNode, Node) {         // pos / rotation / scale / ... come from Node
+        TC_VALUE(color)
+        TC_VALUE(radius)
+        TC_VALUE(filled)
+    }
 };
 
 // Two levels deep: inherits Node + VisualNode members, adds a string + int.
 struct LabeledNode : public VisualNode {
-    using Super = VisualNode;
     string text = "label";
     int    fontSize = 12;
 
@@ -56,19 +54,15 @@ struct LabeledNode : public VisualNode {
         drawBitmapString(text, 0, 0);
     }
 
-    TC_REFLECT(LabeledNode)
-        TC_FIELD(text)
-        TC_FIELD(fontSize)
-    TC_REFLECT_END
+    TC_REFLECT(LabeledNode, VisualNode) {
+        TC_VALUE(text)
+        TC_VALUE(fontSize)
+    }
 };
 
-// Plain group (no extra fields) — still reflects Node's transform, and shows up
-// in the tree as a parent you can collapse / expand.
-struct GroupNode : public Node {
-    using Super = Node;
-    TC_REFLECT(GroupNode)
-    TC_REFLECT_END
-};
+// Plain group (no extra values) — no TC_REFLECT block needed: it inherits
+// Node's, so the inspector still shows the transform.
+struct GroupNode : public Node {};
 
 // =============================================================================
 // 3D space: a camera-scope node. Children are drawn between cam.begin()/end(),
@@ -79,7 +73,6 @@ struct GroupNode : public Node {
 // shift+drag never also selects a node.
 // =============================================================================
 struct Space3D : public Node {
-    using Super = Node;
     EasyCam cam;
 
     void setup() override {
@@ -106,15 +99,12 @@ struct Space3D : public Node {
         }
     }
 
-    TC_REFLECT(Space3D)
-    TC_REFLECT_END
 };
 
 // A cube standing on the floor. Exact ray-vs-box picking (slab test) in local
 // space — the incoming ray was already unprojected through the EasyCam and
 // transformed by this node's matrix, so the test itself stays simple.
 struct CubeNode : public Node {
-    using Super = Node;
     Color color{0.8f, 0.8f, 0.8f, 1.0f};
     float size = 80.0f;
 
@@ -148,18 +138,18 @@ struct CubeNode : public Node {
         return true;
     }
 
-    TC_REFLECT(CubeNode)
-        TC_FIELD(color)
-        TC_FIELD(size)
-    TC_REFLECT_END
+    TC_REFLECT(CubeNode, Node) {
+        TC_VALUE(color)
+        TC_VALUE(size)
+    }
 };
 
 // A demo Mod: draws a ring around its owner (mod draw), and reacts to keys when
 // its owner is selected (mod input). Press X to remove the mod from itself.
-// Its members are reflected (using Super = Mod;), so the inspector shows an
-// "OutlineMod" section under the owner's members and the MCP dump carries them.
+// Its values are reflected (TC_REFLECT with Mod as the base), so the inspector
+// shows an "OutlineMod" section under the owner's members and the MCP dump
+// carries them.
 struct OutlineMod : public Mod {
-    using Super = Mod;
     Color color{1.0f, 0.85f, 0.2f, 1.0f};
     float gap = 6.0f;
 
@@ -175,17 +165,16 @@ struct OutlineMod : public Mod {
         return false;
     }
 
-    TC_REFLECT(OutlineMod)
-        TC_FIELD(color)
-        TC_FIELD(gap)
-    TC_REFLECT_END
+    TC_REFLECT(OutlineMod, Mod) {
+        TC_VALUE(color)
+        TC_VALUE(gap)
+    }
 };
 
 // A flat colored rectangle. Size comes reflected from RectNode; rect-based hit
 // testing makes overlapping rects pick FRONTMOST-first, which is what makes
 // the inspector's "To front" / "To back" operations meaningful to play with.
 struct ColorRect : public RectNode {
-    using Super = RectNode;
     Color color{0.5f, 0.5f, 0.5f, 1.0f};
 
     ColorRect() {
@@ -199,9 +188,9 @@ struct ColorRect : public RectNode {
         drawRect(0, 0, getWidth(), getHeight());
     }
 
-    TC_REFLECT(ColorRect)
-        TC_FIELD(color)
-    TC_REFLECT_END
+    TC_REFLECT(ColorRect, RectNode) {
+        TC_VALUE(color)
+    }
 };
 
 // =============================================================================

--- a/addons/tcxNodeInspector/src/tcxNodeInspector.h
+++ b/addons/tcxNodeInspector/src/tcxNodeInspector.h
@@ -32,7 +32,7 @@ namespace tcx {
 
 // Renders each reflected member as the matching ImGui widget. Public so an app
 // can subclass and override a visit() to customize how a given type is edited.
-// Read-only properties (TC_PROPERTY_RO) render greyed out; enums (TC_ENUM)
+// Read-only values (getter-only TC_VALUE) render greyed out; enums
 // render as a combo of their labels.
 struct ImGuiReflector : ::trussc::Reflector {
     bool visit(const char* n, float& v) override       { return edit([&] { return ImGui::DragFloat(n, &v, 0.5f); }); }

--- a/core/include/tc/types/tcLayoutMod.h
+++ b/core/include/tc/types/tcLayoutMod.h
@@ -124,18 +124,17 @@ public:
     // -------------------------------------------------------------------------
     // Reflection
     // -------------------------------------------------------------------------
-    // Every property re-runs the layout through its setter on edit.
-    using Super = Mod;
-    TC_REFLECT(LayoutMod)
-        TC_ENUM_PROPERTY(direction, getDirection, setDirection)
-        TC_PROPERTY(spacing, getSpacing, setSpacing)
-        TC_ENUM_PROPERTY(crossAxis, getCrossAxis, setCrossAxis)
-        TC_ENUM_PROPERTY(mainAxis, getMainAxis, setMainAxis)
-        TC_PROPERTY(paddingLeft, getPaddingLeft, setPaddingLeft)
-        TC_PROPERTY(paddingTop, getPaddingTop, setPaddingTop)
-        TC_PROPERTY(paddingRight, getPaddingRight, setPaddingRight)
-        TC_PROPERTY(paddingBottom, getPaddingBottom, setPaddingBottom)
-    TC_REFLECT_END
+    // Every value re-runs the layout through its setter on edit.
+    TC_REFLECT(LayoutMod, Mod) {
+        TC_VALUE(direction, getDirection, setDirection)
+        TC_VALUE(spacing, getSpacing, setSpacing)
+        TC_VALUE(crossAxis, getCrossAxis, setCrossAxis)
+        TC_VALUE(mainAxis, getMainAxis, setMainAxis)
+        TC_VALUE(paddingLeft, getPaddingLeft, setPaddingLeft)
+        TC_VALUE(paddingTop, getPaddingTop, setPaddingTop)
+        TC_VALUE(paddingRight, getPaddingRight, setPaddingRight)
+        TC_VALUE(paddingBottom, getPaddingBottom, setPaddingBottom)
+    }
 
     // -------------------------------------------------------------------------
     // Manual layout trigger

--- a/core/include/tc/types/tcMod.h
+++ b/core/include/tc/types/tcMod.h
@@ -43,10 +43,9 @@ public:
     // Reflection (TC_REFLECT)
     // -------------------------------------------------------------------------
     // Mod is its own reflection root (parallel to Node's). Subclasses expose
-    // members with `using Super = Mod;` + their own TC_REFLECT block; they then
-    // show up in inspectors and in the MCP node tree dump.
-    TC_REFLECT_ROOT(Mod)
-    TC_REFLECT_END
+    // values with TC_REFLECT(MyMod, Mod) { TC_VALUE(...) }; they then show up
+    // in inspectors and in the MCP node tree dump.
+    TC_REFLECT_ROOT(Mod) {}
 
 protected:
     // Remove this mod from its owner (no need to name its own type). Safe to

--- a/core/include/tc/types/tcRectNode.h
+++ b/core/include/tc/types/tcRectNode.h
@@ -69,11 +69,10 @@ public:
     // -------------------------------------------------------------------------
     // Reflection
     // -------------------------------------------------------------------------
-    using Super = Node;
-    TC_REFLECT(RectNode)
-        TC_PROPERTY(size, getSize, setSize)
-        TC_PROPERTY(clipping, isClipping, setClipping)
-    TC_REFLECT_END
+    TC_REFLECT(RectNode, Node) {
+        TC_VALUE(size, getSize, setSize)
+        TC_VALUE(clipping, isClipping, setClipping)
+    }
 
     // -------------------------------------------------------------------------
     // Clipping settings

--- a/core/include/tc/types/tcTweenMod.h
+++ b/core/include/tc/types/tcTweenMod.h
@@ -278,15 +278,14 @@ public:
     // Timing + easing are editable (even mid-tween); playback state is shown
     // read-only. Targets are not reflected — they only mean something together
     // with their enabled/relative flags, i.e. through the builder calls.
-    using Super = Mod;
-    TC_REFLECT(TweenMod)
-        TC_PROPERTY(duration, getDuration, duration)
-        TC_PROPERTY(delay, getDelay, delay)
-        TC_ENUM_PROPERTY(easeType, getEaseType, setEaseType)
-        TC_ENUM_PROPERTY(easeMode, getEaseMode, setEaseMode)
-        TC_PROPERTY_RO(playing, isPlaying)
-        TC_PROPERTY_RO(progress, getProgress)
-    TC_REFLECT_END
+    TC_REFLECT(TweenMod, Mod) {
+        TC_VALUE(duration, getDuration, duration)
+        TC_VALUE(delay, getDelay, delay)
+        TC_VALUE(easeType, getEaseType, setEaseType)
+        TC_VALUE(easeMode, getEaseMode, setEaseMode)
+        TC_VALUE(playing, isPlaying)            // no setter = read-only
+        TC_VALUE(progress, getProgress)         // no setter = read-only
+    }
 
 private:
     // Single-value setters for reflection (ease() sets both at once).

--- a/core/include/tc/utils/tcReflect.h
+++ b/core/include/tc/utils/tcReflect.h
@@ -1,37 +1,55 @@
 #pragma once
 
 // =============================================================================
-// tcReflect.h - explicit member reflection (TC_REFLECT)
+// tcReflect.h - explicit member reflection (TC_REFLECT / TC_VALUE)
 //
-// A type exposes editable members for inspectors / serialization by listing
-// them. Node is the reflection root; subclasses chain automatically with
-// `using Super = Base;`:
+// A type exposes values for inspectors / serialization by listing them in a
+// TC_REFLECT block — a normal function body in disguise, so the braces are
+// real braces:
 //
-//     struct Sprite : Node {
-//         using Super = Node;          // inherits Node's reflected members
-//         Color color;
-//         float radius = 30;
-//         BlendMode blend = BlendMode::Alpha;
-//         TC_REFLECT(Sprite)
-//             TC_FIELD(color)          // plain field, edited in place
-//             TC_FIELD(radius)
-//             TC_ENUM(blend)           // enum field (labels via TC_ENUM_LABELS)
-//         TC_REFLECT_END
+//     enum class WeaponType { Sword, Bow, Staff };
+//     TC_ENUM_LABELS(WeaponType, "Sword", "Bow", "Staff")   // optional
+//
+//     struct Enemy : Node {
+//         float hp = 100;
+//         WeaponType weapon = WeaponType::Sword;
+//         bool isAlive() const { return hp > 0; }
+//
+//         TC_REFLECT(Enemy, Node) {                  // list the DIRECT bases
+//             TC_VALUE(hp)                           // member, edited in place
+//             TC_VALUE(weapon)                       // enums auto-detected
+//             TC_VALUE(alive, isAlive)               // getter only = read-only
+//             TC_VALUE(speed, getSpeed, setSpeed)    // setter runs on edit
+//         }
 //     };
 //
-// Backends implement Reflector (one typed visit() per supported type) — e.g.
-// an ImGui inspector, a JSON writer, a binary codec. Plain fields use
-// TC_FIELD; getter/setter pairs use TC_PROPERTY so invariants (dirty flags,
-// clamping, events) run on edit; getter-only values use TC_PROPERTY_RO.
+// TC_VALUE arity is the access mode:
+//     TC_VALUE(member)                // a data member, edited in place
+//     TC_VALUE(name, getter)          // read-only: no setter exists, so it
+//                                     // can't be written — shown greyed out,
+//                                     // write tools refuse it
+//     TC_VALUE(name, getter, setter)  // editable: read via getter, write via
+//                                     // setter so invariants (dirty flags,
+//                                     // clamping, events) run
 //
-// Enums travel through one extra visit() channel as an int plus a label table
-// (index == enum value), declared once per enum type next to the enum:
+// Bases chain recursively: each class lists only its DIRECT bases, and gets
+// the whole ancestor chain through them (multiple direct bases are all
+// chained). TC_REFLECT(Self) with no bases chains nothing. Reflection roots
+// (Node, Mod, or a standalone mixin) use TC_REFLECT_ROOT(Self) instead, which
+// declares the virtual.
+//
+// Enums work in any TC_VALUE (they travel as an int). To get human-readable
+// presentation — a combo box in inspectors, label strings in JSON — declare
+// the label table once, next to the enum:
 //
 //     TC_ENUM_LABELS(BlendMode, "Alpha", "Add", "Multiply", ...)
 //
 // The labels are found by ADL, so invoke TC_ENUM_LABELS in the enum's own
 // namespace. The default enum visit() falls back to the plain int visit, so
 // backends that don't know about enums keep working unchanged.
+//
+// Backends implement Reflector (one typed visit() per supported type) — e.g.
+// an ImGui inspector, a JSON writer, a binary codec.
 // =============================================================================
 
 #include <string>
@@ -50,7 +68,7 @@ struct EnumLabelSpan {
     int count = 0;
 };
 
-// Visitor over a type's members. One overload per supported type; each returns
+// Visitor over a type's values. One overload per supported type; each returns
 // true if the value was edited this call.
 struct Reflector {
     virtual ~Reflector() = default;
@@ -70,9 +88,9 @@ struct Reflector {
         return visit(name, v);
     }
 
-    // Read-only scope — TC_PROPERTY_RO visits inside push/pop. Backends check
-    // isReadOnly() to render disabled / refuse writes; edits are discarded
-    // regardless (there is no setter to receive them).
+    // Read-only scope — the 2-arg TC_VALUE visits inside push/pop. Backends
+    // check isReadOnly() to render disabled / refuse writes; edits are
+    // discarded regardless (there is no setter to receive them).
     bool isReadOnly() const { return readOnlyDepth_ > 0; }
     void pushReadOnly() { ++readOnlyDepth_; }
     void popReadOnly() { if (readOnlyDepth_ > 0) --readOnlyDepth_; }
@@ -81,62 +99,85 @@ private:
     int readOnlyDepth_ = 0;
 };
 
-// Chain to the base's members if the type declares `using Super = Base;`.
-// Qualified call -> non-virtual, so no infinite recursion. No Super -> no-op.
+// Chain the listed direct bases' reflect blocks, in order. Qualified calls ->
+// non-virtual, so each base contributes exactly its own chain (no recursion
+// through the vtable). The single-base helper exists because clang refuses a
+// pack used as the nested-name-specifier of a member access inside a fold.
+template <class Base, class T>
+inline void reflectOneBase(T* self, Reflector& r) {
+    self->Base::reflectMembers(r);
+}
+template <class... Bases, class T>
+inline void reflectBases(T* self, Reflector& r) {
+    (reflectOneBase<Bases>(self, r), ...);
+}
+
+// Visit one value of any reflectable type — the single funnel TC_VALUE goes
+// through. Enums are detected here: they travel as an int, through the
+// labeled enum channel when the enum has a TC_ENUM_LABELS declaration (found
+// by ADL), as a plain int otherwise. Being a template matters: if constexpr
+// discards the non-matching branch without type-checking it.
 template <class T>
-inline void reflectSuper(T* self, Reflector& r) {
-    if constexpr (requires { typename T::Super; }) {
-        using S = typename T::Super;
-        self->S::reflectMembers(r);
+inline bool reflectValue(Reflector& r, const char* name, T& v) {
+    if constexpr (std::is_enum_v<T>) {
+        int i = static_cast<int>(v);
+        bool edited;
+        if constexpr (requires { tcEnumLabelsAdl(T{}); }) {
+            edited = r.visit(name, i, tcEnumLabelsAdl(T{}));
+        } else {
+            edited = r.visit(name, i);
+        }
+        if (edited) v = static_cast<T>(i);
+        return edited;
+    } else {
+        return r.visit(name, v);
     }
 }
 
 } // namespace trussc
 
 // Declare the label table for an enum type. Invoke at namespace scope in the
-// enum's own namespace (found by ADL from TC_ENUM / TC_ENUM_PROPERTY).
-// Labels are listed in declaration order: labels[(int)value] == name.
+// enum's own namespace (found by ADL from TC_VALUE). Labels are listed in
+// declaration order: labels[(int)value] == name.
 #define TC_ENUM_LABELS(EnumType, ...) \
     inline ::trussc::EnumLabelSpan tcEnumLabelsAdl(EnumType) { \
         static constexpr const char* labels_[] = {__VA_ARGS__}; \
         return { labels_, static_cast<int>(sizeof(labels_) / sizeof(labels_[0])) }; \
     }
 
-// Open the member-enumeration function. TC_REFLECT_ROOT declares the virtual
-// (use on the base, e.g. Node); TC_REFLECT overrides it (use on subclasses).
-// Between open and TC_REFLECT_END, list members with TC_FIELD / TC_PROPERTY /
-// TC_PROPERTY_RO / TC_ENUM / TC_ENUM_PROPERTY.
+// Open a reflect block. Both expand to reflectMembers() (chains the bases,
+// then this class's own values) plus the declaration of reflectOwnMembers();
+// the block braces the user writes right after become its body:
+//
+//     TC_REFLECT(Self, DirectBases...) { TC_VALUE(...) ... }
+//     TC_REFLECT_ROOT(Self)            { TC_VALUE(...) ... }   // declares the virtual
+//
 #define TC_REFLECT_ROOT(Self) \
-    virtual void reflectMembers(::trussc::Reflector& r) { \
-        ::trussc::reflectSuper<Self>(this, r);
-#define TC_REFLECT(Self) \
+    virtual void reflectMembers(::trussc::Reflector& r) { reflectOwnMembers(r); } \
+    void reflectOwnMembers(::trussc::Reflector& r)
+
+#define TC_REFLECT(Self, ...) \
     void reflectMembers(::trussc::Reflector& r) override { \
-        ::trussc::reflectSuper<Self>(this, r);
-#define TC_REFLECT_END }
+        ::trussc::reflectBases<__VA_ARGS__>(this, r); \
+        reflectOwnMembers(r); \
+    } \
+    void reflectOwnMembers(::trussc::Reflector& r)
 
-// A plain data member: edited in place.
-#define TC_FIELD(member) r.visit(#member, member);
+// One reflected value (see the header comment for the arity rule). A trailing
+// semicolon after the macro is harmless.
+#define TC_VALUE_1_(member) ::trussc::reflectValue(r, #member, member);
+#define TC_VALUE_2_(name, getter) \
+    do { auto _tcv = getter(); \
+         r.pushReadOnly(); \
+         ::trussc::reflectValue(r, #name, _tcv); \
+         r.popReadOnly(); } while (0);
+#define TC_VALUE_3_(name, getter, setter) \
+    do { auto _tcv = getter(); \
+         if (::trussc::reflectValue(r, #name, _tcv)) setter(_tcv); } while (0);
 
-// A getter/setter property: read via getter; on edit, write via setter so any
-// invariants (dirty flags, clamping, change events) run.
-#define TC_PROPERTY(name, getter, setter) \
-    do { auto _tcv = getter(); if (r.visit(#name, _tcv)) setter(_tcv); } while (0);
-
-// A getter-only property: shown but not editable (runtime state like a tween's
-// progress). Backends see isReadOnly() == true while visiting.
-#define TC_PROPERTY_RO(name, getter) \
-    do { auto _tcv = getter(); r.pushReadOnly(); r.visit(#name, _tcv); r.popReadOnly(); } while (0);
-
-// An enum data member: travels as int + label table (TC_ENUM_LABELS).
-#define TC_ENUM(member) \
-    do { using _tcE = std::decay_t<decltype(member)>; \
-         int _tci = static_cast<int>(member); \
-         if (r.visit(#member, _tci, tcEnumLabelsAdl(_tcE{}))) \
-             member = static_cast<_tcE>(_tci); } while (0);
-
-// An enum getter/setter property.
-#define TC_ENUM_PROPERTY(name, getter, setter) \
-    do { auto _tce = getter(); using _tcE = decltype(_tce); \
-         int _tci = static_cast<int>(_tce); \
-         if (r.visit(#name, _tci, tcEnumLabelsAdl(_tcE{}))) \
-             setter(static_cast<_tcE>(_tci)); } while (0);
+// Arity dispatch (the extra expansion keeps MSVC's traditional preprocessor
+// from passing __VA_ARGS__ through as a single token).
+#define TC_VALUE_SELECT_(_1, _2, _3, NAME, ...) NAME
+#define TC_VALUE_EXPAND_(x) x
+#define TC_VALUE(...) \
+    TC_VALUE_EXPAND_(TC_VALUE_SELECT_(__VA_ARGS__, TC_VALUE_3_, TC_VALUE_2_, TC_VALUE_1_)(__VA_ARGS__))

--- a/core/include/tcNode.h
+++ b/core/include/tcNode.h
@@ -343,18 +343,18 @@ public:
     // -------------------------------------------------------------------------
     // Reflection (TC_REFLECT)
     // -------------------------------------------------------------------------
-    // Exposes a curated set of editable properties (not the raw private fields).
+    // Exposes a curated set of editable values (not the raw private fields).
     // Transform values go through their setters so the matrix cache / change
-    // events stay correct. Subclasses extend via `using Super = Node;` + their
-    // own TC_REFLECT block.
-    TC_REFLECT_ROOT(Node)
-        TC_PROPERTY(pos,       getPos,       setPos)
-        TC_PROPERTY(globalPos, getGlobalPos, setGlobalPos)
-        TC_PROPERTY(rotation,  getEulerDeg,  setEulerDeg)   // euler X/Y/Z, degrees
-        TC_PROPERTY(scale,     getScale,     setScale)
-        TC_PROPERTY(visible,   isVisible,    setVisible)
-        TC_PROPERTY(active,    isActive,     setActive)
-    TC_REFLECT_END
+    // events stay correct. Subclasses extend with their own block, listing
+    // their direct base: TC_REFLECT(Sprite, Node) { TC_VALUE(...) }
+    TC_REFLECT_ROOT(Node) {
+        TC_VALUE(pos,       getPos,       setPos)
+        TC_VALUE(globalPos, getGlobalPos, setGlobalPos)
+        TC_VALUE(rotation,  getEulerDeg,  setEulerDeg)   // euler X/Y/Z, degrees
+        TC_VALUE(scale,     getScale,     setScale)
+        TC_VALUE(visible,   isVisible,    setVisible)
+        TC_VALUE(active,    isActive,     setActive)
+    }
 
     // -------------------------------------------------------------------------
     // Transform - Position

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -4,6 +4,11 @@
   (Gemini Gem, custom GPT, Claude project, etc.) so the assistant can
   generate idiomatic TrussC code. If you are a human looking for docs,
   start with docs/GET_STARTED.md or docs/REFERENCE.md instead.
+  If you are a CONSOLE CODING AGENT (Claude Code, Codex, or similar with
+  file/shell access), do not load this file — install the TrussC development
+  skill instead; it covers the same ground plus build/verify workflows:
+      git clone https://github.com/TrussC-org/TrussC_Development_Skill.git ~/.claude/skills/trussc-dev
+  (Codex: clone into ~/.codex/skills/trussc-dev)
 -->
 
 You are a coding assistant for the TrussC framework.
@@ -75,6 +80,10 @@ int main() {
 setFps(VSYNC);         // Sync to monitor (default)
 setFps(60);            // Fixed 60fps
 setFps(EVENT_DRIVEN);  // Redraw only on demand
+
+// Recommended for GUI/tool apps: fixed update + draw only on redraw().
+// Stable timers/tweens on any monitor Hz; idle GUI costs ~zero GPU.
+setIndependentFps(60, EVENT_DRIVEN);   // call redraw() on every visible change
 ```
 
 ## Drawing
@@ -723,6 +732,14 @@ While the app is running, saving any source file in `src/` triggers an automatic
 
 All projects use `TC_RUN_APP(tcApp, settings)` in `main.cpp` by default. This macro automatically selects between normal and hot reload mode — no changes to `main.cpp` needed.
 
+## AI Automation (MCP)
+
+Every TrussC app can run as an MCP server: launch with `TRUSSC_MCP=1` and the app
+exposes screenshots, input injection, and live node-tree read/write over HTTP —
+AI agents can drive and verify the running app directly. As a chat assistant you
+won't use this yourself; just know it exists so you can point users to it
+(details: docs/AI_AUTOMATION.md, agent workflows: the TrussC_Development_Skill repo).
+
 ## Addons
 
 Addons add optional features. To use: run `trusscli addon add <addon>` (or check the addon in the GUI), then `#include` the addon header.
@@ -737,11 +754,15 @@ using namespace tcx::box2d;
 |-------|----------|-------------|
 | tcxBox2d | physics | 2D physics engine (Box2D) |
 | tcxCurl | network | HTTPS client (libcurl) |
+| tcxDepthCamera | 3d | Unified depth / point-cloud camera interface |
+| tcxDepthRecord | 3d | Record & replay depth recordings (.tcdc) |
 | tcxGltf | 3d | glTF 2.0 / GLB model loader (cgltf) |
 | tcxHap | video | HAP/HAPQ video codec (GPU-compressed) |
 | tcxImGui | gui | Dear ImGui integration |
 | tcxLua | bridges | Lua scripting binding |
 | tcxLut | graphics | 3D LUT color grading (.cube format) |
+| tcxMidi | sound | MIDI input/output (libremidi) |
+| tcxNodeInspector | gui | Runtime hierarchy + inspector + gizmo (Unity-style debug panel) |
 | tcxObj | 3d | Wavefront OBJ model import/export |
 | tcxOsc | network | Open Sound Control (OSC) protocol |
 | tcxQuadWarp | graphics | Quad warping for projection mapping |


### PR DESCRIPTION
Collapses the just-shipped reflection macro family into a minimal surface, **before anyone learns the old spelling** (it landed in #114 days ago — this removes it outright rather than deprecating).

## New API — the whole thing

```cpp
enum class WeaponType { Sword, Bow, Staff };
TC_ENUM_LABELS(WeaponType, "Sword", "Bow", "Staff")   // optional

struct Enemy : Node {
    float hp = 100;
    WeaponType weapon = WeaponType::Sword;
    bool isAlive() const { return hp > 0; }

    TC_REFLECT(Enemy, Node) {                  // list the DIRECT bases
        TC_VALUE(hp)                           // member, edited in place
        TC_VALUE(weapon)                       // enums auto-detected
        TC_VALUE(alive, isAlive)               // getter only = read-only
        TC_VALUE(speed, getSpeed, setSpeed)    // setter runs on edit
    }
};
```

Two macros to learn (TC_REFLECT, TC_VALUE) plus the optional TC_ENUM_LABELS. Arity is the access mode: no setter exists → it can't be written → shown greyed, write tools refuse it.

## Removed (deleted, not deprecated)

`TC_FIELD`, `TC_PROPERTY`, `TC_PROPERTY_RO`, `TC_ENUM`, `TC_ENUM_PROPERTY`, `TC_REFLECT_END`, and the `using Super = X;` convention.

## Why the shape changed

- **Bases live in TC_REFLECT** — `TC_REFLECT(Boss, Enemy, StatsMixin)` chains every direct base (fold expression). Each class lists only its DIRECT bases; skipped generations resolve through inheritance. This kills the silent member loss when a subclass forgot its own `using Super` and inherited the wrong one.
- **Real braces** — TC_REFLECT generates `reflectMembers` plus the `reflectOwnMembers` signature, and the user's `{ ... }` is that function's body. IDE brace matching / folding / clang-format all behave; a missing brace is an ordinary compile error, and plain C++ statements still work inside the block.
- **Enums auto-detect** — TC_VALUE funnels through one `reflectValue<T>`: enums travel as int, upgraded to combo box / JSON label strings when the enum declares `TC_ENUM_LABELS` (found by ADL, works in any namespace).
- Trailing `;` after TC_VALUE is harmless; a trailing `,` is a loud per-line compile error.
- clang quirk worked around: a pack as the nested-name-specifier of a member access inside a fold is rejected → one-base helper.

## Migrated in this PR

Node, RectNode, Mod, LayoutMod, TweenMod, tcxNodeInspector (example + README). (tcxPhysics' RigidBody updated in its own repo.)

## Verification

- Headless: reflection 54/54 — including a multi-base chain (`TC_REFLECT(Boss, TestNode, StatsMixin)`) read & write, unlabeled-enum degradation, read-only refusal reporting — plus gizmo/multi-select 44, camera context, overlay input, all green (macOS)
- Live MCP check on the inspector example (tree dump shows chained members; enum labels intact)