### PR TITLE
fix: tcxImGui crash on window close

### DIFF
--- a/addons/tcxImGui/README.md
+++ b/addons/tcxImGui/README.md
@@ -43,13 +43,11 @@ void tcApp::draw() {
     ImGui::End();
     imguiEnd();
 }
-
-void tcApp::cleanup() {
-    imguiShutdown();
-}
 ```
 
 ImGui renders on top of all TrussC content automatically via the `onRender` event.
+Teardown is automatic too — the addon listens to the framework's exit event and
+shuts itself down when the app closes, so there is nothing to call in `cleanup()`.
 
 ## API
 
@@ -58,7 +56,7 @@ ImGui renders on top of all TrussC content automatically via the `onRender` even
 | Function | Description |
 |----------|-------------|
 | `imguiSetup()` | Initialize ImGui (call in setup) |
-| `imguiShutdown()` | Shutdown ImGui (call in cleanup) |
+| `imguiShutdown()` | Shut down ImGui early (optional — runs automatically on app exit) |
 | `imguiBegin()` | Start ImGui frame (call at start of your GUI code) |
 | `imguiEnd()` | End ImGui frame (rendering is deferred to onRender) |
 

--- a/addons/tcxImGui/example-basic/src/tcApp.cpp
+++ b/addons/tcxImGui/example-basic/src/tcApp.cpp
@@ -72,7 +72,3 @@ void tcApp::draw() {
     imguiEnd();
 }
 
-void tcApp::cleanup() {
-    // Shutdown ImGui
-    imguiShutdown();
-}

--- a/addons/tcxImGui/example-basic/src/tcApp.h
+++ b/addons/tcxImGui/example-basic/src/tcApp.h
@@ -12,7 +12,6 @@ class tcApp : public App {
 public:
     void setup() override;
     void draw() override;
-    void cleanup() override;
 
 private:
     // Variables for demo

--- a/addons/tcxImGui/src/tcxImGui.h
+++ b/addons/tcxImGui/src/tcxImGui.h
@@ -75,12 +75,18 @@ public:
             if (ImGui::GetIO().WantCaptureKeyboard) e.consumed = true;
         }, tc::EventPriority::BeforeApp);
 
+        // Auto-teardown at the framework's exit event, while sokol_gfx and the
+        // event system are still alive. Apps don't need to call imguiShutdown()
+        // themselves (calling it stays harmless — shutdown() is idempotent).
+        exitListener_ = tc::events().exit.listen([this]() { shutdown(); });
+
         tc::logVerbose() << "ImGui initialized";
     }
 
     // Shutdown
     void shutdown() {
         if (!initialized_) return;
+        exitListener_ = {};
         renderListener_ = {};
         eventListener_ = {};
         mousePressConsume_ = {};
@@ -93,7 +99,11 @@ public:
         tc::internal::overlayHoveredQuery = nullptr;
         tc::internal::overlayFocusedQuery = nullptr;
         pointerCaptured_ = false;
-        simgui_shutdown();
+        // GPU teardown only while sokol_gfx is alive. If shutdown runs from the
+        // static destructor during exit() (e.g. an abnormal teardown path where
+        // the exit event never fired), sokol_gfx is already gone and its objects
+        // with it — skipping is the correct cleanup, touching them would crash.
+        if (sg_isvalid()) simgui_shutdown();
         initialized_ = false;
         tc::logVerbose() << "ImGui shutdown";
     }
@@ -130,6 +140,7 @@ private:
 
     bool initialized_ = false;
     bool renderPending_ = false;
+    tc::EventListener exitListener_;
     tc::EventListener renderListener_;
     tc::EventListener eventListener_;
 


### PR DESCRIPTION
Closing the window (`NSApp terminate` → `exit()`) crashed with SIGSEGV in `simgui_shutdown` — the static `ImGuiManager` destructor ran after sokol_gfx was already torn down and touched dead GPU pools (`sg_query_view_image`). The MCP `quit` path was unaffected because sokol's regular cleanup runs while the GPU is alive.

## Fix
- Auto-teardown on `events().exit` (fires while sokol_gfx + the event system are still alive). Apps no longer need to call `imguiShutdown()` in `cleanup()` — it stays available for early shutdown and is idempotent.
- Guard GPU teardown with `sg_isvalid()` for abnormal exit paths.
- Drop the now-unnecessary `imguiShutdown()` from `example-basic` and document that teardown is automatic.

## Verification
Generated app + example-basic — both quit and real close-button exit cleanly (crash reports 1 → 0); double-registration prevented by the `initialized_` guard + `EventListener` RAII.