### PR TITLE
fix: Path::drawFill renders garbage on some fonts (winding rule + self-intersection)

### DIFF
--- a/core/include/tc/graphics/tcPath.h
+++ b/core/include/tc/graphics/tcPath.h
@@ -462,40 +462,144 @@ public:
     // To cut a hole in a hand-built Path, wind the inner subpath opposite to
     // the outer one (see reverseWinding()). Zero-winding subpaths with no
     // enclosing filled ring are drawn as independent polygons (fallback).
+    //
+    // Self-intersecting subpaths are split at each crossing into simple
+    // rings before tessellation. Machine-converted fonts (e.g. CFF →
+    // TrueType builds of Noto) often carry tiny self-crossing loops at
+    // stroke joins; rasterizers never notice (non-zero winding scanning is
+    // immune) but ear clipping requires simple polygons. After splitting,
+    // an inverted micro-loop gets winding 0 and vanishes as a sub-pixel
+    // hole, and a genuine figure-8 fills both lobes — both matching what a
+    // real non-zero winding rasterizer produces.
     // Use draw() with `fill` enabled for the fast convex-only fan path.
     void drawFill() const {
         if (vertices_.empty()) return;
-        const size_t N = subpathStarts_.size();
         auto& ctx = getDefaultContext();
         Color col = ctx.getColor();
 
-        struct SubInfo {
-            size_t s, e;
+        using Point   = std::array<float, 2>;
+        using Ring    = std::vector<Point>;
+        using Polygon = std::vector<Ring>;
+
+        // ---- Collect subpaths into working rings (fill is 2D; z dropped).
+        // Consecutive duplicates and the closing vertex (== start) are
+        // removed so zero-length edges can't confuse the geometry below.
+        std::vector<Ring> rings;
+        rings.reserve(subpathStarts_.size());
+        for (size_t si = 0; si < subpathStarts_.size(); ++si) {
+            auto [s, e] = getSubpathRange(si);
+            if (e - s < 3) continue;
+            Ring r;
+            r.reserve(e - s);
+            for (size_t k = s; k < e; ++k) {
+                const Point p{vertices_[k].x, vertices_[k].y};
+                if (!r.empty() && r.back() == p) continue;
+                r.push_back(p);
+            }
+            while (r.size() >= 2 && r.front() == r.back()) r.pop_back();
+            if (r.size() >= 3) rings.push_back(std::move(r));
+        }
+        if (rings.empty()) return;
+
+        // ---- Split self-intersecting rings into simple rings. Each proper
+        // crossing X of two edges splits the ring into two rings touching at
+        // X; every split strictly reduces the remaining crossing count, so
+        // this terminates (guard cap for float pathologies). Piece edges are
+        // subsets of the original edges, so no new crossings appear.
+        {
+            auto cleanRing = [](Ring& r) {
+                Ring out;
+                out.reserve(r.size());
+                for (const Point& p : r) {
+                    if (out.empty() || out.back() != p) out.push_back(p);
+                }
+                while (out.size() >= 2 && out.front() == out.back()) out.pop_back();
+                r = std::move(out);
+            };
+
+            int guard = 1024;
+            for (size_t ri = 0; ri < rings.size() && guard > 0; ) {
+                const size_t n = rings[ri].size();
+                bool didSplit = false;
+                for (size_t i = 0; i < n && !didSplit; ++i) {
+                    const size_t i2 = (i + 1) % n;
+                    for (size_t j = i + 1; j < n && !didSplit; ++j) {
+                        const size_t j2 = (j + 1) % n;
+                        if (i2 == j || j2 == i) continue;  // adjacent edges share a vertex
+                        const Point& A = rings[ri][i];
+                        const Point& B = rings[ri][i2];
+                        const Point& C = rings[ri][j];
+                        const Point& D = rings[ri][j2];
+                        // bbox reject
+                        if (std::max(A[0], B[0]) < std::min(C[0], D[0]) ||
+                            std::max(C[0], D[0]) < std::min(A[0], B[0]) ||
+                            std::max(A[1], B[1]) < std::min(C[1], D[1]) ||
+                            std::max(C[1], D[1]) < std::min(A[1], B[1])) continue;
+                        // strict proper crossing (touching endpoints excluded —
+                        // touching rings are handled fine by the parity vote)
+                        const double abx = (double)B[0] - A[0], aby = (double)B[1] - A[1];
+                        const double cdx = (double)D[0] - C[0], cdy = (double)D[1] - C[1];
+                        const double denom = abx * cdy - aby * cdx;
+                        if (denom == 0.0) continue;
+                        const double acx = (double)C[0] - A[0], acy = (double)C[1] - A[1];
+                        const double t = (acx * cdy - acy * cdx) / denom;  // along AB
+                        const double u = (acx * aby - acy * abx) / denom;  // along CD
+                        if (t <= 0.0 || t >= 1.0 || u <= 0.0 || u >= 1.0) continue;
+
+                        const Point X{(float)(A[0] + t * abx), (float)(A[1] + t * aby)};
+                        Ring r1, r2;
+                        r1.push_back(X);
+                        for (size_t k = i2; ; k = (k + 1) % n) {
+                            r1.push_back(rings[ri][k]);
+                            if (k == j) break;
+                        }
+                        r2.push_back(X);
+                        for (size_t k = j2; ; k = (k + 1) % n) {
+                            r2.push_back(rings[ri][k]);
+                            if (k == i) break;
+                        }
+                        cleanRing(r1);
+                        cleanRing(r2);
+                        // Replace the ring with the valid pieces (a piece that
+                        // collapsed below 3 verts was a zero-area sliver).
+                        if (r1.size() >= 3 && r2.size() >= 3) {
+                            rings[ri] = std::move(r1);
+                            rings.push_back(std::move(r2));
+                        } else if (r1.size() >= 3) {
+                            rings[ri] = std::move(r1);
+                        } else if (r2.size() >= 3) {
+                            rings[ri] = std::move(r2);
+                        } else {
+                            rings.erase(rings.begin() + (ptrdiff_t)ri);
+                        }
+                        didSplit = true;
+                        --guard;
+                    }
+                }
+                if (!didSplit) ++ri;  // ring is simple; re-scan same index after a split
+            }
+        }
+        if (rings.empty()) return;
+
+        const size_t N = rings.size();
+        struct RingInfo {
             float minX, minY, maxX, maxY;
             float area;       // signed shoelace area; sign = winding direction
             int   winding = 0;
             int   parent  = -1;
         };
-        std::vector<SubInfo> info(N);
+        std::vector<RingInfo> info(N);
         for (size_t i = 0; i < N; ++i) {
-            auto [s, e] = getSubpathRange(i);
-            info[i].s = s; info[i].e = e;
-            info[i].area = 0.f;
-            if (e - s == 0) {
-                info[i].minX = info[i].minY = 0;
-                info[i].maxX = info[i].maxY = 0;
-                continue;
-            }
-            float mnX = vertices_[s].x, mxX = mnX;
-            float mnY = vertices_[s].y, mxY = mnY;
+            const Ring& r = rings[i];
+            float mnX = r[0][0], mxX = mnX;
+            float mnY = r[0][1], mxY = mnY;
             float area = 0.f;
-            for (size_t k = s, j = e - 1; k < e; j = k++) {
-                mnX = std::min(mnX, vertices_[k].x);
-                mxX = std::max(mxX, vertices_[k].x);
-                mnY = std::min(mnY, vertices_[k].y);
-                mxY = std::max(mxY, vertices_[k].y);
-                area += vertices_[j].x * vertices_[k].y
-                      - vertices_[k].x * vertices_[j].y;
+            for (size_t k = 0, j = r.size() - 1; k < r.size(); j = k++) {
+                mnX = std::min(mnX, r[k][0]);
+                mxX = std::max(mxX, r[k][0]);
+                mnY = std::min(mnY, r[k][1]);
+                mxY = std::max(mxY, r[k][1]);
+                area += r[j][0] * r[k][1] - r[k][0] * r[j][1];
             }
             info[i].minX = mnX; info[i].maxX = mxX;
             info[i].minY = mnY; info[i].maxY = mxY;
@@ -504,15 +608,16 @@ public:
 
         auto ringSign = [&](size_t i) { return info[i].area >= 0.f ? 1 : -1; };
 
-        auto pointInRing = [&](float px, float py, const SubInfo& r) -> bool {
-            if (px < r.minX || px > r.maxX || py < r.minY || py > r.maxY) return false;
+        auto pointInRing = [&](float px, float py, size_t j) -> bool {
+            const RingInfo& ji = info[j];
+            if (px < ji.minX || px > ji.maxX || py < ji.minY || py > ji.maxY) return false;
+            const Ring& r = rings[j];
             bool inside = false;
-            const size_t n = r.e - r.s;
-            for (size_t k = 0, j = n - 1; k < n; j = k++) {
-                const Vec3& a = vertices_[r.s + k];
-                const Vec3& b = vertices_[r.s + j];
-                const bool cross = ((a.y > py) != (b.y > py)) &&
-                                   (px < (b.x - a.x) * (py - a.y) / (b.y - a.y) + a.x);
+            for (size_t k = 0, j2 = r.size() - 1; k < r.size(); j2 = k++) {
+                const Point& a = r[k];
+                const Point& b = r[j2];
+                const bool cross = ((a[1] > py) != (b[1] > py)) &&
+                                   (px < (b[0] - a[0]) * (py - a[1]) / (b[1] - a[1]) + a[0]);
                 if (cross) inside = !inside;
             }
             return inside;
@@ -520,20 +625,16 @@ public:
 
         // Ring-in-ring containment by majority vote over 3 spread-out
         // vertices — robust to a single vertex touching the candidate's
-        // boundary (bridged contours). Holes never cross their enclosing
-        // rings in valid outlines, so parity is well-defined where the
-        // answer matters.
+        // boundary (bridged contours, split points). Holes never cross
+        // their enclosing rings once self-intersections are resolved, so
+        // parity is well-defined where the answer matters.
         auto containedIn = [&](size_t i, size_t j) -> bool {
-            const size_t n = info[i].e - info[i].s;
-            const size_t sample[3] = {
-                info[i].s,
-                info[i].s + n / 3,
-                info[i].s + (2 * n) / 3,
-            };
+            const size_t n = rings[i].size();
+            const size_t sample[3] = {0, n / 3, (2 * n) / 3};
             int votes = 0;
             for (int t = 0; t < 3; ++t) {
-                if (pointInRing(vertices_[sample[t]].x,
-                                vertices_[sample[t]].y, info[j])) ++votes;
+                const Point& p = rings[i][sample[t]];
+                if (pointInRing(p[0], p[1], j)) ++votes;
             }
             return votes >= 2;
         };
@@ -541,10 +642,9 @@ public:
         // Containment matrix + winding number per ring.
         std::vector<uint8_t> cont(N * N, 0);
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
             int w = ringSign(i);
             for (size_t j = 0; j < N; ++j) {
-                if (j == i || info[j].e - info[j].s < 3) continue;
+                if (j == i) continue;
                 if (containedIn(i, j)) {
                     cont[i * N + j] = 1;
                     w += ringSign(j);
@@ -555,7 +655,6 @@ public:
 
         // Attach each hole (winding 0) to the smallest enclosing filled ring.
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
             if (info[i].winding != 0) continue;
             float bestBboxArea = std::numeric_limits<float>::infinity();
             for (size_t j = 0; j < N; ++j) {
@@ -566,32 +665,20 @@ public:
             }
         }
 
-        using Point   = std::array<float, 2>;
-        using Ring    = std::vector<Point>;
-        using Polygon = std::vector<Ring>;
-
         sgl_begin_triangles();
         sgl_c4f(col.r, col.g, col.b, col.a);
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
             // Draw filled rings and orphan holes; holes that found a parent
             // are added to that parent's polygon below.
             if (info[i].winding == 0 && info[i].parent >= 0) continue;
 
             Polygon poly;
-            poly.emplace_back();
-            for (size_t k = info[i].s; k < info[i].e; ++k) {
-                poly.back().push_back({vertices_[k].x, vertices_[k].y});
-            }
+            poly.push_back(rings[i]);
 
             // Attach direct-child holes.
             for (size_t j = 0; j < N; ++j) {
                 if (info[j].parent != (int)i) continue;
-                if (info[j].e - info[j].s < 3) continue;
-                poly.emplace_back();
-                for (size_t k = info[j].s; k < info[j].e; ++k) {
-                    poly.back().push_back({vertices_[k].x, vertices_[k].y});
-                }
+                poly.push_back(rings[j]);
             }
 
             // Tessellate. Earcut returns indices into the flat (outer + holes)

--- a/core/include/tc/graphics/tcPath.h
+++ b/core/include/tc/graphics/tcPath.h
@@ -384,6 +384,23 @@ public:
     void setClosed(bool closed)   { subpathClosed_.back() = closed; }
     bool isClosed() const         { return subpathClosed_.back(); }
 
+    // Reverse the winding direction (vertex order) of one subpath, or of
+    // every subpath. Under drawFill()'s non-zero winding rule, reversing a
+    // subpath toggles it between filling and cutting — e.g. build a circle
+    // with the same helper you use for outlines, then reverseWinding() it
+    // into a hole punch. Reversing ALL subpaths leaves the rendered result
+    // unchanged (only relative direction matters), which also makes this
+    // the fix for imported outlines that use the opposite convention.
+    Path& reverseWinding(size_t i) {
+        auto [s, e] = getSubpathRange(i);
+        std::reverse(vertices_.begin() + s, vertices_.begin() + e);
+        return *this;
+    }
+    Path& reverseWinding() {
+        for (size_t i = 0; i < subpathStarts_.size(); ++i) reverseWinding(i);
+        return *this;
+    }
+
     // Draw — fill (per-subpath triangle fan) + 1px stroke (per-subpath line
     // strip). Fill is convex-only; for concave / holed shapes call drawFill().
     void draw() const {
@@ -424,22 +441,27 @@ public:
     //
     // Subpaths are grouped following the non-zero winding rule — the default
     // fill rule of SVG / PostScript and the rule TrueType / CFF rasterizers
-    // use. Subpaths wound in the path's dominant direction are outer rings;
-    // subpaths wound the opposite way are holes. The dominant direction is
-    // taken from the largest subpath by |signed area|: a hole is always
-    // strictly contained in some outer ring (which is therefore larger), so
-    // the largest ring can never be a hole. This self-normalizes across the
-    // opposite winding conventions of TrueType-flavored (CW outers) and
-    // CFF-flavored (CCW outers) fonts, in either Y-axis orientation.
+    // use. For each subpath we compute the winding number of the region just
+    // inside it: its own direction (sign of the shoelace area) plus the
+    // directions of every subpath containing it. Winding 0 → hole boundary,
+    // attached to the smallest enclosing filled subpath; non-zero → filled.
     //
-    // Same-direction subpaths never punch holes in each other, so glyphs
-    // built from several overlapping contours (e.g. serif caps overlapping
-    // the main stem in Noto Serif JP's 'W') fill correctly as their union.
-    // Each hole attaches to the smallest outer ring containing it; holes
-    // with no enclosing outer ring are drawn as independent polygons.
+    // Because only the RELATIVE direction of a ring and its container
+    // matters, this handles TrueType-flavored (CW outers) and CFF-flavored
+    // (CCW outers) fonts, either Y-axis orientation, and even paths that mix
+    // both conventions (e.g. glyph paths from two fonts merged into one
+    // Path) — exactly like a real non-zero winding rasterizer.
     //
-    // To cut a hole in a hand-built Path, wind the inner subpath opposite
-    // to the outer one (same as SVG's nonzero fill rule).
+    // Same-direction subpaths never punch holes in each other (winding adds
+    // up, never cancels), so glyphs built from several overlapping contours
+    // (e.g. serif caps overlapping the main stem in Noto Serif JP's 'W')
+    // fill correctly as their union. Containment between such overlapping
+    // same-direction rings is geometrically ambiguous, but harmless: it only
+    // moves the winding between +1 and +2, never to 0.
+    //
+    // To cut a hole in a hand-built Path, wind the inner subpath opposite to
+    // the outer one (see reverseWinding()). Zero-winding subpaths with no
+    // enclosing filled ring are drawn as independent polygons (fallback).
     // Use draw() with `fill` enabled for the fast convex-only fan path.
     void drawFill() const {
         if (vertices_.empty()) return;
@@ -450,12 +472,11 @@ public:
         struct SubInfo {
             size_t s, e;
             float minX, minY, maxX, maxY;
-            float area;   // signed shoelace area; sign = winding direction
-            int parent = -1;
+            float area;       // signed shoelace area; sign = winding direction
+            int   winding = 0;
+            int   parent  = -1;
         };
         std::vector<SubInfo> info(N);
-        float outerSign  = 0.f;   // sign of the largest ring = outer direction
-        float maxAbsArea = 0.f;
         for (size_t i = 0; i < N; ++i) {
             auto [s, e] = getSubpathRange(i);
             info[i].s = s; info[i].e = e;
@@ -479,15 +500,9 @@ public:
             info[i].minX = mnX; info[i].maxX = mxX;
             info[i].minY = mnY; info[i].maxY = mxY;
             info[i].area = area * 0.5f;
-            if (std::abs(info[i].area) > maxAbsArea) {
-                maxAbsArea = std::abs(info[i].area);
-                outerSign  = (info[i].area >= 0.f) ? 1.f : -1.f;
-            }
         }
 
-        // Wound opposite to the dominant direction → hole candidate.
-        // (outerSign == 0 means all rings are degenerate; nothing is a hole.)
-        auto isHole = [&](size_t i) { return info[i].area * outerSign < 0.f; };
+        auto ringSign = [&](size_t i) { return info[i].area >= 0.f ? 1 : -1; };
 
         auto pointInRing = [&](float px, float py, const SubInfo& r) -> bool {
             if (px < r.minX || px > r.maxX || py < r.minY || py > r.maxY) return false;
@@ -503,33 +518,48 @@ public:
             return inside;
         };
 
-        // For each hole, find the smallest enclosing outer ring. Containment
-        // is decided by majority vote over 3 spread-out vertices of the hole —
-        // robust to a single vertex touching the candidate's boundary. Holes
-        // never cross outer rings in valid outlines, so vertex parity is
-        // well-defined here (unlike same-direction rings, which may overlap
-        // each other and are never containment-tested at all).
-        for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
-            if (!isHole(i)) continue;
-
+        // Ring-in-ring containment by majority vote over 3 spread-out
+        // vertices — robust to a single vertex touching the candidate's
+        // boundary (bridged contours). Holes never cross their enclosing
+        // rings in valid outlines, so parity is well-defined where the
+        // answer matters.
+        auto containedIn = [&](size_t i, size_t j) -> bool {
             const size_t n = info[i].e - info[i].s;
             const size_t sample[3] = {
                 info[i].s,
                 info[i].s + n / 3,
                 info[i].s + (2 * n) / 3,
             };
+            int votes = 0;
+            for (int t = 0; t < 3; ++t) {
+                if (pointInRing(vertices_[sample[t]].x,
+                                vertices_[sample[t]].y, info[j])) ++votes;
+            }
+            return votes >= 2;
+        };
 
-            float bestBboxArea = std::numeric_limits<float>::infinity();
+        // Containment matrix + winding number per ring.
+        std::vector<uint8_t> cont(N * N, 0);
+        for (size_t i = 0; i < N; ++i) {
+            if (info[i].e - info[i].s < 3) continue;
+            int w = ringSign(i);
             for (size_t j = 0; j < N; ++j) {
                 if (j == i || info[j].e - info[j].s < 3) continue;
-                if (isHole(j)) continue;  // only outer rings can be parents
-                int votes = 0;
-                for (int t = 0; t < 3; ++t) {
-                    if (pointInRing(vertices_[sample[t]].x,
-                                    vertices_[sample[t]].y, info[j])) ++votes;
+                if (containedIn(i, j)) {
+                    cont[i * N + j] = 1;
+                    w += ringSign(j);
                 }
-                if (votes < 2) continue;
+            }
+            info[i].winding = w;
+        }
+
+        // Attach each hole (winding 0) to the smallest enclosing filled ring.
+        for (size_t i = 0; i < N; ++i) {
+            if (info[i].e - info[i].s < 3) continue;
+            if (info[i].winding != 0) continue;
+            float bestBboxArea = std::numeric_limits<float>::infinity();
+            for (size_t j = 0; j < N; ++j) {
+                if (!cont[i * N + j] || info[j].winding == 0) continue;
                 const float a = (info[j].maxX - info[j].minX) *
                                 (info[j].maxY - info[j].minY);
                 if (a < bestBboxArea) { bestBboxArea = a; info[i].parent = (int)j; }
@@ -544,9 +574,9 @@ public:
         sgl_c4f(col.r, col.g, col.b, col.a);
         for (size_t i = 0; i < N; ++i) {
             if (info[i].e - info[i].s < 3) continue;
-            // Draw outer rings and orphan holes; holes that found a parent
+            // Draw filled rings and orphan holes; holes that found a parent
             // are added to that parent's polygon below.
-            if (isHole(i) && info[i].parent >= 0) continue;
+            if (info[i].winding == 0 && info[i].parent >= 0) continue;
 
             Polygon poly;
             poly.emplace_back();

--- a/core/include/tc/graphics/tcPath.h
+++ b/core/include/tc/graphics/tcPath.h
@@ -421,11 +421,25 @@ public:
     }
 
     // Fill the path as a concave polygon with holes (earcut tessellation).
-    // Subpaths are grouped by spatial containment: each subpath at even
-    // nesting depth is treated as the outer ring of a polygon, and direct
-    // children at the next odd depth become its holes. Grandchildren (depth
-    // +2) become their own outers — i.e. an island inside a hole renders as
-    // a separate filled region, matching SVG / PostScript even-odd fill.
+    //
+    // Subpaths are grouped following the non-zero winding rule — the default
+    // fill rule of SVG / PostScript and the rule TrueType / CFF rasterizers
+    // use. Subpaths wound in the path's dominant direction are outer rings;
+    // subpaths wound the opposite way are holes. The dominant direction is
+    // taken from the largest subpath by |signed area|: a hole is always
+    // strictly contained in some outer ring (which is therefore larger), so
+    // the largest ring can never be a hole. This self-normalizes across the
+    // opposite winding conventions of TrueType-flavored (CW outers) and
+    // CFF-flavored (CCW outers) fonts, in either Y-axis orientation.
+    //
+    // Same-direction subpaths never punch holes in each other, so glyphs
+    // built from several overlapping contours (e.g. serif caps overlapping
+    // the main stem in Noto Serif JP's 'W') fill correctly as their union.
+    // Each hole attaches to the smallest outer ring containing it; holes
+    // with no enclosing outer ring are drawn as independent polygons.
+    //
+    // To cut a hole in a hand-built Path, wind the inner subpath opposite
+    // to the outer one (same as SVG's nonzero fill rule).
     // Use draw() with `fill` enabled for the fast convex-only fan path.
     void drawFill() const {
         if (vertices_.empty()) return;
@@ -436,13 +450,16 @@ public:
         struct SubInfo {
             size_t s, e;
             float minX, minY, maxX, maxY;
+            float area;   // signed shoelace area; sign = winding direction
             int parent = -1;
-            int depth  = 0;
         };
         std::vector<SubInfo> info(N);
+        float outerSign  = 0.f;   // sign of the largest ring = outer direction
+        float maxAbsArea = 0.f;
         for (size_t i = 0; i < N; ++i) {
             auto [s, e] = getSubpathRange(i);
             info[i].s = s; info[i].e = e;
+            info[i].area = 0.f;
             if (e - s == 0) {
                 info[i].minX = info[i].minY = 0;
                 info[i].maxX = info[i].maxY = 0;
@@ -450,17 +467,28 @@ public:
             }
             float mnX = vertices_[s].x, mxX = mnX;
             float mnY = vertices_[s].y, mxY = mnY;
-            for (size_t k = s + 1; k < e; ++k) {
+            float area = 0.f;
+            for (size_t k = s, j = e - 1; k < e; j = k++) {
                 mnX = std::min(mnX, vertices_[k].x);
                 mxX = std::max(mxX, vertices_[k].x);
                 mnY = std::min(mnY, vertices_[k].y);
                 mxY = std::max(mxY, vertices_[k].y);
+                area += vertices_[j].x * vertices_[k].y
+                      - vertices_[k].x * vertices_[j].y;
             }
             info[i].minX = mnX; info[i].maxX = mxX;
             info[i].minY = mnY; info[i].maxY = mxY;
+            info[i].area = area * 0.5f;
+            if (std::abs(info[i].area) > maxAbsArea) {
+                maxAbsArea = std::abs(info[i].area);
+                outerSign  = (info[i].area >= 0.f) ? 1.f : -1.f;
+            }
         }
 
-        // Point-in-polygon (ray casting) — used to detect subpath containment.
+        // Wound opposite to the dominant direction → hole candidate.
+        // (outerSign == 0 means all rings are degenerate; nothing is a hole.)
+        auto isHole = [&](size_t i) { return info[i].area * outerSign < 0.f; };
+
         auto pointInRing = [&](float px, float py, const SubInfo& r) -> bool {
             if (px < r.minX || px > r.maxX || py < r.minY || py > r.maxY) return false;
             bool inside = false;
@@ -475,30 +503,37 @@ public:
             return inside;
         };
 
-        // For each subpath, find its smallest enclosing subpath. We pick the
-        // candidate parent with the smallest bbox area (cheap proxy that's
-        // correct as long as the rings aren't pathologically interleaved —
-        // good enough for font glyphs).
+        // For each hole, find the smallest enclosing outer ring. Containment
+        // is decided by majority vote over 3 spread-out vertices of the hole —
+        // robust to a single vertex touching the candidate's boundary. Holes
+        // never cross outer rings in valid outlines, so vertex parity is
+        // well-defined here (unlike same-direction rings, which may overlap
+        // each other and are never containment-tested at all).
         for (size_t i = 0; i < N; ++i) {
             if (info[i].e - info[i].s < 3) continue;
-            const float px = vertices_[info[i].s].x;
-            const float py = vertices_[info[i].s].y;
+            if (!isHole(i)) continue;
+
+            const size_t n = info[i].e - info[i].s;
+            const size_t sample[3] = {
+                info[i].s,
+                info[i].s + n / 3,
+                info[i].s + (2 * n) / 3,
+            };
+
             float bestBboxArea = std::numeric_limits<float>::infinity();
             for (size_t j = 0; j < N; ++j) {
                 if (j == i || info[j].e - info[j].s < 3) continue;
-                if (!pointInRing(px, py, info[j])) continue;
+                if (isHole(j)) continue;  // only outer rings can be parents
+                int votes = 0;
+                for (int t = 0; t < 3; ++t) {
+                    if (pointInRing(vertices_[sample[t]].x,
+                                    vertices_[sample[t]].y, info[j])) ++votes;
+                }
+                if (votes < 2) continue;
                 const float a = (info[j].maxX - info[j].minX) *
                                 (info[j].maxY - info[j].minY);
                 if (a < bestBboxArea) { bestBboxArea = a; info[i].parent = (int)j; }
             }
-        }
-
-        // Resolve depth iteratively (parent chain length).
-        for (size_t i = 0; i < N; ++i) {
-            int d = 0;
-            int p = info[i].parent;
-            while (p >= 0) { ++d; p = info[p].parent; }
-            info[i].depth = d;
         }
 
         using Point   = std::array<float, 2>;
@@ -508,8 +543,10 @@ public:
         sgl_begin_triangles();
         sgl_c4f(col.r, col.g, col.b, col.a);
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].depth % 2 != 0) continue;        // skip holes
             if (info[i].e - info[i].s < 3) continue;
+            // Draw outer rings and orphan holes; holes that found a parent
+            // are added to that parent's polygon below.
+            if (isHole(i) && info[i].parent >= 0) continue;
 
             Polygon poly;
             poly.emplace_back();
@@ -517,10 +554,9 @@ public:
                 poly.back().push_back({vertices_[k].x, vertices_[k].y});
             }
 
-            // Direct-child holes.
+            // Attach direct-child holes.
             for (size_t j = 0; j < N; ++j) {
                 if (info[j].parent != (int)i) continue;
-                if (info[j].depth != info[i].depth + 1) continue;
                 if (info[j].e - info[j].s < 3) continue;
                 poly.emplace_back();
                 for (size_t k = info[j].s; k < info[j].e; ++k) {

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -9759,6 +9759,15 @@ types:
         description_ja: "パスが閉じているか確認"
         description_ko: "경로가 닫혀 있는지 확인"
         snippet: "isClosed()"
+      - name: reverseWinding
+        return: "Path&"
+        signatures:
+          - params: ""
+          - params: "size_t subpath"
+        description: "Reverse the winding direction (vertex order) of all subpaths, or of one subpath. Under drawFill's non-zero winding rule, reversing a subpath toggles it between filling and cutting — e.g. build a circle contour, then reverseWinding(i) it into a hole punch. Reversing ALL subpaths leaves the render unchanged (only relative direction matters) — handy for imported outlines using the opposite convention."
+        description_ja: "subpath の巻き方向 (頂点順) を反転。引数なしで全 subpath、index 指定で 1 つだけ。drawFill の non-zero winding rule では反転で塗り ↔ 穴が切り替わる — 円の contour を作って reverseWinding(i) すれば穴パンチになる。全部反転しても描画結果は不変 (相対方向のみ意味を持つ) なので、逆巻き慣習のインポートデータの修正にも使える。"
+        description_ko: "subpath의 감김 방향 (정점 순서)을 반전. 인수 없이 전체, index 지정으로 하나만. drawFill의 non-zero winding rule에서는 반전으로 채움 ↔ 구멍이 전환됨. 전체 반전은 렌더 결과 불변 (상대 방향만 의미) — 반대 규약의 임포트 데이터 수정에도 사용."
+        snippet: "reverseWinding(${1:1})"
       - name: draw
         return: "void"
         signatures:
@@ -9771,9 +9780,9 @@ types:
         return: "void"
         signatures:
           - params: ""
-        description: "Fill the path as a concave polygon with holes (earcut tessellation). Subpaths are grouped by spatial containment — outer ring + direct children become holes, grandchildren become separate filled islands. Use this for glyphs with holes (e, a, O, 日 ...) and any shape that drawString-style fill can't handle."
-        description_ja: "穴付き凹多角形として塗りつぶし (earcut)。subpath は包含関係でグループ化 — 外枠 + 直下の子が穴、孫は別の塗り島。穴付きグリフ (e, a, O, 日 等) や凹形状に使う。"
-        description_ko: "구멍 있는 오목 다각형 채우기 (earcut). subpath는 공간적 포함 관계로 그룹화 — 외곽선 + 직접 자식이 구멍, 손자는 별도 채우기 섬. 구멍 있는 글리프 (e, a, O, 日 등)와 오목한 형태에 사용."
+        description: "Fill the path as a concave polygon with holes (earcut tessellation). Subpaths follow the non-zero winding rule (SVG / PostScript default): a subpath wound opposite to its enclosing ring becomes a hole; same-direction subpaths union (never punch holes). Handles glyphs with holes (e, a, O, 日 ...), overlapping contours, and both TrueType / CFF winding conventions. To cut a hole in a hand-built Path, wind the inner subpath opposite (see reverseWinding)."
+        description_ja: "穴付き凹多角形として塗りつぶし (earcut)。subpath は non-zero winding rule (SVG / PostScript のデフォルト) に従う — 外側のリングと逆巻きの subpath が穴になり、同方向は union (穴を開けない)。穴付きグリフ (e, a, O, 日 等)、重なった contour、TrueType / CFF 両方の巻き方向慣習に対応。手書き Path で穴を開けるには内側を逆巻きにする (reverseWinding 参照)。"
+        description_ko: "구멍 있는 오목 다각형 채우기 (earcut). subpath는 non-zero winding rule (SVG / PostScript 기본값)을 따름 — 바깥 링과 반대로 감긴 subpath가 구멍이 되고, 같은 방향은 union. 구멍 있는 글리프 (e, a, O, 日 등), 겹친 contour, TrueType / CFF 양쪽 규약 지원. 수제 Path에 구멍을 내려면 안쪽을 반대로 감음 (reverseWinding 참조)."
         snippet: "drawFill()"
       - name: drawStroke
         return: "void"


### PR DESCRIPTION
`Path::drawFill` produced garbage triangles for some fonts (overlapping contours, mixed winding conventions, machine-converted outlines with self-crossing stroke joins). Three commits:

1. **Non-zero winding hole detection** — replaces spatial-containment (even-odd) grouping that misclassified overlapping same-direction contours as holes (e.g. Noto Serif JP 'W'). Self-normalized per path; works for both TrueType-flavored (CW) and CFF-flavored (CCW) fonts.
2. **Per-ring winding numbers + `Path::reverseWinding`** — true non-zero winding number per subpath, so paths mixing both conventions in one `Path` fill correctly.
3. **Split self-intersecting subpaths before earcut** — machine-converted fonts carry tiny self-crossing loops at stroke joins; earcut only handles simple polygons. This was the actual root cause of the Noto Serif JP 'W'/'v' garbage.

## Verification
Hiragino Mincho (CFF), Noto Serif JP (TT + fontsource self-crossing), Arial (TT opposite winding), plus a hand-built donut/bowtie suite. fontPathExample builds & renders clean (native; breakage was identical on wasm, not platform-specific).