### PR TITLE
feat: mouse_press/release MCP tools + mouse_move optional button fix

### DIFF
--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -159,11 +159,16 @@ inline void registerDebuggerTools() {
 
     // --- Mouse Tools ---
 
-    tool("mouse_move", "Move mouse cursor")
+    tool("mouse_move", "Move mouse cursor (with a button held, emits a drag)")
         .arg<float>("x", "X coordinate")
         .arg<float>("y", "Y coordinate")
-        .arg<int>("button", "Button state (0:left, 1:right, 2:middle, -1:none)", false)
-        .bind<float, float, int>([](float x, float y, int button) {
+        .arg<int>("button", "Button held during the move (0:left, 1:right, 2:middle; omit or -1 for a plain move)", false)
+        .bind([](const json& a) -> json {
+            // json bind, not the typed one — the typed bind requires every
+            // declared arg, which contradicted "button" being optional.
+            float x = a.at("x").get<float>();
+            float y = a.at("y").get<float>();
+            int button = a.value("button", -1);
             // If button is pressed, treat as drag
             if (button >= 0) {
                 MouseEventRaw args;
@@ -187,6 +192,50 @@ inline void registerDebuggerTools() {
             // Update global mouse state
             ::trussc::internal::mouseX = x;
             ::trussc::internal::mouseY = y;
+
+            return json{{"status", "ok"}};
+        });
+
+    // Split press/release. A drag gesture is press → mouse_move(button) × N →
+    // release; mouse_click fires press+release back-to-back, so drag consumers
+    // (e.g. EasyCam orbit) never see an open gesture. Anchoring the global
+    // mouse position at press keeps the first drag delta sane.
+    tool("mouse_press", "Press and hold a mouse button (start of a drag; pair with mouse_move + mouse_release)")
+        .arg<float>("x", "X coordinate")
+        .arg<float>("y", "Y coordinate")
+        .arg<int>("button", "Button (0:left, 1:right, 2:middle)", false)
+        .bind([](const json& a) -> json {
+            MouseEventArgs args;
+            args.pos = args.globalPos = Vec2(a.at("x").get<float>(), a.at("y").get<float>());
+            args.button = a.value("button", 0);
+            args.syncLegacy();
+
+            ::trussc::internal::mouseX = args.pos.x;
+            ::trussc::internal::mouseY = args.pos.y;
+
+            events().mousePressed.notify(args);
+            if (::trussc::internal::appMousePressedFunc)
+                ::trussc::internal::appMousePressedFunc(args);
+
+            return json{{"status", "ok"}};
+        });
+
+    tool("mouse_release", "Release a mouse button (end of a drag)")
+        .arg<float>("x", "X coordinate")
+        .arg<float>("y", "Y coordinate")
+        .arg<int>("button", "Button (0:left, 1:right, 2:middle)", false)
+        .bind([](const json& a) -> json {
+            MouseEventArgs args;
+            args.pos = args.globalPos = Vec2(a.at("x").get<float>(), a.at("y").get<float>());
+            args.button = a.value("button", 0);
+            args.syncLegacy();
+
+            ::trussc::internal::mouseX = args.pos.x;
+            ::trussc::internal::mouseY = args.pos.y;
+
+            events().mouseReleased.notify(args);
+            if (::trussc::internal::appMouseReleasedFunc)
+                ::trussc::internal::appMouseReleasedFunc(args);
 
             return json{{"status", "ok"}};
         });

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -52,7 +52,9 @@ TrussC uses **HTTP transport** for MCP. All JSON-RPC messages are sent as HTTP P
 ### Debugger Tools (opt-in via `mcp::enableDebugger()`)
 | Tool | Arguments | Description |
 |------|-----------|-------------|
-| `mouse_move` | `x`, `y`, `button` | Move mouse cursor (and optionally drag) |
+| `mouse_move` | `x`, `y`, `button` (optional) | Move cursor; with `button` held, emits a drag |
+| `mouse_press` | `x`, `y`, `button` | Press and hold — start of a drag gesture |
+| `mouse_release` | `x`, `y`, `button` | Release — end of a drag gesture |
 | `mouse_click` | `x`, `y`, `button`, `shift`/`ctrl`/`alt`/`super` (optional) | Click mouse button (0:left, 1:right), optionally with modifier keys held — e.g. `super: true` Cmd+clicks |
 | `mouse_scroll` | `dx`, `dy` | Scroll mouse wheel |
 | `key_press` | `key` | Press a key (sokol_app keycode) |
@@ -207,7 +209,7 @@ Configure your MCP client with the HTTP URL:
 | Category | Tools | Enabled by |
 |----------|-------|------------|
 | Inspection (read-only) | `get_screenshot`, `save_screenshot`, `get_node_tree`, `get_selected_node` | Automatic when MCP is enabled |
-| Debugger (input injection / scene mutation) | `mouse_click`, `key_press`, `mouse_move`, `mouse_scroll`, `key_release`, `select_node`, `set_node_members` | `mcp::enableDebugger()` + `mcp::registerDebuggerTools()` |
+| Debugger (input injection / scene mutation) | `mouse_click`, `mouse_press`, `mouse_release`, `key_press`, `mouse_move`, `mouse_scroll`, `key_release`, `select_node`, `set_node_members` | `mcp::enableDebugger()` + `mcp::registerDebuggerTools()` |
 | ImGui (widget interaction) | `imgui_get_widgets`, `imgui_click`, `imgui_input`, `imgui_checkbox` | Requires tcxImGui addon + `mcp::registerDebuggerTools()` |
 | Custom | `mcp::tool(...)` | Your code |
 


### PR DESCRIPTION
MCP drag gestures (EasyCam orbit, slider drags, node dragging) couldn't be injected — `mouse_click` fires press+release back-to-back, so drag consumers never see an open gesture. Also `mouse_move` errored when `button` was omitted despite being declared optional.

## Fix
- Add `mouse_press` / `mouse_release` tools. Drag recipe: `press → mouse_move(button) × N → release`. Press anchors the global mouse position so the first drag delta is sane.
- `mouse_move`: switch the typed bind to a json bind with a `-1` default.
- Update AI_AUTOMATION.md tool tables.

## Verification
EasyCam orbit injected on a generated app; before/after screenshots show the camera rotation; `mouse_move` without button no longer errors.