### PR TITLE
fix: Windows CI build — Ninja generator + stale CMakeCache wipe (VS2026 compat)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,9 @@ jobs:
           path: |
             core/build-${{ matrix.preset }}
             tools/build
-          key: ${{ runner.os }}-build-v3-${{ hashFiles('core/**/*.h', 'core/**/*.cpp', 'core/**/*.mm') }}
+          key: ${{ runner.os }}-build-v4-${{ hashFiles('core/**/*.h', 'core/**/*.cpp', 'core/**/*.mm') }}
           restore-keys: |
-            ${{ runner.os }}-build-v3-
+            ${{ runner.os }}-build-v4-
 
       # Linux: Install dependencies using shared script
       - name: Install Linux dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,11 @@ jobs:
         include:
           - os: macos-latest
             preset: macos
-          - os: windows-latest
+          # Pinned to 2022: windows-latest now redirects to a VS2026 runner,
+          # where projectGenerator's VS-project generation falls back to the
+          # "Visual Studio 17 2022" generator and fails (VS2022 absent). Revert
+          # to windows-latest once projectGenerator supports VS2026.
+          - os: windows-2022
             preset: windows
           - os: ubuntu-latest
             preset: linux

--- a/tools/build_win.bat
+++ b/tools/build_win.bat
@@ -30,6 +30,19 @@ REM Setup Visual Studio environment
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set VS_PATH=%%i
 if defined VS_PATH call "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
 
+REM A leftover CMakeCache.txt from a previous run with a different generator
+REM (e.g. a Visual Studio generator from before this Ninja switch, or a CI
+REM cache) makes -G Ninja abort with a generator-mismatch error. Wipe the
+REM cache when it doesn't already record Ninja so the switch is seamless.
+if exist "CMakeCache.txt" (
+    findstr /C:"CMAKE_GENERATOR:INTERNAL=Ninja" "CMakeCache.txt" >nul 2>&1
+    if errorlevel 1 (
+        echo Different CMake generator found in cache, cleaning...
+        del /q "CMakeCache.txt"
+        if exist "CMakeFiles" rmdir /s /q "CMakeFiles"
+    )
+)
+
 REM CMake configuration. Force the Ninja generator: without -G, CMake defaults
 REM to the Visual Studio generator on Windows, which fails when the installed
 REM CMake doesn't recognize a newer VS (e.g. VS2026 / "Visual Studio 18"). The

--- a/tools/build_win.bat
+++ b/tools/build_win.bat
@@ -30,9 +30,14 @@ REM Setup Visual Studio environment
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set VS_PATH=%%i
 if defined VS_PATH call "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
 
-REM CMake configuration
+REM CMake configuration. Force the Ninja generator: without -G, CMake defaults
+REM to the Visual Studio generator on Windows, which fails when the installed
+REM CMake doesn't recognize a newer VS (e.g. VS2026 / "Visual Studio 18"). The
+REM vcvarsall call above puts cl.exe and VS-bundled ninja on PATH, so Ninja
+REM builds work across VS versions. Single-config generator -> set the build
+REM type here (the --build --config flag is multi-config only).
 echo Running CMake...
-cmake ..
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
 if %ERRORLEVEL% neq 0 (
     echo.
     echo ERROR: CMake configuration failed!
@@ -45,7 +50,7 @@ if %ERRORLEVEL% neq 0 (
 REM Build
 echo.
 echo Building...
-cmake --build . --config Release --parallel
+cmake --build . --parallel
 if %ERRORLEVEL% neq 0 (
     echo.
     echo ERROR: Build failed!


### PR DESCRIPTION
Fix the Windows build failing in CI after `windows-latest` moved to VS2026.

- `build_win.bat`: force the **Ninja generator** for VS2026 compatibility
- Wipe **stale CMakeCache** on generator switch + bump the CI cache key
- Pin the CI runner to **windows-2022** (VS2026 not yet supported) as a stopgap

This is the CI-fix base; the bundle of previously CI-failed PRs (#116–#120) + Android serial will follow as a single dev→main PR once this lands.