### PR TITLE
feat: re-bundle CI-failed PRs (#116-#120) + Android serial

### DIFF
--- a/addons/tcxImGui/README.md
+++ b/addons/tcxImGui/README.md
@@ -43,13 +43,11 @@ void tcApp::draw() {
     ImGui::End();
     imguiEnd();
 }
-
-void tcApp::cleanup() {
-    imguiShutdown();
-}
 ```
 
 ImGui renders on top of all TrussC content automatically via the `onRender` event.
+Teardown is automatic too — the addon listens to the framework's exit event and
+shuts itself down when the app closes, so there is nothing to call in `cleanup()`.
 
 ## API
 
@@ -58,7 +56,7 @@ ImGui renders on top of all TrussC content automatically via the `onRender` even
 | Function | Description |
 |----------|-------------|
 | `imguiSetup()` | Initialize ImGui (call in setup) |
-| `imguiShutdown()` | Shutdown ImGui (call in cleanup) |
+| `imguiShutdown()` | Shut down ImGui early (optional — runs automatically on app exit) |
 | `imguiBegin()` | Start ImGui frame (call at start of your GUI code) |
 | `imguiEnd()` | End ImGui frame (rendering is deferred to onRender) |
 

--- a/addons/tcxImGui/example-basic/src/tcApp.cpp
+++ b/addons/tcxImGui/example-basic/src/tcApp.cpp
@@ -72,7 +72,3 @@ void tcApp::draw() {
     imguiEnd();
 }
 
-void tcApp::cleanup() {
-    // Shutdown ImGui
-    imguiShutdown();
-}

--- a/addons/tcxImGui/example-basic/src/tcApp.h
+++ b/addons/tcxImGui/example-basic/src/tcApp.h
@@ -12,7 +12,6 @@ class tcApp : public App {
 public:
     void setup() override;
     void draw() override;
-    void cleanup() override;
 
 private:
     // Variables for demo

--- a/addons/tcxImGui/src/tcxImGui.h
+++ b/addons/tcxImGui/src/tcxImGui.h
@@ -75,12 +75,18 @@ public:
             if (ImGui::GetIO().WantCaptureKeyboard) e.consumed = true;
         }, tc::EventPriority::BeforeApp);
 
+        // Auto-teardown at the framework's exit event, while sokol_gfx and the
+        // event system are still alive. Apps don't need to call imguiShutdown()
+        // themselves (calling it stays harmless — shutdown() is idempotent).
+        exitListener_ = tc::events().exit.listen([this]() { shutdown(); });
+
         tc::logVerbose() << "ImGui initialized";
     }
 
     // Shutdown
     void shutdown() {
         if (!initialized_) return;
+        exitListener_ = {};
         renderListener_ = {};
         eventListener_ = {};
         mousePressConsume_ = {};
@@ -93,7 +99,11 @@ public:
         tc::internal::overlayHoveredQuery = nullptr;
         tc::internal::overlayFocusedQuery = nullptr;
         pointerCaptured_ = false;
-        simgui_shutdown();
+        // GPU teardown only while sokol_gfx is alive. If shutdown runs from the
+        // static destructor during exit() (e.g. an abnormal teardown path where
+        // the exit event never fired), sokol_gfx is already gone and its objects
+        // with it — skipping is the correct cleanup, touching them would crash.
+        if (sg_isvalid()) simgui_shutdown();
         initialized_ = false;
         tc::logVerbose() << "ImGui shutdown";
     }
@@ -130,6 +140,7 @@ private:
 
     bool initialized_ = false;
     bool renderPending_ = false;
+    tc::EventListener exitListener_;
     tc::EventListener renderListener_;
     tc::EventListener eventListener_;
 

--- a/addons/tcxNodeInspector/src/tcxNodeInspector.cpp
+++ b/addons/tcxNodeInspector/src/tcxNodeInspector.cpp
@@ -240,22 +240,38 @@ void NodeInspector::drawInspector() {
 
 namespace {
 
-// World units spanned by ONE screen pixel in the view plane at `worldPos`
-// (two cursor rays one pixel apart, intersected with the plane through the
-// point facing the camera). This is the gizmo's single size basis: it does
-// not depend on any axis direction, so handle sizes are stable while the
-// node rotates, and there is no per-direction solve to misbehave on
+// World units spanned by ONE screen pixel at `worldPos`, on the
+// constant-depth plane through the point. This is the gizmo's single size
+// basis: it does not depend on any axis direction, so handle sizes are stable
+// while the node rotates, and there is no per-direction solve to misbehave on
 // view-aligned axes — those simply foreshorten naturally on screen and hide
 // below the length threshold (Unity behaves the same way).
-float worldPerPixelAt(const CameraContext& ctx, const Vec3& worldPos, const Vec2& screenPos) {
-    Ray r0 = ctx.screenPointToRay(screenPos.x, screenPos.y);
-    Ray r1 = ctx.screenPointToRay(screenPos.x + 1.0f, screenPos.y);
-    const Vec3& n = r0.direction;
-    float d1 = r1.direction.dot(n);
-    if (std::abs(d1) < 1e-6f) return 0.0f;
-    float t0 = (worldPos - r0.origin).dot(n);                 // r0.direction.dot(n) == 1
-    float t1 = (worldPos - r1.origin).dot(n) / d1;
-    return (r1.at(t1) - r0.at(t0)).length();
+//
+// Measured by FORWARD projection only (worldToScreen finite difference along
+// the camera-right axis). Never through screenPointToRay: the inverse-ray
+// construction unprojects two clip-space points only `near` apart, and with
+// an extreme near/far (EasyCam defaults to 0.1/10000) float cancellation puts
+// ~1% noise on the ray direction — extrapolated to the node's depth that made
+// the whole gizmo flicker ±15% frame to frame. The forward path has no
+// cancellation. Sampling along camera-right also keeps the measurement on the
+// constant-depth plane (a uniform scale under perspective), so the result is
+// independent of where the node sits on screen — no pulse while it orbits.
+float worldPerPixelAt(const CameraContext& ctx, const Vec3& worldPos, const Vec2& /*screenPos*/) {
+    Vec4 r4 = ctx.view.inverted() * Vec4(1.0f, 0.0f, 0.0f, 0.0f);   // camera right in world
+    Vec3 right = Vec3(r4.x, r4.y, r4.z).normalized();
+    Vec3 s0 = ctx.worldToScreen(worldPos);
+    // Two passes: measure with a 1-unit step, then re-aim the step to ~4 px
+    // so the finite difference is local but well above float screen noise.
+    float step = 1.0f;
+    for (int pass = 0; pass < 2; ++pass) {
+        Vec3 s1 = ctx.worldToScreen(worldPos + right * step);
+        if (s1.z < 0.0f) return 0.0f;
+        float px = Vec2(s1.x - s0.x, s1.y - s0.y).length();
+        if (px < 1e-6f) return 0.0f;
+        if (pass == 1) return step / px;
+        step *= 4.0f / px;
+    }
+    return 0.0f;
 }
 
 } // namespace
@@ -385,18 +401,25 @@ NodeInspector::GizmoGeom NodeInspector::computeGizmoGeomFrame(
         g.axis[i].dir = dir;
 
         if (mode == GizmoMode::Translate) {
-            Vec3 tip = origin + dir * worldLen;
             Vec2 p1;
             if (ctx) {
-                Vec3 s2 = ctx->worldToScreen(tip);
-                if (s2.z < 0.0f || s2.z > 1.0f) continue;     // tip behind the camera
-                p1 = Vec2(s2.x, s2.y);
+                // Linearized projection: project a SMALL step along the axis
+                // and scale up (the projection derivative at the origin).
+                // Projecting the full-length tip would re-apply the
+                // perspective divide at the tip's own depth, so an axis
+                // leaning toward the camera grows past its nominal length and
+                // a rotating node makes the handles pulse. The derivative
+                // keeps only the natural cos-theta foreshortening.
+                const float EPS = 0.05f;
+                Vec3 s2 = ctx->worldToScreen(origin + dir * (worldLen * EPS));
+                if (s2.z < 0.0f || s2.z > 1.0f) continue;     // behind the camera
+                p1 = so + (Vec2(s2.x, s2.y) - so) * (1.0f / EPS);
             } else {
                 p1 = so + Vec2(dir.x, dir.y) * worldLen;
             }
             // View-aligned axes foreshorten; below this they are neither
             // readable nor meaningfully draggable.
-            if ((p1 - so).length() < handlePx * 0.3f) continue;
+            if ((p1 - so).length() < handlePx * 0.2f) continue;
 
             g.axis[i].valid = true;
             g.axis[i].p0 = so;

--- a/core/include/tc/comm/tcSerial.h
+++ b/core/include/tc/comm/tcSerial.h
@@ -5,6 +5,8 @@
 // Cross-platform serial communication class
 // - Windows: Win32 API (CreateFile, SetCommState, etc.)
 // - macOS/Linux: POSIX API (termios)
+// - Android: USB Host API (CDC-ACM devices only), JNI + usbfs.
+//   See platform/android/tcSerial_android.cpp for details and caveats.
 // =============================================================================
 
 #include <string>
@@ -21,6 +23,9 @@
     #define NOMINMAX
     #endif
     #include <windows.h>
+#elif defined(__ANDROID__)
+    // Android: no platform headers needed here; the backend lives in
+    // platform/android/tcSerial_android.cpp (USB Host CDC-ACM via JNI + usbfs).
 #else
     // POSIX (macOS, Linux)
     #include <fcntl.h>
@@ -49,6 +54,32 @@ struct SerialDeviceInfo {
     const std::string& getDeviceName() const { return deviceName; }
 };
 
+#if defined(__ANDROID__)
+// ---------------------------------------------------------------------------
+// Android backend (USB Host, CDC-ACM class devices).
+// Implemented in platform/android/tcSerial_android.cpp.
+//
+// Behavior difference vs desktop: opening a USB device requires a one-time
+// user permission dialog. setup() returns false while the dialog is pending
+// and the connection completes asynchronously; isInitialized() flips to true
+// once the user grants access. Calling setup() again for the same device
+// while pending is a cheap no-op (safe to call from a reconnect loop).
+// ---------------------------------------------------------------------------
+namespace androidserial {
+    struct Impl;
+    Impl* create();
+    void destroy(Impl* impl);
+    std::vector<SerialDeviceInfo> listDevices();
+    bool setup(Impl* impl, const std::string& devicePath, int baudRate);
+    void close(Impl* impl);
+    bool isConnected(const Impl* impl);
+    int available(const Impl* impl);
+    int readBytes(Impl* impl, void* buffer, int length);
+    int writeBytes(Impl* impl, const void* buffer, int length);
+    void flushInput(Impl* impl);
+}
+#endif
+
 // ---------------------------------------------------------------------------
 // Serial Communication Class
 // ---------------------------------------------------------------------------
@@ -57,12 +88,18 @@ class Serial {
 public:
 #if defined(_WIN32)
     Serial() : handle_(INVALID_HANDLE_VALUE), initialized_(false) {}
+#elif defined(__ANDROID__)
+    Serial() : aimpl_(androidserial::create()), initialized_(false) {}
 #else
     Serial() : fd_(-1), initialized_(false) {}
 #endif
 
     ~Serial() {
         close();
+#if defined(__ANDROID__)
+        androidserial::destroy(aimpl_);
+        aimpl_ = nullptr;
+#endif
     }
 
     // Non-copyable
@@ -74,6 +111,9 @@ public:
 #if defined(_WIN32)
         : handle_(other.handle_), initialized_(other.initialized_), devicePath_(std::move(other.devicePath_)) {
         other.handle_ = INVALID_HANDLE_VALUE;
+#elif defined(__ANDROID__)
+        : aimpl_(other.aimpl_), initialized_(other.initialized_), devicePath_(std::move(other.devicePath_)) {
+        other.aimpl_ = nullptr;
 #else
         : fd_(other.fd_), initialized_(other.initialized_), devicePath_(std::move(other.devicePath_)) {
         other.fd_ = -1;
@@ -87,6 +127,10 @@ public:
 #if defined(_WIN32)
             handle_ = other.handle_;
             other.handle_ = INVALID_HANDLE_VALUE;
+#elif defined(__ANDROID__)
+            androidserial::destroy(aimpl_);
+            aimpl_ = other.aimpl_;
+            other.aimpl_ = nullptr;
 #else
             fd_ = other.fd_;
             other.fd_ = -1;
@@ -157,6 +201,10 @@ public:
             }
             closedir(dir);
         }
+#elif defined(__ANDROID__)
+        // Android: enumerate CDC-ACM capable devices via USB Host API.
+        // devicePath is the usbfs node (e.g. /dev/bus/usb/001/002).
+        devices = androidserial::listDevices();
 #elif defined(__linux__)
         // Linux: Enumerate /dev/ttyUSB*, /dev/ttyACM*
         DIR* dir = opendir("/dev");
@@ -191,7 +239,17 @@ public:
 
     // Connect by specifying device path
     bool setup(const std::string& portName, int baudRate) {
+#if defined(__ANDROID__)
+        // Do NOT close() first here: androidserial::setup() keeps a pending
+        // permission request alive when called again for the same device
+        // (reconnect loops must not re-trigger the permission dialog).
+        if (!aimpl_) aimpl_ = androidserial::create();
+        devicePath_ = portName;
+        initialized_ = androidserial::setup(aimpl_, portName, baudRate);
+        return initialized_;
+#else
         close();
+#endif
 
 #if defined(_WIN32)
         // Windows: Open COM port
@@ -267,7 +325,7 @@ public:
         logNotice() << "Serial: connected to " << portName << " at " << baudRate << " baud";
         return true;
 
-#else
+#elif !defined(__ANDROID__)
         // POSIX (macOS, Linux)
         // Open device (non-blocking)
         fd_ = open(portName.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
@@ -356,6 +414,8 @@ public:
             handle_ = INVALID_HANDLE_VALUE;
             logVerbose() << "Serial: disconnected from " << devicePath_;
         }
+#elif defined(__ANDROID__)
+        if (aimpl_) androidserial::close(aimpl_);
 #else
         if (fd_ != -1) {
             ::close(fd_);
@@ -371,9 +431,13 @@ public:
     // ---------------------------------------------------------------------------
 
     // Check if connected
+    // Android: may flip to true AFTER setup() returned false, once the user
+    // grants USB permission (see androidserial note above).
     bool isInitialized() const {
 #if defined(_WIN32)
         return initialized_ && handle_ != INVALID_HANDLE_VALUE;
+#elif defined(__ANDROID__)
+        return aimpl_ && androidserial::isConnected(aimpl_);
 #else
         return initialized_ && fd_ != -1;
 #endif
@@ -395,6 +459,8 @@ public:
             return (int)comStat.cbInQue;
         }
         return 0;
+#elif defined(__ANDROID__)
+        return androidserial::available(aimpl_);
 #else
         int bytesAvailable = 0;
         if (ioctl(fd_, FIONREAD, &bytesAvailable) == -1) {
@@ -420,6 +486,8 @@ public:
             return -1;
         }
         return (int)bytesRead;
+#elif defined(__ANDROID__)
+        return androidserial::readBytes(aimpl_, buffer, length);
 #else
         ssize_t result = read(fd_, buffer, length);
         if (result == -1) {
@@ -458,6 +526,11 @@ public:
             return byte;
         }
         return -1;  // No data
+#elif defined(__ANDROID__)
+        int result = androidserial::readBytes(aimpl_, &byte, 1);
+        if (result == 1) return byte;
+        if (result == 0) return -1;  // No data
+        return -2;  // Error
 #else
         ssize_t result = read(fd_, &byte, 1);
         if (result == 1) {
@@ -485,6 +558,8 @@ public:
             return -1;
         }
         return (int)bytesWritten;
+#elif defined(__ANDROID__)
+        return androidserial::writeBytes(aimpl_, buffer, length);
 #else
         ssize_t result = write(fd_, buffer, length);
         if (result == -1) {
@@ -513,6 +588,8 @@ public:
         if (!isInitialized()) return;
 #if defined(_WIN32)
         PurgeComm(handle_, PURGE_RXCLEAR);
+#elif defined(__ANDROID__)
+        androidserial::flushInput(aimpl_);
 #else
         tcflush(fd_, TCIFLUSH);
 #endif
@@ -523,6 +600,8 @@ public:
         if (!isInitialized()) return;
 #if defined(_WIN32)
         PurgeComm(handle_, PURGE_TXCLEAR);
+#elif defined(__ANDROID__)
+        // No-op: Android writes are synchronous bulk transfers
 #else
         tcflush(fd_, TCOFLUSH);
 #endif
@@ -533,6 +612,8 @@ public:
         if (!isInitialized()) return;
 #if defined(_WIN32)
         PurgeComm(handle_, PURGE_RXCLEAR | PURGE_TXCLEAR);
+#elif defined(__ANDROID__)
+        androidserial::flushInput(aimpl_);
 #else
         tcflush(fd_, TCIOFLUSH);
 #endif
@@ -543,6 +624,8 @@ public:
         if (!isInitialized()) return;
 #if defined(_WIN32)
         FlushFileBuffers(handle_);
+#elif defined(__ANDROID__)
+        // No-op: Android writes are synchronous bulk transfers
 #else
         tcdrain(fd_);
 #endif
@@ -551,13 +634,15 @@ public:
 private:
 #if defined(_WIN32)
     HANDLE handle_;        // Windows handle
+#elif defined(__ANDROID__)
+    androidserial::Impl* aimpl_;  // Android backend state
 #else
     int fd_;               // File descriptor (POSIX)
 #endif
     bool initialized_;     // Connection state
     std::string devicePath_; // Current device path
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
     // Convert baud rate to speed_t (POSIX only)
     speed_t baudRateToSpeed(int baudRate) {
         switch (baudRate) {

--- a/core/include/tc/graphics/tcPath.h
+++ b/core/include/tc/graphics/tcPath.h
@@ -462,40 +462,144 @@ public:
     // To cut a hole in a hand-built Path, wind the inner subpath opposite to
     // the outer one (see reverseWinding()). Zero-winding subpaths with no
     // enclosing filled ring are drawn as independent polygons (fallback).
+    //
+    // Self-intersecting subpaths are split at each crossing into simple
+    // rings before tessellation. Machine-converted fonts (e.g. CFF →
+    // TrueType builds of Noto) often carry tiny self-crossing loops at
+    // stroke joins; rasterizers never notice (non-zero winding scanning is
+    // immune) but ear clipping requires simple polygons. After splitting,
+    // an inverted micro-loop gets winding 0 and vanishes as a sub-pixel
+    // hole, and a genuine figure-8 fills both lobes — both matching what a
+    // real non-zero winding rasterizer produces.
     // Use draw() with `fill` enabled for the fast convex-only fan path.
     void drawFill() const {
         if (vertices_.empty()) return;
-        const size_t N = subpathStarts_.size();
         auto& ctx = getDefaultContext();
         Color col = ctx.getColor();
 
-        struct SubInfo {
-            size_t s, e;
+        using Point   = std::array<float, 2>;
+        using Ring    = std::vector<Point>;
+        using Polygon = std::vector<Ring>;
+
+        // ---- Collect subpaths into working rings (fill is 2D; z dropped).
+        // Consecutive duplicates and the closing vertex (== start) are
+        // removed so zero-length edges can't confuse the geometry below.
+        std::vector<Ring> rings;
+        rings.reserve(subpathStarts_.size());
+        for (size_t si = 0; si < subpathStarts_.size(); ++si) {
+            auto [s, e] = getSubpathRange(si);
+            if (e - s < 3) continue;
+            Ring r;
+            r.reserve(e - s);
+            for (size_t k = s; k < e; ++k) {
+                const Point p{vertices_[k].x, vertices_[k].y};
+                if (!r.empty() && r.back() == p) continue;
+                r.push_back(p);
+            }
+            while (r.size() >= 2 && r.front() == r.back()) r.pop_back();
+            if (r.size() >= 3) rings.push_back(std::move(r));
+        }
+        if (rings.empty()) return;
+
+        // ---- Split self-intersecting rings into simple rings. Each proper
+        // crossing X of two edges splits the ring into two rings touching at
+        // X; every split strictly reduces the remaining crossing count, so
+        // this terminates (guard cap for float pathologies). Piece edges are
+        // subsets of the original edges, so no new crossings appear.
+        {
+            auto cleanRing = [](Ring& r) {
+                Ring out;
+                out.reserve(r.size());
+                for (const Point& p : r) {
+                    if (out.empty() || out.back() != p) out.push_back(p);
+                }
+                while (out.size() >= 2 && out.front() == out.back()) out.pop_back();
+                r = std::move(out);
+            };
+
+            int guard = 1024;
+            for (size_t ri = 0; ri < rings.size() && guard > 0; ) {
+                const size_t n = rings[ri].size();
+                bool didSplit = false;
+                for (size_t i = 0; i < n && !didSplit; ++i) {
+                    const size_t i2 = (i + 1) % n;
+                    for (size_t j = i + 1; j < n && !didSplit; ++j) {
+                        const size_t j2 = (j + 1) % n;
+                        if (i2 == j || j2 == i) continue;  // adjacent edges share a vertex
+                        const Point& A = rings[ri][i];
+                        const Point& B = rings[ri][i2];
+                        const Point& C = rings[ri][j];
+                        const Point& D = rings[ri][j2];
+                        // bbox reject
+                        if (std::max(A[0], B[0]) < std::min(C[0], D[0]) ||
+                            std::max(C[0], D[0]) < std::min(A[0], B[0]) ||
+                            std::max(A[1], B[1]) < std::min(C[1], D[1]) ||
+                            std::max(C[1], D[1]) < std::min(A[1], B[1])) continue;
+                        // strict proper crossing (touching endpoints excluded —
+                        // touching rings are handled fine by the parity vote)
+                        const double abx = (double)B[0] - A[0], aby = (double)B[1] - A[1];
+                        const double cdx = (double)D[0] - C[0], cdy = (double)D[1] - C[1];
+                        const double denom = abx * cdy - aby * cdx;
+                        if (denom == 0.0) continue;
+                        const double acx = (double)C[0] - A[0], acy = (double)C[1] - A[1];
+                        const double t = (acx * cdy - acy * cdx) / denom;  // along AB
+                        const double u = (acx * aby - acy * abx) / denom;  // along CD
+                        if (t <= 0.0 || t >= 1.0 || u <= 0.0 || u >= 1.0) continue;
+
+                        const Point X{(float)(A[0] + t * abx), (float)(A[1] + t * aby)};
+                        Ring r1, r2;
+                        r1.push_back(X);
+                        for (size_t k = i2; ; k = (k + 1) % n) {
+                            r1.push_back(rings[ri][k]);
+                            if (k == j) break;
+                        }
+                        r2.push_back(X);
+                        for (size_t k = j2; ; k = (k + 1) % n) {
+                            r2.push_back(rings[ri][k]);
+                            if (k == i) break;
+                        }
+                        cleanRing(r1);
+                        cleanRing(r2);
+                        // Replace the ring with the valid pieces (a piece that
+                        // collapsed below 3 verts was a zero-area sliver).
+                        if (r1.size() >= 3 && r2.size() >= 3) {
+                            rings[ri] = std::move(r1);
+                            rings.push_back(std::move(r2));
+                        } else if (r1.size() >= 3) {
+                            rings[ri] = std::move(r1);
+                        } else if (r2.size() >= 3) {
+                            rings[ri] = std::move(r2);
+                        } else {
+                            rings.erase(rings.begin() + (ptrdiff_t)ri);
+                        }
+                        didSplit = true;
+                        --guard;
+                    }
+                }
+                if (!didSplit) ++ri;  // ring is simple; re-scan same index after a split
+            }
+        }
+        if (rings.empty()) return;
+
+        const size_t N = rings.size();
+        struct RingInfo {
             float minX, minY, maxX, maxY;
             float area;       // signed shoelace area; sign = winding direction
             int   winding = 0;
             int   parent  = -1;
         };
-        std::vector<SubInfo> info(N);
+        std::vector<RingInfo> info(N);
         for (size_t i = 0; i < N; ++i) {
-            auto [s, e] = getSubpathRange(i);
-            info[i].s = s; info[i].e = e;
-            info[i].area = 0.f;
-            if (e - s == 0) {
-                info[i].minX = info[i].minY = 0;
-                info[i].maxX = info[i].maxY = 0;
-                continue;
-            }
-            float mnX = vertices_[s].x, mxX = mnX;
-            float mnY = vertices_[s].y, mxY = mnY;
+            const Ring& r = rings[i];
+            float mnX = r[0][0], mxX = mnX;
+            float mnY = r[0][1], mxY = mnY;
             float area = 0.f;
-            for (size_t k = s, j = e - 1; k < e; j = k++) {
-                mnX = std::min(mnX, vertices_[k].x);
-                mxX = std::max(mxX, vertices_[k].x);
-                mnY = std::min(mnY, vertices_[k].y);
-                mxY = std::max(mxY, vertices_[k].y);
-                area += vertices_[j].x * vertices_[k].y
-                      - vertices_[k].x * vertices_[j].y;
+            for (size_t k = 0, j = r.size() - 1; k < r.size(); j = k++) {
+                mnX = std::min(mnX, r[k][0]);
+                mxX = std::max(mxX, r[k][0]);
+                mnY = std::min(mnY, r[k][1]);
+                mxY = std::max(mxY, r[k][1]);
+                area += r[j][0] * r[k][1] - r[k][0] * r[j][1];
             }
             info[i].minX = mnX; info[i].maxX = mxX;
             info[i].minY = mnY; info[i].maxY = mxY;
@@ -504,15 +608,16 @@ public:
 
         auto ringSign = [&](size_t i) { return info[i].area >= 0.f ? 1 : -1; };
 
-        auto pointInRing = [&](float px, float py, const SubInfo& r) -> bool {
-            if (px < r.minX || px > r.maxX || py < r.minY || py > r.maxY) return false;
+        auto pointInRing = [&](float px, float py, size_t j) -> bool {
+            const RingInfo& ji = info[j];
+            if (px < ji.minX || px > ji.maxX || py < ji.minY || py > ji.maxY) return false;
+            const Ring& r = rings[j];
             bool inside = false;
-            const size_t n = r.e - r.s;
-            for (size_t k = 0, j = n - 1; k < n; j = k++) {
-                const Vec3& a = vertices_[r.s + k];
-                const Vec3& b = vertices_[r.s + j];
-                const bool cross = ((a.y > py) != (b.y > py)) &&
-                                   (px < (b.x - a.x) * (py - a.y) / (b.y - a.y) + a.x);
+            for (size_t k = 0, j2 = r.size() - 1; k < r.size(); j2 = k++) {
+                const Point& a = r[k];
+                const Point& b = r[j2];
+                const bool cross = ((a[1] > py) != (b[1] > py)) &&
+                                   (px < (b[0] - a[0]) * (py - a[1]) / (b[1] - a[1]) + a[0]);
                 if (cross) inside = !inside;
             }
             return inside;
@@ -520,20 +625,16 @@ public:
 
         // Ring-in-ring containment by majority vote over 3 spread-out
         // vertices — robust to a single vertex touching the candidate's
-        // boundary (bridged contours). Holes never cross their enclosing
-        // rings in valid outlines, so parity is well-defined where the
-        // answer matters.
+        // boundary (bridged contours, split points). Holes never cross
+        // their enclosing rings once self-intersections are resolved, so
+        // parity is well-defined where the answer matters.
         auto containedIn = [&](size_t i, size_t j) -> bool {
-            const size_t n = info[i].e - info[i].s;
-            const size_t sample[3] = {
-                info[i].s,
-                info[i].s + n / 3,
-                info[i].s + (2 * n) / 3,
-            };
+            const size_t n = rings[i].size();
+            const size_t sample[3] = {0, n / 3, (2 * n) / 3};
             int votes = 0;
             for (int t = 0; t < 3; ++t) {
-                if (pointInRing(vertices_[sample[t]].x,
-                                vertices_[sample[t]].y, info[j])) ++votes;
+                const Point& p = rings[i][sample[t]];
+                if (pointInRing(p[0], p[1], j)) ++votes;
             }
             return votes >= 2;
         };
@@ -541,10 +642,9 @@ public:
         // Containment matrix + winding number per ring.
         std::vector<uint8_t> cont(N * N, 0);
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
             int w = ringSign(i);
             for (size_t j = 0; j < N; ++j) {
-                if (j == i || info[j].e - info[j].s < 3) continue;
+                if (j == i) continue;
                 if (containedIn(i, j)) {
                     cont[i * N + j] = 1;
                     w += ringSign(j);
@@ -555,7 +655,6 @@ public:
 
         // Attach each hole (winding 0) to the smallest enclosing filled ring.
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
             if (info[i].winding != 0) continue;
             float bestBboxArea = std::numeric_limits<float>::infinity();
             for (size_t j = 0; j < N; ++j) {
@@ -566,32 +665,20 @@ public:
             }
         }
 
-        using Point   = std::array<float, 2>;
-        using Ring    = std::vector<Point>;
-        using Polygon = std::vector<Ring>;
-
         sgl_begin_triangles();
         sgl_c4f(col.r, col.g, col.b, col.a);
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
             // Draw filled rings and orphan holes; holes that found a parent
             // are added to that parent's polygon below.
             if (info[i].winding == 0 && info[i].parent >= 0) continue;
 
             Polygon poly;
-            poly.emplace_back();
-            for (size_t k = info[i].s; k < info[i].e; ++k) {
-                poly.back().push_back({vertices_[k].x, vertices_[k].y});
-            }
+            poly.push_back(rings[i]);
 
             // Attach direct-child holes.
             for (size_t j = 0; j < N; ++j) {
                 if (info[j].parent != (int)i) continue;
-                if (info[j].e - info[j].s < 3) continue;
-                poly.emplace_back();
-                for (size_t k = info[j].s; k < info[j].e; ++k) {
-                    poly.back().push_back({vertices_[k].x, vertices_[k].y});
-                }
+                poly.push_back(rings[j]);
             }
 
             // Tessellate. Earcut returns indices into the flat (outer + holes)

--- a/core/include/tc/graphics/tcPath.h
+++ b/core/include/tc/graphics/tcPath.h
@@ -384,6 +384,23 @@ public:
     void setClosed(bool closed)   { subpathClosed_.back() = closed; }
     bool isClosed() const         { return subpathClosed_.back(); }
 
+    // Reverse the winding direction (vertex order) of one subpath, or of
+    // every subpath. Under drawFill()'s non-zero winding rule, reversing a
+    // subpath toggles it between filling and cutting — e.g. build a circle
+    // with the same helper you use for outlines, then reverseWinding() it
+    // into a hole punch. Reversing ALL subpaths leaves the rendered result
+    // unchanged (only relative direction matters), which also makes this
+    // the fix for imported outlines that use the opposite convention.
+    Path& reverseWinding(size_t i) {
+        auto [s, e] = getSubpathRange(i);
+        std::reverse(vertices_.begin() + s, vertices_.begin() + e);
+        return *this;
+    }
+    Path& reverseWinding() {
+        for (size_t i = 0; i < subpathStarts_.size(); ++i) reverseWinding(i);
+        return *this;
+    }
+
     // Draw — fill (per-subpath triangle fan) + 1px stroke (per-subpath line
     // strip). Fill is convex-only; for concave / holed shapes call drawFill().
     void draw() const {
@@ -424,22 +441,27 @@ public:
     //
     // Subpaths are grouped following the non-zero winding rule — the default
     // fill rule of SVG / PostScript and the rule TrueType / CFF rasterizers
-    // use. Subpaths wound in the path's dominant direction are outer rings;
-    // subpaths wound the opposite way are holes. The dominant direction is
-    // taken from the largest subpath by |signed area|: a hole is always
-    // strictly contained in some outer ring (which is therefore larger), so
-    // the largest ring can never be a hole. This self-normalizes across the
-    // opposite winding conventions of TrueType-flavored (CW outers) and
-    // CFF-flavored (CCW outers) fonts, in either Y-axis orientation.
+    // use. For each subpath we compute the winding number of the region just
+    // inside it: its own direction (sign of the shoelace area) plus the
+    // directions of every subpath containing it. Winding 0 → hole boundary,
+    // attached to the smallest enclosing filled subpath; non-zero → filled.
     //
-    // Same-direction subpaths never punch holes in each other, so glyphs
-    // built from several overlapping contours (e.g. serif caps overlapping
-    // the main stem in Noto Serif JP's 'W') fill correctly as their union.
-    // Each hole attaches to the smallest outer ring containing it; holes
-    // with no enclosing outer ring are drawn as independent polygons.
+    // Because only the RELATIVE direction of a ring and its container
+    // matters, this handles TrueType-flavored (CW outers) and CFF-flavored
+    // (CCW outers) fonts, either Y-axis orientation, and even paths that mix
+    // both conventions (e.g. glyph paths from two fonts merged into one
+    // Path) — exactly like a real non-zero winding rasterizer.
     //
-    // To cut a hole in a hand-built Path, wind the inner subpath opposite
-    // to the outer one (same as SVG's nonzero fill rule).
+    // Same-direction subpaths never punch holes in each other (winding adds
+    // up, never cancels), so glyphs built from several overlapping contours
+    // (e.g. serif caps overlapping the main stem in Noto Serif JP's 'W')
+    // fill correctly as their union. Containment between such overlapping
+    // same-direction rings is geometrically ambiguous, but harmless: it only
+    // moves the winding between +1 and +2, never to 0.
+    //
+    // To cut a hole in a hand-built Path, wind the inner subpath opposite to
+    // the outer one (see reverseWinding()). Zero-winding subpaths with no
+    // enclosing filled ring are drawn as independent polygons (fallback).
     // Use draw() with `fill` enabled for the fast convex-only fan path.
     void drawFill() const {
         if (vertices_.empty()) return;
@@ -450,12 +472,11 @@ public:
         struct SubInfo {
             size_t s, e;
             float minX, minY, maxX, maxY;
-            float area;   // signed shoelace area; sign = winding direction
-            int parent = -1;
+            float area;       // signed shoelace area; sign = winding direction
+            int   winding = 0;
+            int   parent  = -1;
         };
         std::vector<SubInfo> info(N);
-        float outerSign  = 0.f;   // sign of the largest ring = outer direction
-        float maxAbsArea = 0.f;
         for (size_t i = 0; i < N; ++i) {
             auto [s, e] = getSubpathRange(i);
             info[i].s = s; info[i].e = e;
@@ -479,15 +500,9 @@ public:
             info[i].minX = mnX; info[i].maxX = mxX;
             info[i].minY = mnY; info[i].maxY = mxY;
             info[i].area = area * 0.5f;
-            if (std::abs(info[i].area) > maxAbsArea) {
-                maxAbsArea = std::abs(info[i].area);
-                outerSign  = (info[i].area >= 0.f) ? 1.f : -1.f;
-            }
         }
 
-        // Wound opposite to the dominant direction → hole candidate.
-        // (outerSign == 0 means all rings are degenerate; nothing is a hole.)
-        auto isHole = [&](size_t i) { return info[i].area * outerSign < 0.f; };
+        auto ringSign = [&](size_t i) { return info[i].area >= 0.f ? 1 : -1; };
 
         auto pointInRing = [&](float px, float py, const SubInfo& r) -> bool {
             if (px < r.minX || px > r.maxX || py < r.minY || py > r.maxY) return false;
@@ -503,33 +518,48 @@ public:
             return inside;
         };
 
-        // For each hole, find the smallest enclosing outer ring. Containment
-        // is decided by majority vote over 3 spread-out vertices of the hole —
-        // robust to a single vertex touching the candidate's boundary. Holes
-        // never cross outer rings in valid outlines, so vertex parity is
-        // well-defined here (unlike same-direction rings, which may overlap
-        // each other and are never containment-tested at all).
-        for (size_t i = 0; i < N; ++i) {
-            if (info[i].e - info[i].s < 3) continue;
-            if (!isHole(i)) continue;
-
+        // Ring-in-ring containment by majority vote over 3 spread-out
+        // vertices — robust to a single vertex touching the candidate's
+        // boundary (bridged contours). Holes never cross their enclosing
+        // rings in valid outlines, so parity is well-defined where the
+        // answer matters.
+        auto containedIn = [&](size_t i, size_t j) -> bool {
             const size_t n = info[i].e - info[i].s;
             const size_t sample[3] = {
                 info[i].s,
                 info[i].s + n / 3,
                 info[i].s + (2 * n) / 3,
             };
+            int votes = 0;
+            for (int t = 0; t < 3; ++t) {
+                if (pointInRing(vertices_[sample[t]].x,
+                                vertices_[sample[t]].y, info[j])) ++votes;
+            }
+            return votes >= 2;
+        };
 
-            float bestBboxArea = std::numeric_limits<float>::infinity();
+        // Containment matrix + winding number per ring.
+        std::vector<uint8_t> cont(N * N, 0);
+        for (size_t i = 0; i < N; ++i) {
+            if (info[i].e - info[i].s < 3) continue;
+            int w = ringSign(i);
             for (size_t j = 0; j < N; ++j) {
                 if (j == i || info[j].e - info[j].s < 3) continue;
-                if (isHole(j)) continue;  // only outer rings can be parents
-                int votes = 0;
-                for (int t = 0; t < 3; ++t) {
-                    if (pointInRing(vertices_[sample[t]].x,
-                                    vertices_[sample[t]].y, info[j])) ++votes;
+                if (containedIn(i, j)) {
+                    cont[i * N + j] = 1;
+                    w += ringSign(j);
                 }
-                if (votes < 2) continue;
+            }
+            info[i].winding = w;
+        }
+
+        // Attach each hole (winding 0) to the smallest enclosing filled ring.
+        for (size_t i = 0; i < N; ++i) {
+            if (info[i].e - info[i].s < 3) continue;
+            if (info[i].winding != 0) continue;
+            float bestBboxArea = std::numeric_limits<float>::infinity();
+            for (size_t j = 0; j < N; ++j) {
+                if (!cont[i * N + j] || info[j].winding == 0) continue;
                 const float a = (info[j].maxX - info[j].minX) *
                                 (info[j].maxY - info[j].minY);
                 if (a < bestBboxArea) { bestBboxArea = a; info[i].parent = (int)j; }
@@ -544,9 +574,9 @@ public:
         sgl_c4f(col.r, col.g, col.b, col.a);
         for (size_t i = 0; i < N; ++i) {
             if (info[i].e - info[i].s < 3) continue;
-            // Draw outer rings and orphan holes; holes that found a parent
+            // Draw filled rings and orphan holes; holes that found a parent
             // are added to that parent's polygon below.
-            if (isHole(i) && info[i].parent >= 0) continue;
+            if (info[i].winding == 0 && info[i].parent >= 0) continue;
 
             Polygon poly;
             poly.emplace_back();

--- a/core/include/tc/graphics/tcPath.h
+++ b/core/include/tc/graphics/tcPath.h
@@ -421,11 +421,25 @@ public:
     }
 
     // Fill the path as a concave polygon with holes (earcut tessellation).
-    // Subpaths are grouped by spatial containment: each subpath at even
-    // nesting depth is treated as the outer ring of a polygon, and direct
-    // children at the next odd depth become its holes. Grandchildren (depth
-    // +2) become their own outers — i.e. an island inside a hole renders as
-    // a separate filled region, matching SVG / PostScript even-odd fill.
+    //
+    // Subpaths are grouped following the non-zero winding rule — the default
+    // fill rule of SVG / PostScript and the rule TrueType / CFF rasterizers
+    // use. Subpaths wound in the path's dominant direction are outer rings;
+    // subpaths wound the opposite way are holes. The dominant direction is
+    // taken from the largest subpath by |signed area|: a hole is always
+    // strictly contained in some outer ring (which is therefore larger), so
+    // the largest ring can never be a hole. This self-normalizes across the
+    // opposite winding conventions of TrueType-flavored (CW outers) and
+    // CFF-flavored (CCW outers) fonts, in either Y-axis orientation.
+    //
+    // Same-direction subpaths never punch holes in each other, so glyphs
+    // built from several overlapping contours (e.g. serif caps overlapping
+    // the main stem in Noto Serif JP's 'W') fill correctly as their union.
+    // Each hole attaches to the smallest outer ring containing it; holes
+    // with no enclosing outer ring are drawn as independent polygons.
+    //
+    // To cut a hole in a hand-built Path, wind the inner subpath opposite
+    // to the outer one (same as SVG's nonzero fill rule).
     // Use draw() with `fill` enabled for the fast convex-only fan path.
     void drawFill() const {
         if (vertices_.empty()) return;
@@ -436,13 +450,16 @@ public:
         struct SubInfo {
             size_t s, e;
             float minX, minY, maxX, maxY;
+            float area;   // signed shoelace area; sign = winding direction
             int parent = -1;
-            int depth  = 0;
         };
         std::vector<SubInfo> info(N);
+        float outerSign  = 0.f;   // sign of the largest ring = outer direction
+        float maxAbsArea = 0.f;
         for (size_t i = 0; i < N; ++i) {
             auto [s, e] = getSubpathRange(i);
             info[i].s = s; info[i].e = e;
+            info[i].area = 0.f;
             if (e - s == 0) {
                 info[i].minX = info[i].minY = 0;
                 info[i].maxX = info[i].maxY = 0;
@@ -450,17 +467,28 @@ public:
             }
             float mnX = vertices_[s].x, mxX = mnX;
             float mnY = vertices_[s].y, mxY = mnY;
-            for (size_t k = s + 1; k < e; ++k) {
+            float area = 0.f;
+            for (size_t k = s, j = e - 1; k < e; j = k++) {
                 mnX = std::min(mnX, vertices_[k].x);
                 mxX = std::max(mxX, vertices_[k].x);
                 mnY = std::min(mnY, vertices_[k].y);
                 mxY = std::max(mxY, vertices_[k].y);
+                area += vertices_[j].x * vertices_[k].y
+                      - vertices_[k].x * vertices_[j].y;
             }
             info[i].minX = mnX; info[i].maxX = mxX;
             info[i].minY = mnY; info[i].maxY = mxY;
+            info[i].area = area * 0.5f;
+            if (std::abs(info[i].area) > maxAbsArea) {
+                maxAbsArea = std::abs(info[i].area);
+                outerSign  = (info[i].area >= 0.f) ? 1.f : -1.f;
+            }
         }
 
-        // Point-in-polygon (ray casting) — used to detect subpath containment.
+        // Wound opposite to the dominant direction → hole candidate.
+        // (outerSign == 0 means all rings are degenerate; nothing is a hole.)
+        auto isHole = [&](size_t i) { return info[i].area * outerSign < 0.f; };
+
         auto pointInRing = [&](float px, float py, const SubInfo& r) -> bool {
             if (px < r.minX || px > r.maxX || py < r.minY || py > r.maxY) return false;
             bool inside = false;
@@ -475,30 +503,37 @@ public:
             return inside;
         };
 
-        // For each subpath, find its smallest enclosing subpath. We pick the
-        // candidate parent with the smallest bbox area (cheap proxy that's
-        // correct as long as the rings aren't pathologically interleaved —
-        // good enough for font glyphs).
+        // For each hole, find the smallest enclosing outer ring. Containment
+        // is decided by majority vote over 3 spread-out vertices of the hole —
+        // robust to a single vertex touching the candidate's boundary. Holes
+        // never cross outer rings in valid outlines, so vertex parity is
+        // well-defined here (unlike same-direction rings, which may overlap
+        // each other and are never containment-tested at all).
         for (size_t i = 0; i < N; ++i) {
             if (info[i].e - info[i].s < 3) continue;
-            const float px = vertices_[info[i].s].x;
-            const float py = vertices_[info[i].s].y;
+            if (!isHole(i)) continue;
+
+            const size_t n = info[i].e - info[i].s;
+            const size_t sample[3] = {
+                info[i].s,
+                info[i].s + n / 3,
+                info[i].s + (2 * n) / 3,
+            };
+
             float bestBboxArea = std::numeric_limits<float>::infinity();
             for (size_t j = 0; j < N; ++j) {
                 if (j == i || info[j].e - info[j].s < 3) continue;
-                if (!pointInRing(px, py, info[j])) continue;
+                if (isHole(j)) continue;  // only outer rings can be parents
+                int votes = 0;
+                for (int t = 0; t < 3; ++t) {
+                    if (pointInRing(vertices_[sample[t]].x,
+                                    vertices_[sample[t]].y, info[j])) ++votes;
+                }
+                if (votes < 2) continue;
                 const float a = (info[j].maxX - info[j].minX) *
                                 (info[j].maxY - info[j].minY);
                 if (a < bestBboxArea) { bestBboxArea = a; info[i].parent = (int)j; }
             }
-        }
-
-        // Resolve depth iteratively (parent chain length).
-        for (size_t i = 0; i < N; ++i) {
-            int d = 0;
-            int p = info[i].parent;
-            while (p >= 0) { ++d; p = info[p].parent; }
-            info[i].depth = d;
         }
 
         using Point   = std::array<float, 2>;
@@ -508,8 +543,10 @@ public:
         sgl_begin_triangles();
         sgl_c4f(col.r, col.g, col.b, col.a);
         for (size_t i = 0; i < N; ++i) {
-            if (info[i].depth % 2 != 0) continue;        // skip holes
             if (info[i].e - info[i].s < 3) continue;
+            // Draw outer rings and orphan holes; holes that found a parent
+            // are added to that parent's polygon below.
+            if (isHole(i) && info[i].parent >= 0) continue;
 
             Polygon poly;
             poly.emplace_back();
@@ -517,10 +554,9 @@ public:
                 poly.back().push_back({vertices_[k].x, vertices_[k].y});
             }
 
-            // Direct-child holes.
+            // Attach direct-child holes.
             for (size_t j = 0; j < N; ++j) {
                 if (info[j].parent != (int)i) continue;
-                if (info[j].depth != info[i].depth + 1) continue;
                 if (info[j].e - info[j].s < 3) continue;
                 poly.emplace_back();
                 for (size_t k = info[j].s; k < info[j].e; ++k) {

--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -159,11 +159,16 @@ inline void registerDebuggerTools() {
 
     // --- Mouse Tools ---
 
-    tool("mouse_move", "Move mouse cursor")
+    tool("mouse_move", "Move mouse cursor (with a button held, emits a drag)")
         .arg<float>("x", "X coordinate")
         .arg<float>("y", "Y coordinate")
-        .arg<int>("button", "Button state (0:left, 1:right, 2:middle, -1:none)", false)
-        .bind<float, float, int>([](float x, float y, int button) {
+        .arg<int>("button", "Button held during the move (0:left, 1:right, 2:middle; omit or -1 for a plain move)", false)
+        .bind([](const json& a) -> json {
+            // json bind, not the typed one — the typed bind requires every
+            // declared arg, which contradicted "button" being optional.
+            float x = a.at("x").get<float>();
+            float y = a.at("y").get<float>();
+            int button = a.value("button", -1);
             // If button is pressed, treat as drag
             if (button >= 0) {
                 MouseEventRaw args;
@@ -187,6 +192,50 @@ inline void registerDebuggerTools() {
             // Update global mouse state
             ::trussc::internal::mouseX = x;
             ::trussc::internal::mouseY = y;
+
+            return json{{"status", "ok"}};
+        });
+
+    // Split press/release. A drag gesture is press → mouse_move(button) × N →
+    // release; mouse_click fires press+release back-to-back, so drag consumers
+    // (e.g. EasyCam orbit) never see an open gesture. Anchoring the global
+    // mouse position at press keeps the first drag delta sane.
+    tool("mouse_press", "Press and hold a mouse button (start of a drag; pair with mouse_move + mouse_release)")
+        .arg<float>("x", "X coordinate")
+        .arg<float>("y", "Y coordinate")
+        .arg<int>("button", "Button (0:left, 1:right, 2:middle)", false)
+        .bind([](const json& a) -> json {
+            MouseEventArgs args;
+            args.pos = args.globalPos = Vec2(a.at("x").get<float>(), a.at("y").get<float>());
+            args.button = a.value("button", 0);
+            args.syncLegacy();
+
+            ::trussc::internal::mouseX = args.pos.x;
+            ::trussc::internal::mouseY = args.pos.y;
+
+            events().mousePressed.notify(args);
+            if (::trussc::internal::appMousePressedFunc)
+                ::trussc::internal::appMousePressedFunc(args);
+
+            return json{{"status", "ok"}};
+        });
+
+    tool("mouse_release", "Release a mouse button (end of a drag)")
+        .arg<float>("x", "X coordinate")
+        .arg<float>("y", "Y coordinate")
+        .arg<int>("button", "Button (0:left, 1:right, 2:middle)", false)
+        .bind([](const json& a) -> json {
+            MouseEventArgs args;
+            args.pos = args.globalPos = Vec2(a.at("x").get<float>(), a.at("y").get<float>());
+            args.button = a.value("button", 0);
+            args.syncLegacy();
+
+            ::trussc::internal::mouseX = args.pos.x;
+            ::trussc::internal::mouseY = args.pos.y;
+
+            events().mouseReleased.notify(args);
+            if (::trussc::internal::appMouseReleasedFunc)
+                ::trussc::internal::appMouseReleasedFunc(args);
 
             return json{{"status", "ok"}};
         });

--- a/core/platform/android/tcSerial_android.cpp
+++ b/core/platform/android/tcSerial_android.cpp
@@ -1,0 +1,704 @@
+// =============================================================================
+// Android Serial backend (USB Host, CDC-ACM)
+//
+// No Java sources required:
+// - Enumeration / permission / interface claiming use the framework USB Host
+//   API (android.hardware.usb.*) called via JNI.
+// - The permission result is detected by polling UsbManager.hasPermission()
+//   from a worker thread, so no BroadcastReceiver class (= no .dex) is needed.
+//   The PendingIntent passed to requestPermission() broadcasts to nowhere.
+// - Bulk data I/O bypasses JNI entirely: UsbDeviceConnection.getFileDescriptor()
+//   exposes the usbfs fd, and reads/writes go through USBDEVFS_BULK ioctls.
+//
+// Limitations:
+// - CDC-ACM class devices only (nRF, RP2040, ESP32-S2/S3 native USB, etc.).
+//   Vendor protocol chips (FTDI, CP210x, CH34x) are not supported here.
+// - First connect shows the system permission dialog: setup() returns false,
+//   the connection completes asynchronously, and isInitialized() flips to
+//   true once granted. setup() for the same device while the dialog is
+//   pending is a no-op, so app-side reconnect loops are safe.
+// =============================================================================
+
+#include "TrussC.h"
+
+#ifdef __ANDROID__
+
+#include <jni.h>
+#include <android/native_activity.h>
+#include <linux/usbdevice_fs.h>
+#include <sys/ioctl.h>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include "sokol_app.h"
+
+namespace trussc {
+namespace androidserial {
+
+namespace {
+
+// USB / CDC constants
+constexpr int USB_CLASS_COMM     = 2;    // CDC control interface
+constexpr int USB_CLASS_CDC_DATA = 10;   // CDC data interface
+constexpr int EP_TYPE_BULK       = 2;    // UsbConstants.USB_ENDPOINT_XFER_BULK
+constexpr int EP_DIR_IN          = 0x80; // UsbConstants.USB_DIR_IN
+
+// CDC-ACM class requests
+constexpr int CDC_REQ_TYPE               = 0x21; // host-to-device | class | interface
+constexpr int CDC_SET_LINE_CODING        = 0x20;
+constexpr int CDC_SET_CONTROL_LINE_STATE = 0x22;
+constexpr int CDC_LINE_DTR_RTS           = 0x03;
+
+constexpr int    PERMISSION_TIMEOUT_SEC = 60;   // give up on an unanswered dialog
+constexpr int    PERMISSION_POLL_MS     = 200;
+constexpr int    READ_TIMEOUT_MS        = 250;  // per-ioctl bulk read timeout
+constexpr int    WRITE_TIMEOUT_MS       = 1000;
+constexpr size_t RX_BUFFER_CAP          = 1 << 20;  // drop oldest beyond 1 MiB
+constexpr int    READ_CHUNK             = 4096;     // multiple of bulk max packet
+constexpr int    WRITE_CHUNK            = 16384;    // usbfs per-urb limit
+
+enum class State : int { Idle = 0, Pending = 1, Connected = 2 };
+
+// Get a JNI env attached to the current thread (same pattern as
+// tcPlatform_android.cpp). Detaches on destruction if it attached.
+struct JniScope {
+    JNIEnv* env = nullptr;
+    JavaVM* vm = nullptr;
+    bool attached = false;
+
+    JniScope() {
+        auto* activity = (ANativeActivity*)sapp_android_get_native_activity();
+        if (!activity) return;
+        vm = activity->vm;
+        jint res = vm->GetEnv((void**)&env, JNI_VERSION_1_6);
+        if (res == JNI_EDETACHED) {
+            vm->AttachCurrentThread(&env, nullptr);
+            attached = true;
+        }
+    }
+    ~JniScope() {
+        if (attached && vm) vm->DetachCurrentThread();
+    }
+    operator bool() const { return env != nullptr; }
+
+    jobject activity() const {
+        return ((ANativeActivity*)sapp_android_get_native_activity())->clazz;
+    }
+
+    jobject getSystemService(const char* name) {
+        jclass ctxClass = env->FindClass("android/content/Context");
+        jmethodID getService = env->GetMethodID(ctxClass, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+        jstring serviceName = env->NewStringUTF(name);
+        jobject service = env->CallObjectMethod(activity(), getService, serviceName);
+        env->DeleteLocalRef(serviceName);
+        env->DeleteLocalRef(ctxClass);
+        return service;
+    }
+};
+
+// Log and clear a pending Java exception. Returns true if one was pending.
+bool clearJniException(JNIEnv* env, const char* what) {
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        logError() << "Serial: " << what << " threw a Java exception";
+        return true;
+    }
+    return false;
+}
+
+std::string jstringToStd(JNIEnv* env, jstring js) {
+    if (!js) return "";
+    const char* chars = env->GetStringUTFChars(js, nullptr);
+    std::string result = chars ? chars : "";
+    if (chars) env->ReleaseStringUTFChars(js, chars);
+    return result;
+}
+
+int sdkInt(JNIEnv* env) {
+    jclass ver = env->FindClass("android/os/Build$VERSION");
+    jfieldID f = env->GetStaticFieldID(ver, "SDK_INT", "I");
+    int v = env->GetStaticIntField(ver, f);
+    env->DeleteLocalRef(ver);
+    return v;
+}
+
+// Find a UsbDevice by usbfs path (UsbDevice.getDeviceName()).
+// Returns a local ref or nullptr.
+jobject findDeviceByPath(JNIEnv* env, jobject usbManager, const std::string& path) {
+    jclass umClass = env->GetObjectClass(usbManager);
+    jmethodID getDeviceList = env->GetMethodID(umClass, "getDeviceList", "()Ljava/util/HashMap;");
+    jobject map = env->CallObjectMethod(usbManager, getDeviceList);
+    env->DeleteLocalRef(umClass);
+    if (clearJniException(env, "getDeviceList") || !map) return nullptr;
+
+    jclass mapClass = env->GetObjectClass(map);
+    jmethodID get = env->GetMethodID(mapClass, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+    jstring key = env->NewStringUTF(path.c_str());
+    jobject device = env->CallObjectMethod(map, get, key);
+    env->DeleteLocalRef(key);
+    env->DeleteLocalRef(mapClass);
+    env->DeleteLocalRef(map);
+    return device;
+}
+
+bool hasPermission(JNIEnv* env, jobject usbManager, jobject device) {
+    jclass umClass = env->GetObjectClass(usbManager);
+    jmethodID has = env->GetMethodID(umClass, "hasPermission", "(Landroid/hardware/usb/UsbDevice;)Z");
+    bool result = env->CallBooleanMethod(usbManager, has, device);
+    env->DeleteLocalRef(umClass);
+    if (clearJniException(env, "hasPermission")) return false;
+    return result;
+}
+
+// Show the system USB permission dialog. The PendingIntent broadcast goes
+// nowhere (no receiver registered); the result is observed by polling
+// hasPermission(). The Intent must be explicit (setPackage) because apps
+// targeting API 34+ may not create mutable PendingIntents from implicit ones.
+bool requestPermission(JniScope& jni, jobject usbManager, jobject device) {
+    JNIEnv* env = jni.env;
+
+    jclass ctxClass = env->FindClass("android/content/Context");
+    jmethodID getPackageName = env->GetMethodID(ctxClass, "getPackageName", "()Ljava/lang/String;");
+    auto packageName = (jstring)env->CallObjectMethod(jni.activity(), getPackageName);
+    env->DeleteLocalRef(ctxClass);
+
+    jclass intentClass = env->FindClass("android/content/Intent");
+    jmethodID intentCtor = env->GetMethodID(intentClass, "<init>", "(Ljava/lang/String;)V");
+    jmethodID setPackage = env->GetMethodID(intentClass, "setPackage", "(Ljava/lang/String;)Landroid/content/Intent;");
+    jstring action = env->NewStringUTF("trussc.serial.USB_PERMISSION");
+    jobject intent = env->NewObject(intentClass, intentCtor, action);
+    env->DeleteLocalRef(env->CallObjectMethod(intent, setPackage, packageName));
+    env->DeleteLocalRef(action);
+    env->DeleteLocalRef(packageName);
+    env->DeleteLocalRef(intentClass);
+
+    // FLAG_MUTABLE (API 31+): the system fills the result extras
+    int flags = (sdkInt(env) >= 31) ? 0x02000000 : 0;
+    jclass piClass = env->FindClass("android/app/PendingIntent");
+    jmethodID getBroadcast = env->GetStaticMethodID(piClass, "getBroadcast",
+        "(Landroid/content/Context;ILandroid/content/Intent;I)Landroid/app/PendingIntent;");
+    jobject pending = env->CallStaticObjectMethod(piClass, getBroadcast, jni.activity(), 0, intent, flags);
+    env->DeleteLocalRef(intent);
+    env->DeleteLocalRef(piClass);
+    if (clearJniException(env, "PendingIntent.getBroadcast") || !pending) return false;
+
+    jclass umClass = env->GetObjectClass(usbManager);
+    jmethodID request = env->GetMethodID(umClass, "requestPermission",
+        "(Landroid/hardware/usb/UsbDevice;Landroid/app/PendingIntent;)V");
+    env->CallVoidMethod(usbManager, request, device, pending);
+    env->DeleteLocalRef(umClass);
+    env->DeleteLocalRef(pending);
+    return !clearJniException(env, "requestPermission");
+}
+
+// True if the device exposes a CDC data interface (class 10)
+bool isCdcDevice(JNIEnv* env, jobject device) {
+    jclass devClass = env->GetObjectClass(device);
+    jmethodID getInterfaceCount = env->GetMethodID(devClass, "getInterfaceCount", "()I");
+    jmethodID getInterface = env->GetMethodID(devClass, "getInterface", "(I)Landroid/hardware/usb/UsbInterface;");
+    int count = env->CallIntMethod(device, getInterfaceCount);
+
+    bool found = false;
+    for (int i = 0; i < count && !found; i++) {
+        jobject iface = env->CallObjectMethod(device, getInterface, i);
+        if (!iface) continue;
+        jclass ifClass = env->GetObjectClass(iface);
+        jmethodID getInterfaceClass = env->GetMethodID(ifClass, "getInterfaceClass", "()I");
+        found = (env->CallIntMethod(iface, getInterfaceClass) == USB_CLASS_CDC_DATA);
+        env->DeleteLocalRef(ifClass);
+        env->DeleteLocalRef(iface);
+    }
+    env->DeleteLocalRef(devClass);
+    return found;
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+
+struct Impl {
+    std::atomic<int> state{(int)State::Idle};
+    std::atomic<bool> stop{false};
+    std::string path;       // requested usbfs path
+    int baud = 9600;
+    std::thread worker;     // permission poll + bulk read loop
+
+    jobject connection = nullptr;  // global ref to UsbDeviceConnection
+    int fd = -1;                   // usbfs fd owned by `connection`
+    int epIn = 0;                  // bulk IN endpoint address
+    int epOut = 0;                 // bulk OUT endpoint address
+
+    std::mutex rxMutex;
+    std::deque<uint8_t> rx;
+    bool rxOverflowWarned = false;
+};
+
+namespace {
+
+// Open the device, claim the CDC interfaces, apply line coding, and fill
+// impl->connection/fd/epIn/epOut. Caller must hold the permission.
+bool openAndClaim(Impl* impl, JniScope& jni) {
+    JNIEnv* env = jni.env;
+
+    jobject usbManager = jni.getSystemService("usb");
+    if (!usbManager) {
+        logError() << "Serial: UsbManager unavailable";
+        return false;
+    }
+    jobject device = findDeviceByPath(env, usbManager, impl->path);
+    if (!device) {
+        logError() << "Serial: device not found: " << impl->path;
+        env->DeleteLocalRef(usbManager);
+        return false;
+    }
+
+    jclass umClass = env->GetObjectClass(usbManager);
+    jmethodID openDevice = env->GetMethodID(umClass, "openDevice",
+        "(Landroid/hardware/usb/UsbDevice;)Landroid/hardware/usb/UsbDeviceConnection;");
+    jobject connection = env->CallObjectMethod(usbManager, openDevice, device);
+    env->DeleteLocalRef(umClass);
+    env->DeleteLocalRef(usbManager);
+    if (clearJniException(env, "openDevice") || !connection) {
+        logError() << "Serial: openDevice failed for " << impl->path;
+        env->DeleteLocalRef(device);
+        return false;
+    }
+
+    // Locate the CDC control (class 2) and data (class 10) interfaces
+    jclass devClass = env->GetObjectClass(device);
+    jmethodID getInterfaceCount = env->GetMethodID(devClass, "getInterfaceCount", "()I");
+    jmethodID getInterface = env->GetMethodID(devClass, "getInterface", "(I)Landroid/hardware/usb/UsbInterface;");
+    int ifCount = env->CallIntMethod(device, getInterfaceCount);
+    env->DeleteLocalRef(devClass);
+
+    jobject commIface = nullptr;
+    jobject dataIface = nullptr;
+    for (int i = 0; i < ifCount; i++) {
+        jobject iface = env->CallObjectMethod(device, getInterface, i);
+        if (!iface) continue;
+        jclass ifClass = env->GetObjectClass(iface);
+        jmethodID getInterfaceClass = env->GetMethodID(ifClass, "getInterfaceClass", "()I");
+        int cls = env->CallIntMethod(iface, getInterfaceClass);
+        env->DeleteLocalRef(ifClass);
+        if (cls == USB_CLASS_CDC_DATA && !dataIface) {
+            dataIface = iface;
+        } else if (cls == USB_CLASS_COMM && !commIface) {
+            commIface = iface;
+        } else {
+            env->DeleteLocalRef(iface);
+        }
+    }
+    env->DeleteLocalRef(device);
+
+    jclass connClass = env->GetObjectClass(connection);
+    jmethodID claimInterface = env->GetMethodID(connClass, "claimInterface",
+        "(Landroid/hardware/usb/UsbInterface;Z)Z");
+    jmethodID controlTransfer = env->GetMethodID(connClass, "controlTransfer", "(IIII[BII)I");
+    jmethodID getFileDescriptor = env->GetMethodID(connClass, "getFileDescriptor", "()I");
+    jmethodID connClose = env->GetMethodID(connClass, "close", "()V");
+
+    auto fail = [&](const char* msg) {
+        logError() << "Serial: " << msg << " (" << impl->path << ")";
+        env->CallVoidMethod(connection, connClose);
+        clearJniException(env, "close");
+        if (commIface) env->DeleteLocalRef(commIface);
+        if (dataIface) env->DeleteLocalRef(dataIface);
+        env->DeleteLocalRef(connClass);
+        env->DeleteLocalRef(connection);
+        return false;
+    };
+
+    if (!dataIface) {
+        return fail("no CDC data interface found (only CDC-ACM devices are supported on Android)");
+    }
+
+    // Claim (force = true detaches a kernel driver if one is bound)
+    if (commIface) {
+        env->CallBooleanMethod(connection, claimInterface, commIface, JNI_TRUE);
+        clearJniException(env, "claimInterface(comm)");
+    }
+    bool claimed = env->CallBooleanMethod(connection, claimInterface, dataIface, JNI_TRUE);
+    if (clearJniException(env, "claimInterface(data)") || !claimed) {
+        return fail("failed to claim CDC data interface");
+    }
+
+    // Find bulk IN/OUT endpoints on the data interface
+    jclass ifClass = env->GetObjectClass(dataIface);
+    jmethodID getEndpointCount = env->GetMethodID(ifClass, "getEndpointCount", "()I");
+    jmethodID getEndpoint = env->GetMethodID(ifClass, "getEndpoint", "(I)Landroid/hardware/usb/UsbEndpoint;");
+    jmethodID getId = env->GetMethodID(ifClass, "getId", "()I");
+    int commIfaceId = commIface ? env->CallIntMethod(commIface, getId) : 0;
+
+    int epIn = 0, epOut = 0;
+    int epCount = env->CallIntMethod(dataIface, getEndpointCount);
+    for (int i = 0; i < epCount; i++) {
+        jobject ep = env->CallObjectMethod(dataIface, getEndpoint, i);
+        if (!ep) continue;
+        jclass epClass = env->GetObjectClass(ep);
+        jmethodID getType = env->GetMethodID(epClass, "getType", "()I");
+        jmethodID getAddress = env->GetMethodID(epClass, "getAddress", "()I");
+        if (env->CallIntMethod(ep, getType) == EP_TYPE_BULK) {
+            int addr = env->CallIntMethod(ep, getAddress);
+            if (addr & EP_DIR_IN) epIn = addr;
+            else epOut = addr;
+        }
+        env->DeleteLocalRef(epClass);
+        env->DeleteLocalRef(ep);
+    }
+    env->DeleteLocalRef(ifClass);
+
+    if (!epIn || !epOut) {
+        return fail("bulk endpoints not found on CDC data interface");
+    }
+
+    // CDC-ACM line coding: baud (LE32) + 1 stop bit + no parity + 8 data bits.
+    // Some devices (nRF among them) ignore this; failures are non-fatal.
+    {
+        unsigned char coding[7] = {
+            (unsigned char)(impl->baud & 0xFF),
+            (unsigned char)((impl->baud >> 8) & 0xFF),
+            (unsigned char)((impl->baud >> 16) & 0xFF),
+            (unsigned char)((impl->baud >> 24) & 0xFF),
+            0, 0, 8
+        };
+        jbyteArray arr = env->NewByteArray(7);
+        env->SetByteArrayRegion(arr, 0, 7, (const jbyte*)coding);
+        int r = env->CallIntMethod(connection, controlTransfer,
+            CDC_REQ_TYPE, CDC_SET_LINE_CODING, 0, commIfaceId, arr, 7, WRITE_TIMEOUT_MS);
+        clearJniException(env, "controlTransfer(SET_LINE_CODING)");
+        env->DeleteLocalRef(arr);
+        if (r < 0) logWarning() << "Serial: SET_LINE_CODING not accepted (continuing)";
+
+        // Assert DTR + RTS so the device starts sending
+        env->CallIntMethod(connection, controlTransfer,
+            CDC_REQ_TYPE, CDC_SET_CONTROL_LINE_STATE, CDC_LINE_DTR_RTS, commIfaceId,
+            (jbyteArray) nullptr, 0, WRITE_TIMEOUT_MS);
+        clearJniException(env, "controlTransfer(SET_CONTROL_LINE_STATE)");
+    }
+
+    int fd = env->CallIntMethod(connection, getFileDescriptor);
+    if (clearJniException(env, "getFileDescriptor") || fd < 0) {
+        return fail("could not get usbfs file descriptor");
+    }
+
+    impl->connection = env->NewGlobalRef(connection);
+    impl->fd = fd;
+    impl->epIn = epIn;
+    impl->epOut = epOut;
+
+    if (commIface) env->DeleteLocalRef(commIface);
+    env->DeleteLocalRef(dataIface);
+    env->DeleteLocalRef(connClass);
+    env->DeleteLocalRef(connection);
+    return true;
+}
+
+// Worker thread: waits for the permission dialog result (if pending),
+// connects, then runs the bulk read loop on the raw fd (no JNI in the loop).
+void workerMain(Impl* impl) {
+    if (impl->state.load() == (int)State::Pending) {
+        JniScope jni;
+        if (!jni) {
+            impl->state = (int)State::Idle;
+            return;
+        }
+        jobject usbManager = jni.getSystemService("usb");
+        jobject device = usbManager ? findDeviceByPath(jni.env, usbManager, impl->path) : nullptr;
+        if (!device) {
+            if (usbManager) jni.env->DeleteLocalRef(usbManager);
+            impl->state = (int)State::Idle;
+            return;
+        }
+
+        auto deadline = std::chrono::steady_clock::now()
+                      + std::chrono::seconds(PERMISSION_TIMEOUT_SEC);
+        bool granted = false;
+        while (!impl->stop.load()) {
+            if (hasPermission(jni.env, usbManager, device)) {
+                granted = true;
+                break;
+            }
+            if (std::chrono::steady_clock::now() > deadline) {
+                logWarning() << "Serial: USB permission not granted within "
+                             << PERMISSION_TIMEOUT_SEC << "s for " << impl->path
+                             << " (setup() will re-show the dialog)";
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(PERMISSION_POLL_MS));
+        }
+        jni.env->DeleteLocalRef(device);
+        jni.env->DeleteLocalRef(usbManager);
+
+        if (!granted || impl->stop.load()) {
+            impl->state = (int)State::Idle;
+            return;
+        }
+        if (!openAndClaim(impl, jni)) {
+            impl->state = (int)State::Idle;
+            return;
+        }
+        impl->state = (int)State::Connected;
+        logNotice() << "Serial: connected to " << impl->path << " at " << impl->baud << " baud";
+    }
+
+    // Bulk read loop. usbfs returns -ETIMEDOUT when no data arrived within
+    // the window, which doubles as our stop-flag poll interval.
+    std::vector<unsigned char> buf(READ_CHUNK);
+    while (!impl->stop.load()) {
+        usbdevfs_bulktransfer bt{};
+        bt.ep = (unsigned int)impl->epIn;
+        bt.len = (unsigned int)buf.size();
+        bt.timeout = READ_TIMEOUT_MS;
+        bt.data = buf.data();
+        int r = ioctl(impl->fd, USBDEVFS_BULK, &bt);
+        if (r > 0) {
+            std::lock_guard<std::mutex> lock(impl->rxMutex);
+            impl->rx.insert(impl->rx.end(), buf.begin(), buf.begin() + r);
+            if (impl->rx.size() > RX_BUFFER_CAP) {
+                if (!impl->rxOverflowWarned) {
+                    impl->rxOverflowWarned = true;
+                    logWarning() << "Serial: RX buffer overflow, dropping oldest data (app is not reading fast enough)";
+                }
+                impl->rx.erase(impl->rx.begin(), impl->rx.begin() + (impl->rx.size() - RX_BUFFER_CAP));
+            }
+        } else if (r < 0 && (errno == ETIMEDOUT || errno == EAGAIN || errno == EINTR)) {
+            continue;
+        } else if (r < 0) {
+            // ENODEV / EIO / ESHUTDOWN: device unplugged or connection broken
+            logWarning() << "Serial: device lost: " << impl->path;
+            impl->state = (int)State::Idle;
+            return;
+        }
+    }
+}
+
+// Stop the worker and release the USB connection. Joins the thread, so it
+// must never be called from the worker itself.
+void closeImpl(Impl* impl) {
+    impl->stop = true;
+    if (impl->worker.joinable()) impl->worker.join();
+    impl->stop = false;
+
+    if (impl->connection) {
+        JniScope jni;
+        if (jni) {
+            jclass connClass = jni.env->GetObjectClass(impl->connection);
+            jmethodID connClose = jni.env->GetMethodID(connClass, "close", "()V");
+            jni.env->CallVoidMethod(impl->connection, connClose);
+            clearJniException(jni.env, "close");
+            jni.env->DeleteLocalRef(connClass);
+            jni.env->DeleteGlobalRef(impl->connection);
+        }
+        impl->connection = nullptr;
+        if (impl->state.load() == (int)State::Connected) {
+            logVerbose() << "Serial: disconnected from " << impl->path;
+        }
+    }
+    impl->fd = -1;
+    impl->epIn = 0;
+    impl->epOut = 0;
+    impl->state = (int)State::Idle;
+
+    std::lock_guard<std::mutex> lock(impl->rxMutex);
+    impl->rx.clear();
+    impl->rxOverflowWarned = false;
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Public backend API (called from tcSerial.h)
+// ---------------------------------------------------------------------------
+
+Impl* create() {
+    return new Impl();
+}
+
+void destroy(Impl* impl) {
+    if (!impl) return;
+    closeImpl(impl);
+    delete impl;
+}
+
+std::vector<SerialDeviceInfo> listDevices() {
+    std::vector<SerialDeviceInfo> devices;
+    JniScope jni;
+    if (!jni) return devices;
+    JNIEnv* env = jni.env;
+
+    jobject usbManager = jni.getSystemService("usb");
+    if (!usbManager) return devices;
+
+    jclass umClass = env->GetObjectClass(usbManager);
+    jmethodID getDeviceList = env->GetMethodID(umClass, "getDeviceList", "()Ljava/util/HashMap;");
+    jobject map = env->CallObjectMethod(usbManager, getDeviceList);
+    env->DeleteLocalRef(umClass);
+    env->DeleteLocalRef(usbManager);
+    if (clearJniException(env, "getDeviceList") || !map) return devices;
+
+    jclass mapClass = env->GetObjectClass(map);
+    jmethodID values = env->GetMethodID(mapClass, "values", "()Ljava/util/Collection;");
+    jobject collection = env->CallObjectMethod(map, values);
+    env->DeleteLocalRef(mapClass);
+    env->DeleteLocalRef(map);
+    if (!collection) return devices;
+
+    jclass collClass = env->GetObjectClass(collection);
+    jmethodID iteratorMethod = env->GetMethodID(collClass, "iterator", "()Ljava/util/Iterator;");
+    jobject iterator = env->CallObjectMethod(collection, iteratorMethod);
+    env->DeleteLocalRef(collClass);
+    env->DeleteLocalRef(collection);
+    if (!iterator) return devices;
+
+    jclass iterClass = env->GetObjectClass(iterator);
+    jmethodID hasNext = env->GetMethodID(iterClass, "hasNext", "()Z");
+    jmethodID next = env->GetMethodID(iterClass, "next", "()Ljava/lang/Object;");
+    env->DeleteLocalRef(iterClass);
+
+    int id = 0;
+    while (env->CallBooleanMethod(iterator, hasNext)) {
+        jobject device = env->CallObjectMethod(iterator, next);
+        if (!device) continue;
+
+        if (isCdcDevice(env, device)) {
+            jclass devClass = env->GetObjectClass(device);
+            jmethodID getDeviceName = env->GetMethodID(devClass, "getDeviceName", "()Ljava/lang/String;");
+            jmethodID getProductName = env->GetMethodID(devClass, "getProductName", "()Ljava/lang/String;");
+            auto pathStr = (jstring)env->CallObjectMethod(device, getDeviceName);
+            auto productStr = (jstring)env->CallObjectMethod(device, getProductName);
+            clearJniException(env, "getProductName");
+            env->DeleteLocalRef(devClass);
+
+            SerialDeviceInfo info;
+            info.deviceId = id++;
+            info.devicePath = jstringToStd(env, pathStr);
+            std::string product = jstringToStd(env, productStr);
+            info.deviceName = product.empty() ? info.devicePath : product;
+            if (pathStr) env->DeleteLocalRef(pathStr);
+            if (productStr) env->DeleteLocalRef(productStr);
+            devices.push_back(info);
+        }
+        env->DeleteLocalRef(device);
+    }
+    env->DeleteLocalRef(iterator);
+    return devices;
+}
+
+bool setup(Impl* impl, const std::string& devicePath, int baudRate) {
+    // Reconnect-loop guard: while the permission dialog for this device is
+    // still pending, repeated setup() calls must not re-trigger it.
+    if (impl->state.load() == (int)State::Pending && impl->path == devicePath) {
+        logVerbose() << "Serial: USB permission still pending for " << devicePath;
+        return false;
+    }
+
+    closeImpl(impl);
+    impl->path = devicePath;
+    impl->baud = baudRate;
+
+    JniScope jni;
+    if (!jni) {
+        logError() << "Serial: JNI unavailable";
+        return false;
+    }
+    jobject usbManager = jni.getSystemService("usb");
+    if (!usbManager) {
+        logError() << "Serial: UsbManager unavailable";
+        return false;
+    }
+    jobject device = findDeviceByPath(jni.env, usbManager, devicePath);
+    if (!device) {
+        logError() << "Serial: device not found: " << devicePath;
+        jni.env->DeleteLocalRef(usbManager);
+        return false;
+    }
+
+    if (hasPermission(jni.env, usbManager, device)) {
+        jni.env->DeleteLocalRef(device);
+        jni.env->DeleteLocalRef(usbManager);
+        if (!openAndClaim(impl, jni)) return false;
+        impl->state = (int)State::Connected;
+        impl->worker = std::thread(workerMain, impl);
+        logNotice() << "Serial: connected to " << devicePath << " at " << baudRate << " baud";
+        return true;
+    }
+
+    // No permission yet: show the dialog and finish connecting asynchronously
+    bool requested = requestPermission(jni, usbManager, device);
+    jni.env->DeleteLocalRef(device);
+    jni.env->DeleteLocalRef(usbManager);
+    if (!requested) {
+        logError() << "Serial: USB permission request failed for " << devicePath;
+        return false;
+    }
+    impl->state = (int)State::Pending;
+    impl->worker = std::thread(workerMain, impl);
+    logNotice() << "Serial: requesting USB permission for " << devicePath
+                << " (isInitialized() becomes true once granted)";
+    return false;
+}
+
+void close(Impl* impl) {
+    closeImpl(impl);
+}
+
+bool isConnected(const Impl* impl) {
+    return impl->state.load() == (int)State::Connected;
+}
+
+int available(const Impl* impl) {
+    std::lock_guard<std::mutex> lock(const_cast<Impl*>(impl)->rxMutex);
+    return (int)impl->rx.size();
+}
+
+int readBytes(Impl* impl, void* buffer, int length) {
+    if (length <= 0) return 0;
+    std::lock_guard<std::mutex> lock(impl->rxMutex);
+    int n = (int)std::min<size_t>((size_t)length, impl->rx.size());
+    for (int i = 0; i < n; i++) {
+        ((unsigned char*)buffer)[i] = impl->rx.front();
+        impl->rx.pop_front();
+    }
+    return n;
+}
+
+int writeBytes(Impl* impl, const void* buffer, int length) {
+    if (impl->state.load() != (int)State::Connected) return -1;
+    if (length <= 0) return 0;
+
+    int written = 0;
+    while (written < length) {
+        int chunk = std::min(WRITE_CHUNK, length - written);
+        usbdevfs_bulktransfer bt{};
+        bt.ep = (unsigned int)impl->epOut;
+        bt.len = (unsigned int)chunk;
+        bt.timeout = WRITE_TIMEOUT_MS;
+        bt.data = (void*)((const unsigned char*)buffer + written);
+        int r = ioctl(impl->fd, USBDEVFS_BULK, &bt);
+        if (r < 0) {
+            logError() << "Serial: write failed (" << strerror(errno) << ")";
+            return written > 0 ? written : -1;
+        }
+        written += r;
+        if (r == 0) break;
+    }
+    return written;
+}
+
+void flushInput(Impl* impl) {
+    std::lock_guard<std::mutex> lock(impl->rxMutex);
+    impl->rx.clear();
+    impl->rxOverflowWarned = false;
+}
+
+} // namespace androidserial
+} // namespace trussc
+
+#endif // __ANDROID__

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -52,7 +52,9 @@ TrussC uses **HTTP transport** for MCP. All JSON-RPC messages are sent as HTTP P
 ### Debugger Tools (opt-in via `mcp::enableDebugger()`)
 | Tool | Arguments | Description |
 |------|-----------|-------------|
-| `mouse_move` | `x`, `y`, `button` | Move mouse cursor (and optionally drag) |
+| `mouse_move` | `x`, `y`, `button` (optional) | Move cursor; with `button` held, emits a drag |
+| `mouse_press` | `x`, `y`, `button` | Press and hold — start of a drag gesture |
+| `mouse_release` | `x`, `y`, `button` | Release — end of a drag gesture |
 | `mouse_click` | `x`, `y`, `button`, `shift`/`ctrl`/`alt`/`super` (optional) | Click mouse button (0:left, 1:right), optionally with modifier keys held — e.g. `super: true` Cmd+clicks |
 | `mouse_scroll` | `dx`, `dy` | Scroll mouse wheel |
 | `key_press` | `key` | Press a key (sokol_app keycode) |
@@ -207,7 +209,7 @@ Configure your MCP client with the HTTP URL:
 | Category | Tools | Enabled by |
 |----------|-------|------------|
 | Inspection (read-only) | `get_screenshot`, `save_screenshot`, `get_node_tree`, `get_selected_node` | Automatic when MCP is enabled |
-| Debugger (input injection / scene mutation) | `mouse_click`, `key_press`, `mouse_move`, `mouse_scroll`, `key_release`, `select_node`, `set_node_members` | `mcp::enableDebugger()` + `mcp::registerDebuggerTools()` |
+| Debugger (input injection / scene mutation) | `mouse_click`, `mouse_press`, `mouse_release`, `key_press`, `mouse_move`, `mouse_scroll`, `key_release`, `select_node`, `set_node_members` | `mcp::enableDebugger()` + `mcp::registerDebuggerTools()` |
 | ImGui (widget interaction) | `imgui_get_widgets`, `imgui_click`, `imgui_input`, `imgui_checkbox` | Requires tcxImGui addon + `mcp::registerDebuggerTools()` |
 | Custom | `mcp::tool(...)` | Your code |
 

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -7,7 +7,7 @@
   If you are a CONSOLE CODING AGENT (Claude Code, Codex, or similar with
   file/shell access), do not load this file — install the TrussC development
   skill instead; it covers the same ground plus build/verify workflows:
-      git clone https://github.com/TrussC-org/TrussC_Development_Skill.git ~/.claude/skills/trussc-dev
+      git clone https://github.com/TrussC-org/trussc-dev-skill.git ~/.claude/skills/trussc-dev
   (Codex: clone into ~/.codex/skills/trussc-dev)
 -->
 
@@ -738,7 +738,7 @@ Every TrussC app can run as an MCP server: launch with `TRUSSC_MCP=1` and the ap
 exposes screenshots, input injection, and live node-tree read/write over HTTP —
 AI agents can drive and verify the running app directly. As a chat assistant you
 won't use this yourself; just know it exists so you can point users to it
-(details: docs/AI_AUTOMATION.md, agent workflows: the TrussC_Development_Skill repo).
+(details: docs/AI_AUTOMATION.md, agent workflows: the trussc-dev-skill repo).
 
 ## Addons
 

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -9759,6 +9759,15 @@ types:
         description_ja: "パスが閉じているか確認"
         description_ko: "경로가 닫혀 있는지 확인"
         snippet: "isClosed()"
+      - name: reverseWinding
+        return: "Path&"
+        signatures:
+          - params: ""
+          - params: "size_t subpath"
+        description: "Reverse the winding direction (vertex order) of all subpaths, or of one subpath. Under drawFill's non-zero winding rule, reversing a subpath toggles it between filling and cutting — e.g. build a circle contour, then reverseWinding(i) it into a hole punch. Reversing ALL subpaths leaves the render unchanged (only relative direction matters) — handy for imported outlines using the opposite convention."
+        description_ja: "subpath の巻き方向 (頂点順) を反転。引数なしで全 subpath、index 指定で 1 つだけ。drawFill の non-zero winding rule では反転で塗り ↔ 穴が切り替わる — 円の contour を作って reverseWinding(i) すれば穴パンチになる。全部反転しても描画結果は不変 (相対方向のみ意味を持つ) なので、逆巻き慣習のインポートデータの修正にも使える。"
+        description_ko: "subpath의 감김 방향 (정점 순서)을 반전. 인수 없이 전체, index 지정으로 하나만. drawFill의 non-zero winding rule에서는 반전으로 채움 ↔ 구멍이 전환됨. 전체 반전은 렌더 결과 불변 (상대 방향만 의미) — 반대 규약의 임포트 데이터 수정에도 사용."
+        snippet: "reverseWinding(${1:1})"
       - name: draw
         return: "void"
         signatures:
@@ -9771,9 +9780,9 @@ types:
         return: "void"
         signatures:
           - params: ""
-        description: "Fill the path as a concave polygon with holes (earcut tessellation). Subpaths are grouped by spatial containment — outer ring + direct children become holes, grandchildren become separate filled islands. Use this for glyphs with holes (e, a, O, 日 ...) and any shape that drawString-style fill can't handle."
-        description_ja: "穴付き凹多角形として塗りつぶし (earcut)。subpath は包含関係でグループ化 — 外枠 + 直下の子が穴、孫は別の塗り島。穴付きグリフ (e, a, O, 日 等) や凹形状に使う。"
-        description_ko: "구멍 있는 오목 다각형 채우기 (earcut). subpath는 공간적 포함 관계로 그룹화 — 외곽선 + 직접 자식이 구멍, 손자는 별도 채우기 섬. 구멍 있는 글리프 (e, a, O, 日 등)와 오목한 형태에 사용."
+        description: "Fill the path as a concave polygon with holes (earcut tessellation). Subpaths follow the non-zero winding rule (SVG / PostScript default): a subpath wound opposite to its enclosing ring becomes a hole; same-direction subpaths union (never punch holes). Handles glyphs with holes (e, a, O, 日 ...), overlapping contours, and both TrueType / CFF winding conventions. To cut a hole in a hand-built Path, wind the inner subpath opposite (see reverseWinding)."
+        description_ja: "穴付き凹多角形として塗りつぶし (earcut)。subpath は non-zero winding rule (SVG / PostScript のデフォルト) に従う — 外側のリングと逆巻きの subpath が穴になり、同方向は union (穴を開けない)。穴付きグリフ (e, a, O, 日 等)、重なった contour、TrueType / CFF 両方の巻き方向慣習に対応。手書き Path で穴を開けるには内側を逆巻きにする (reverseWinding 参照)。"
+        description_ko: "구멍 있는 오목 다각형 채우기 (earcut). subpath는 non-zero winding rule (SVG / PostScript 기본값)을 따름 — 바깥 링과 반대로 감긴 subpath가 구멍이 되고, 같은 방향은 union. 구멍 있는 글리프 (e, a, O, 日 등), 겹친 contour, TrueType / CFF 양쪽 규약 지원. 수제 Path에 구멍을 내려면 안쪽을 반대로 감음 (reverseWinding 참조)."
         snippet: "drawFill()"
       - name: drawStroke
         return: "void"

--- a/examples/communication/serialExample/src/tcApp.cpp
+++ b/examples/communication/serialExample/src/tcApp.cpp
@@ -116,7 +116,7 @@ void tcApp::draw() {
     drawBitmapString(deviceStr, 50, 60);
 
     // Message to send
-    std::string msgStr = "Type to send message\n";
+    std::string msgStr = "Type to send message (or click/tap to send \"hello\")\n";
     if (!messageToSend.empty()) {
         msgStr += messageToSend;
     }
@@ -137,6 +137,15 @@ void tcApp::draw() {
         drawBitmapString(receivedMessages[i], 550, posY, 2.0f);
         posY += 42;
     }
+}
+
+// =============================================================================
+// mousePressed - click/tap sends a test message
+// (mainly for Android and other targets without a hardware keyboard)
+// =============================================================================
+void tcApp::mousePressed(Vec2 pos, int button) {
+    messageToSend = "hello";
+    bSendSerialMessage = true;
 }
 
 // =============================================================================

--- a/examples/communication/serialExample/src/tcApp.h
+++ b/examples/communication/serialExample/src/tcApp.h
@@ -15,6 +15,7 @@ public:
     void update() override;
     void draw() override;
     void keyPressed(int key) override;
+    void mousePressed(Vec2 pos, int button) override;
 
 private:
     // Serial communication


### PR DESCRIPTION
Re-bundle the five PRs that were closed because CI was broken on Windows (now fixed in #121), plus the Android serial backend, into a single dev→main PR.

### Included
- **#116** fix: tcxImGui crash on window close — auto-teardown on exit event + `sg_isvalid` guard
- **#117** fix: tcxNodeInspector gizmo handle flicker on moving nodes
- **#118** fix: `Path::drawFill` winding rule + self-intersection split (garbage fills on some fonts)
- **#119** feat: `mouse_press`/`mouse_release` MCP tools + `mouse_move` optional-button fix
- **#120** doc: skill repo renamed to trussc-dev-skill
- **(new)** feat: Android USB Host CDC-ACM serial backend (JNI + usbfs) — hardware-verified on XIAO nRF52840

### Notes
- Built on top of the CI fix (#121), so Windows CI passes.
- The CI-fix commits are shared with `main` and do not appear in this diff.