### PR TITLE
fix: drawBitmapStringHighlight — solid background under external noFill() + no style leak

### DIFF
--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -1376,6 +1376,12 @@ inline void drawBitmapStringHighlight(const std::string& text, float x, float y,
     ensureFontAtlasForText(text);
     if (!internal::fontAtlasInitialized) return;
 
+    // Isolate style: the highlight always wants a solid background and its own
+    // colors. Without this an external noFill() would leave only the rect
+    // outline, and the setColor(background) below would leak to the caller.
+    pushStyle();
+    fill();
+
     // Calculate text size
     float textWidth, textHeight;
     getBitmapStringBounds(text, textWidth, textHeight);
@@ -1476,6 +1482,9 @@ inline void drawBitmapStringHighlight(const std::string& text, float x, float y,
     sgl_matrix_mode_projection();
     sgl_pop_matrix();
     sgl_matrix_mode_modelview();
+
+    // Restore caller's style (color, fill/stroke, etc.)
+    popStyle();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`drawBitmapStringHighlight` drew its background with `drawRect()`, so it inherited the caller's fill mode: after an external `noFill()` the "highlight" was just a rect **outline**, not a solid background. It also called `setColor(background)` without restoring, **leaking** the color to the caller.

### Fix
Wrap the body in `pushStyle()` / `popStyle()` and force `fill()` internally. The highlight now always paints a solid background regardless of the external fill state, and restores the caller's color + fill mode on exit.

### Verification
Screenshot test (throwaway app): highlight drawn right after `noFill()` shows a solid background; a subsequent `drawRect()` confirms the caller's `noFill()` + color survived (red outline, not filled), and the normal `fill()` path is unaffected.