### PR TITLE
feat(tcxNodeInspector): autonomous singleton attach() + toggle keys

### DIFF
--- a/addons/tcxNodeInspector/example-basic/src/tcApp.cpp
+++ b/addons/tcxNodeInspector/example-basic/src/tcApp.cpp
@@ -2,7 +2,6 @@
 
 void tcApp::setup() {
     setWindowTitle("tcxNodeInspector");
-    imguiSetup();   // registers the ImGui overlay (and MCP ImGui tools when TRUSSC_MCP is set)
 
     // Input-injection MCP tools (mouse_click / key_press / ...), so an AI
     // agent can drive the demo. No-ops unless TRUSSC_MCP is set.
@@ -16,29 +15,19 @@ void tcApp::setup() {
 
     buildDemo(*sceneRoot_);
 
-    // Give the inspector a distinct accent (teal is the default — shown here so
-    // it's obvious where to recolor it).
-    inspector_.setAccent(Color(0.16f, 0.55f, 0.62f));
+    // One line and the inspector runs itself: it sets up imgui, draws its own
+    // frame on sceneRoot_ every frame, and F1 toggles it. The static call
+    // returns the singleton, so we chain a custom accent (teal is the default —
+    // shown here so it's obvious where to recolor it).
+    NodeInspector::attach(*sceneRoot_, KEY_F1).setAccent(Color(0.16f, 0.55f, 0.62f));
 }
 
 void tcApp::update() {}
 
-void tcApp::keyPressed(const KeyEventArgs& e) {
-    if (e.key == KEY_F1) inspector_.toggle();   // hide/show the whole tool
-}
-
 void tcApp::draw() {
     clear(0.11f, 0.12f, 0.13f);
 
-    // A short hint on the canvas.
+    // A short hint on the canvas. The inspector draws itself (see setup()).
     setColor(0.5f, 0.5f, 0.55f);
     drawBitmapString("click circles (2D) or cubes (3D) to select / shift+drag orbits the camera / F1 toggles the inspector", 16, 620);
-
-    imguiBegin();
-    inspector_.draw(*sceneRoot_);   // hierarchy + inspector + gizmo
-    imguiEnd();
-}
-
-void tcApp::cleanup() {
-    imguiShutdown();
 }

--- a/addons/tcxNodeInspector/example-basic/src/tcApp.h
+++ b/addons/tcxNodeInspector/example-basic/src/tcApp.h
@@ -13,10 +13,7 @@ public:
     void setup() override;
     void update() override;
     void draw() override;
-    void keyPressed(const KeyEventArgs& e) override;
-    void cleanup() override;
 
 private:
     RectNode::Ptr sceneRoot_;
-    NodeInspector inspector_;
 };

--- a/addons/tcxNodeInspector/src/tcxNodeInspector.cpp
+++ b/addons/tcxNodeInspector/src/tcxNodeInspector.cpp
@@ -768,4 +768,106 @@ void NodeInspector::drawGizmo() {
     }
 }
 
+// =============================================================================
+// Autonomous mode — the inspector draws itself every frame with no per-frame
+// calls. Static API drives the singleton; the work lives in private helpers.
+// =============================================================================
+
+NodeInspector& NodeInspector::attach() {
+    NodeInspector& s = instance();
+    s.attachRoot_ = nullptr;
+    s.doAttach();
+    return s;
+}
+
+NodeInspector& NodeInspector::attach(Node& root) {
+    NodeInspector& s = instance();
+    s.attachRoot_ = &root;
+    s.doAttach();
+    return s;
+}
+
+NodeInspector& NodeInspector::attach(int toggleKey) {
+    setToggleKey(toggleKey);
+    return attach();
+}
+
+NodeInspector& NodeInspector::attach(Node& root, int toggleKey) {
+    setToggleKey(toggleKey);
+    return attach(root);
+}
+
+void NodeInspector::detach() {
+    instance().doDetach();
+}
+
+NodeInspector& NodeInspector::setToggleKey(int key) {
+    NodeInspector& s = instance();
+    s.toggleKeys_ = {key};
+    s.ensureToggleKeyListener();
+    return s;
+}
+
+NodeInspector& NodeInspector::addToggleKey(int key) {
+    NodeInspector& s = instance();
+    s.toggleKeys_.push_back(key);
+    s.ensureToggleKeyListener();
+    return s;
+}
+
+NodeInspector& NodeInspector::clearToggleKeys() {
+    instance().toggleKeys_.clear();         // listener stays; nothing matches
+    return instance();
+}
+
+// --- private helpers ---------------------------------------------------------
+
+void NodeInspector::doAttach() {
+    imguiSetup();                           // idempotent — safe if already set up
+    ensureExitGuard();
+
+    // onRender fires after the scene has drawn (so camera contexts are current
+    // for the gizmo) and before tcxImGui's render listener (priority 1000).
+    // Building the frame at the default priority lands it in the same pass, on
+    // top of the scene. Re-attaching just replaces the previous listener.
+    autoDraw_ = events().onRender.listen([this] {
+        Node* r = attachRoot_ ? attachRoot_ : getRootNode();
+        if (!r) return;
+        imguiBegin();
+        draw(*r);
+        imguiEnd();
+    });
+}
+
+void NodeInspector::doDetach() {
+    autoDraw_ = {};
+}
+
+// Installed once and kept for the app's lifetime; set/add/clear only edit
+// toggleKeys_, so a cleared set simply never matches.
+void NodeInspector::ensureToggleKeyListener() {
+    if (toggleKeyListener_) return;
+    ensureExitGuard();
+    toggleKeyListener_ = events().keyPressed.listen([this](KeyEventArgs& e) {
+        if (e.consumed) return;             // e.g. typing in the inspector's name field
+        for (int k : toggleKeys_) {
+            if (e.key == k) { toggle(); break; }
+        }
+    });
+}
+
+// The singleton outlives the framework, so its listeners would otherwise be
+// torn down at static-destruction time — after events() may already be gone.
+// Drop them at the exit event instead, while everything is still alive (the
+// same pattern tcxImGui's ImGuiManager uses). Removing exitListener_ from
+// inside its own callback is fine: the dispatch list is snapshotted.
+void NodeInspector::ensureExitGuard() {
+    if (exitListener_) return;
+    exitListener_ = events().exit.listen([this] {
+        autoDraw_ = {};
+        toggleKeyListener_ = {};
+        exitListener_ = {};
+    });
+}
+
 } // namespace tcx

--- a/addons/tcxNodeInspector/src/tcxNodeInspector.h
+++ b/addons/tcxNodeInspector/src/tcxNodeInspector.h
@@ -75,8 +75,23 @@ protected:
     }
 };
 
+// A single debug overlay per app — NodeInspector is a singleton, not something
+// you instantiate. The init / autonomous API is static (attach / toggle keys);
+// everything else (style, selection, manual draw) hangs off instance(). Drop it
+// in with one line in setup() and no member:
+//
+//     NodeInspector::attach(KEY_F1);                 // autonomous, F1 toggles
+//     NodeInspector::attach(KEY_F1).setAccent(...);  // static call chains into instance
+//
 class NodeInspector {
 public:
+    // The one inspector. Constructed on first use (Meyers singleton). Use this
+    // to reach the instance-level API (style, selection, manual draw).
+    static NodeInspector& instance() {
+        static NodeInspector inst;
+        return inst;
+    }
+
     // Look & feel. Inspectors get cramped fast, so the defaults are compact and
     // the panel background is semi-transparent. The accent recolors the title
     // bars / selection so an inspector reads as visually distinct from an app's
@@ -129,6 +144,35 @@ public:
     bool isGizmoDragging() const { return dragAxis_ >= 0; }
 
     // -------------------------------------------------------------------------
+    // Autonomous mode (static — drives the singleton)
+    // -------------------------------------------------------------------------
+    // attach() makes the inspector draw itself every frame — call it once in
+    // setup() and write nothing in your app's draw(). It ensures imgui is
+    // initialized (imguiSetup) and then drives imguiBegin()/draw(root)/imguiEnd()
+    // from an onRender listener — after the scene is drawn, so the gizmo's camera
+    // projection is current-frame, and before tcxImGui's render. Root defaults to
+    // getRootNode() (the running App); pass one to inspect a subtree instead.
+    // Each returns the singleton, so a call chains into the instance API
+    // (e.g. NodeInspector::attach(KEY_F1).setAccent(...)).
+    //
+    // attach() OWNS the imgui frame. If your app also drives imgui itself, don't
+    // attach() — call instance().draw(root) inside your own imguiBegin()/imguiEnd().
+    static NodeInspector& attach();
+    static NodeInspector& attach(::tc::Node& root);
+    static NodeInspector& attach(int toggleKey);                  // attach() + setToggleKey
+    static NodeInspector& attach(::tc::Node& root, int toggleKey);
+    static void detach();                                         // stop drawing itself
+    static bool isAttached() { return static_cast<bool>(instance().autoDraw_); }
+
+    // Toggle key(s): pressing any registered key flips the inspector on/off
+    // (toggle()). The key listener is installed on the first set/add and stays
+    // for the app's lifetime; these just edit the key set, so a cleared set
+    // simply never matches. Works with or without attach().
+    static NodeInspector& setToggleKey(int key);     // replace the set with one key
+    static NodeInspector& addToggleKey(int key);     // add one key
+    static NodeInspector& clearToggleKeys();         // forget all keys (listener stays)
+
+    // -------------------------------------------------------------------------
     // Multi-selection
     // -------------------------------------------------------------------------
     // Lives in the inspector, NOT in core: core's selection stays the single
@@ -154,8 +198,24 @@ private:
     char     nameBuf_[128] = "";
     uint64_t nameBufFor_   = 0;
 
+    // Singleton: no user-constructed instances (use instance() / the static API).
+    NodeInspector() = default;
+    NodeInspector(const NodeInspector&) = delete;
+    NodeInspector& operator=(const NodeInspector&) = delete;
+
     void drawTreeNode(const ::tc::Node::Ptr& node);
     void syncNameBuf(::tc::Node* node);
+
+    // --- autonomous mode -----------------------------------------------------
+    void doAttach();                          // imguiSetup + onRender listener
+    void doDetach();                          // drop the frame driver
+    void ensureToggleKeyListener();
+    void ensureExitGuard();                   // drop listeners at exit (before teardown)
+    ::tc::EventListener autoDraw_;             // onRender frame driver (attach)
+    ::tc::Node*         attachRoot_ = nullptr; // null => getRootNode() each frame
+    std::vector<int>    toggleKeys_;
+    ::tc::EventListener toggleKeyListener_;    // installed once, then lives on
+    ::tc::EventListener exitListener_;         // clears the above while events() is alive
 
     // --- gizmo ---------------------------------------------------------------
     enum class GizmoMode { Translate, Rotate };


### PR DESCRIPTION
## Summary

Make `tcxNodeInspector::NodeInspector` a singleton driven by a static API, so the
debug overlay can be dropped into any app with one line in `setup()` and no member:

```cpp
NodeInspector::attach(KEY_F1);   // autonomous; F1 toggles; pass a root to scope it
```

## Changes

- **Static init API on a singleton:** `attach()` / `attach(root)` / `attach(key)` /
  `attach(root, key)`, `detach()`, `isAttached()`, plus `setToggleKey` /
  `addToggleKey` / `clearToggleKeys`. Each returns the singleton, so calls chain into
  the instance API (e.g. `attach(KEY_F1).setAccent(...)`).
- **No user-constructed instances:** private ctor; reach the instance-level API
  (style, selection, manual `draw()`) via `instance()`.
- **Self-driving:** draws on `onRender` — after the scene, before tcxImGui's render —
  so the gizmo's camera projection is current-frame. `imguiSetup()` is folded in, and
  the singleton's listeners are dropped on the `exit` event (same pattern as
  `ImGuiManager`) to stay safe across teardown.
- **Toggle keys:** one key listener installed on first set/add and kept for the app's
  lifetime; the set/add/clear calls only edit the key list.
- Update `example-basic` to the one-line static usage.

## Verification

- macOS: builds and links (addon + `example-basic`); ran the example via MCP and
  confirmed the inspector draws itself autonomously (Hierarchy + Inspector + gizmo) and
  the F1 toggle works.
- No platform-specific code touched (imgui / events / `getRootNode()` only); Windows /
  Linux not built.
