### PR TITLE
feat: auto-resolve addon dependencies in trusscli (add + GUI) + version-sync warning

### DIFF
--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -50,6 +50,29 @@ trusscli update -p path/to/myProject --tc-root path/to/TrussC
 trusscli new path/to/myNewApp
 ```
 
+### Keeping `trusscli` in sync
+
+`trusscli` is a compiled binary. When you update TrussC by pulling the latest
+source (`git pull`), the binary you already have is **not** rebuilt automatically,
+so it can fall out of step with the framework.
+
+```bash
+# Pull + rebuild trusscli in one step (recommended)
+trusscli upgrade
+```
+
+If you pull manually instead, rebuild `trusscli` afterwards
+(`tools/build_mac.command` / `build_win.bat` / `build_linux.sh`). `trusscli`
+detects this drift and prints a reminder on startup when the source has changed
+since the binary was built:
+
+```
+Note: TrussC has changed since trusscli was built (trusscli v0.6.1 vs TrussC v0.7.0).
+      Run 'trusscli upgrade' to rebuild trusscli in sync.
+```
+
+`trusscli doctor` reports the same version-sync status in detail.
+
 ---
 
 ## 2. Building Projects

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -515,6 +515,23 @@ static void printVersion() {
     }
 }
 
+// Print a one-line nudge to stderr when the running trusscli was built from a
+// different TrussC revision than the source tree it now points at (e.g. after a
+// manual `git pull`). Non-fatal — it only reminds the user to `trusscli upgrade`
+// so the binary is rebuilt in sync. Silent when the version can't be determined
+// (no git, "unknown" build, etc.) so it never nags where the check is moot.
+static void warnIfVersionDrift(const string& tcRoot) {
+    if (tcRoot.empty()) return;
+    const string built = TRUSSCLI_VERSION;
+    if (built == "unknown") return;
+    const string current = queryTrussCVersion(tcRoot);
+    if (current.empty() || current == built) return;
+
+    cerr << "Note: TrussC has changed since trusscli was built "
+         << "(trusscli " << built << " vs TrussC " << current << ").\n"
+         << "      Run 'trusscli upgrade' to rebuild trusscli in sync.\n";
+}
+
 // =============================================================================
 // Common helpers for project-based subcommands
 // =============================================================================
@@ -1299,6 +1316,38 @@ static void printAddHelp() {
          << "  trusscli addon add tcxOsc tcxImGui tcxBox2d    Add multiple addons at once\n";
 }
 
+// Collect the transitive dependency names of a locally-installed addon by
+// reading its addon.json `dependencies` field (entries may be plain strings or
+// objects with a "name" key). Only names are gathered here — the caller checks
+// availability and selects them. `seen` guards against cycles and duplicates;
+// pre-seed it with the already-requested addons so they are not re-listed.
+static void collectAddonDependencies(const string& tcRoot,
+                                     const string& addonName,
+                                     set<string>& seen,
+                                     vector<string>& out) {
+    string jsonPath = tcRoot + "/addons/" + addonName + "/addon.json";
+    if (!fs::exists(jsonPath)) return;
+    Json meta;
+    try {
+        ifstream f(jsonPath);
+        stringstream ss;
+        ss << f.rdbuf();
+        meta = Json::parse(ss.str());
+    } catch (...) {
+        return;
+    }
+    if (!meta.contains("dependencies") || !meta["dependencies"].is_array()) return;
+    for (const auto& d : meta["dependencies"]) {
+        string dep;
+        if (d.is_string()) dep = d.get<string>();
+        else if (d.is_object()) dep = d.value("name", "");
+        if (dep.empty() || seen.count(dep)) continue;
+        seen.insert(dep);
+        out.push_back(dep);
+        collectAddonDependencies(tcRoot, dep, seen, out);  // transitive
+    }
+}
+
 static int cmdAdd(const vector<string>& args) {
     vector<string> requestedAddons;
     string explicitPath;
@@ -1356,12 +1405,33 @@ static int cmdAdd(const vector<string>& args) {
         }
     }
 
-    // Read current selection, add the requested addons (idempotent — duplicates warn)
+    // Expand with transitive dependencies so addons.make records everything the
+    // build needs — no addon gets pulled in implicitly without appearing here.
+    vector<string> depAddons;
+    {
+        set<string> seen(requestedAddons.begin(), requestedAddons.end());
+        for (const string& want : requestedAddons) {
+            collectAddonDependencies(resolvedTcRoot, want, seen, depAddons);
+        }
+    }
+    for (const string& dep : depAddons) {
+        if (find(availableAddons.begin(), availableAddons.end(), dep) == availableAddons.end()) {
+            cerr << "Error: dependency '" << dep << "' is required but not available locally.\n"
+                 << "Clone it first:  trusscli addon clone " << dep << "\n";
+            return 1;
+        }
+    }
+
+    // Read current selection, add requested + dependency addons (idempotent).
     vector<int> addonSelected;
     parseAddonsMake(projectPath, availableAddons, addonSelected);
 
+    vector<string> toAdd = requestedAddons;
+    toAdd.insert(toAdd.end(), depAddons.begin(), depAddons.end());
+    set<string> depSet(depAddons.begin(), depAddons.end());
+
     vector<string> addedNow;
-    for (const string& want : requestedAddons) {
+    for (const string& want : toAdd) {
         for (size_t i = 0; i < availableAddons.size(); ++i) {
             if (availableAddons[i] == want) {
                 if (addonSelected[i]) {
@@ -1369,6 +1439,9 @@ static int cmdAdd(const vector<string>& args) {
                 } else {
                     addonSelected[i] = 1;
                     addedNow.push_back(want);
+                    if (depSet.count(want)) {
+                        cout << "  + dependency " << want << "\n";
+                    }
                 }
                 break;
             }
@@ -3692,6 +3765,7 @@ int main(int argc, char* argv[]) {
             return 1;
         }
         #endif
+        warnIfVersionDrift(autoDetectTcRoot());
         WindowSettings settings;
         settings.title = "TrussC Project Generator";
         settings.width = 500;
@@ -3708,6 +3782,14 @@ int main(int argc, char* argv[]) {
     if (first == "-v" || first == "--version" || first == "version") {
         printVersion();
         return 0;
+    }
+
+    // Nudge the user to re-sync when the TrussC source drifted from the revision
+    // trusscli was built from. Skipped for commands that either report this
+    // themselves (doctor), act on it (upgrade), or must keep output machine-clean
+    // (completion).
+    if (first != "upgrade" && first != "doctor" && first != "completion") {
+        warnIfVersionDrift(autoDetectTcRoot());
     }
 
     // On Windows, make sure `cmake` is resolvable before any subcommand that

--- a/tools/src/tcApp.cpp
+++ b/tools/src/tcApp.cpp
@@ -6,6 +6,9 @@
 #include "ProjectGenerator.h"
 #include <filesystem>
 #include <fstream>
+#include <sstream>
+#include <set>
+#include <map>
 #include <thread>
 
 namespace fs = std::filesystem;
@@ -363,7 +366,25 @@ void tcApp::draw() {
         for (size_t i = 0; i < addons.size(); i++) {
             bool selected = addonSelected[i] != 0;
             if (ImGui::Checkbox(addons[i].c_str(), &selected)) {
-                addonSelected[i] = selected ? 1 : 0;
+                if (selected) {
+                    // Checking an addon auto-selects its dependencies so they
+                    // are recorded in addons.make (no implicit/hidden deps).
+                    selectAddonWithDeps(i);
+                } else {
+                    addonSelected[i] = 0;
+                }
+            }
+            // Show declared dependencies as a hint next to the checkbox.
+            auto depIt = addonDeps.find(addons[i]);
+            if (depIt != addonDeps.end() && !depIt->second.empty()) {
+                string hint = "(needs ";
+                for (size_t d = 0; d < depIt->second.size(); d++) {
+                    if (d > 0) hint += ", ";
+                    hint += depIt->second[d];
+                }
+                hint += ")";
+                ImGui::SameLine();
+                ImGui::TextDisabled("%s", hint.c_str());
             }
         }
     }
@@ -658,6 +679,7 @@ void tcApp::saveConfig() {
 void tcApp::scanAddons() {
     addons.clear();
     addonSelected.clear();
+    addonDeps.clear();
 
     if (tcRoot.empty()) return;
 
@@ -671,12 +693,56 @@ void tcApp::scanAddons() {
             if (name.substr(0, 3) == "tcx") {
                 addons.push_back(name);
                 addonSelected.push_back(0);
+
+                // Read declared dependencies from addon.json (entries may be
+                // plain strings or objects with a "name" key).
+                string jsonPath = entry.path().string() + "/addon.json";
+                if (fs::exists(jsonPath)) {
+                    try {
+                        ifstream f(jsonPath);
+                        stringstream ss;
+                        ss << f.rdbuf();
+                        Json meta = Json::parse(ss.str());
+                        if (meta.contains("dependencies") && meta["dependencies"].is_array()) {
+                            for (const auto& d : meta["dependencies"]) {
+                                string dep;
+                                if (d.is_string()) dep = d.get<string>();
+                                else if (d.is_object()) dep = d.value("name", "");
+                                if (!dep.empty()) addonDeps[name].push_back(dep);
+                            }
+                        }
+                    } catch (...) {
+                        // Ignore malformed addon.json — treat as no dependencies.
+                    }
+                }
             }
         }
     }
 
     // Sort
     sort(addons.begin(), addons.end());
+}
+
+void tcApp::selectAddonWithDeps(size_t index) {
+    if (index >= addons.size()) return;
+    addonSelected[index] = 1;
+
+    // Walk the dependency graph, selecting each dep that exists locally.
+    vector<string> stack = addonDeps[addons[index]];
+    set<string> seen;
+    while (!stack.empty()) {
+        string dep = stack.back();
+        stack.pop_back();
+        if (seen.count(dep)) continue;
+        seen.insert(dep);
+        for (size_t i = 0; i < addons.size(); i++) {
+            if (addons[i] == dep) {
+                addonSelected[i] = 1;
+                for (const string& sub : addonDeps[dep]) stack.push_back(sub);
+                break;
+            }
+        }
+    }
 }
 
 string tcApp::getTemplatePath() {

--- a/tools/src/tcApp.h
+++ b/tools/src/tcApp.h
@@ -43,6 +43,7 @@ private:
     string importedProjectPath;         // Full path for Import mode
     vector<string> addons;              // Available addons
     vector<int> addonSelected;          // Addon selection state (0/1)
+    map<string, vector<string>> addonDeps;  // addon name -> declared dependency names
     IdeType ideType = IdeType::VSCode;  // Default is VSCode
     bool generateWebBuild = false;      // Generate Web (Emscripten) build
     bool generateAndroidBuild = false;  // Generate Android build
@@ -89,6 +90,8 @@ private:
     void loadConfig();
     void saveConfig();
     void scanAddons();
+    // Select an addon (by index) and auto-select its transitive dependencies.
+    void selectAddonWithDeps(size_t index);
     void importProject(const string& path);
     string getTemplatePath();
     void setStatus(const string& msg, bool isError = false);


### PR DESCRIPTION
## Summary
Addons declare their dependencies in `addon.json`, but until now only
`trusscli addon clone` honored them. Adding an addon to a project — via the CLI
or the Project Generator GUI — left its dependencies out of `addons.make`, so
the build silently relied on addons that were never recorded. This PR resolves
dependencies in both paths, and adds a startup warning when `trusscli` itself
has drifted from the TrussC source.

## Changes
**Addon dependency resolution**
- `trusscli addon add` now expands requested addons with their *transitive*
  dependencies and writes them all to `addons.make`. If a dependency is not
  available locally, it errors with a `clone` hint.
- The Project Generator GUI auto-selects an addon's dependencies when you check
  it, and shows a `(needs ...)` hint next to each addon that declares any.

**trusscli version-sync warning**
- After a manual `git pull`, the compiled `trusscli` can drift from the source.
  The version-sync check (already used by `doctor`/`--version`) now also prints
  a one-line reminder on startup to run `trusscli upgrade`.
- Skipped for `upgrade` (acts on it), `doctor` (reports it in detail), and
  `completion` (keeps machine output clean). Silent when the version is
  undeterminable.
- Docs: `BUILD_SYSTEM.md` note on keeping `trusscli` in sync.

## Testing
- macOS: built; `addon add tcxNodeInspector` pulls `tcxImGui` into
  `addons.make`; GUI auto-check + hint verified; drift warning fires only on
  real drift, `completion` stays clean.
- Windows: built and verified OK.