### PR TITLE
fix: resolve loadXml/Xml::save paths via getDataPath (match loadJson)

### DIFF
--- a/core/include/tc/utils/tcXml.h
+++ b/core/include/tc/utils/tcXml.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include "pugixml/pugixml.hpp"
 #include "tcLog.h"
+#include "tcUtils.h"   // getDataPath
 
 namespace trussc {
 
@@ -25,16 +26,17 @@ class Xml {
 public:
     Xml() = default;
 
-    // Load from file
+    // Load from file (relative paths resolved via getDataPath, like loadJson)
     bool load(const std::string& path) {
-        XmlParseResult result = doc_.load_file(path.c_str());
+        std::string fullPath = getDataPath(path);
+        XmlParseResult result = doc_.load_file(fullPath.c_str());
         if (!result) {
             logError() << "XML load error: " << path
                          << " - " << result.description()
                          << " (offset: " << result.offset << ")";
             return false;
         }
-        logVerbose() << "XML loaded: " << path;
+        logVerbose() << "XML loaded: " << fullPath;
         return true;
     }
 
@@ -49,14 +51,15 @@ public:
         return true;
     }
 
-    // Save to file
+    // Save to file (relative paths resolved via getDataPath, like saveJson)
     bool save(const std::string& path, const std::string& indent = "  ") const {
-        bool success = doc_.save_file(path.c_str(), indent.c_str());
+        std::string fullPath = getDataPath(path);
+        bool success = doc_.save_file(fullPath.c_str(), indent.c_str());
         if (!success) {
             logError() << "XML write error: " << path;
             return false;
         }
-        logVerbose() << "XML saved: " << path;
+        logVerbose() << "XML saved: " << fullPath;
         return true;
     }
 


### PR DESCRIPTION
## What
`Xml::load()` / `Xml::save()` passed the raw path straight to pugixml, so
relative paths resolved against the current working directory instead of the
data dir — inconsistent with `loadJson` / `loadTextFile`, which go through
`getDataPath()`.

In a macOS `.app` bundle (CWD = `/`) `loadXml("foo.xml")` would always miss.

## Change
Route `Xml::load()` and `Xml::save()` through `getDataPath()` (added the
`tcUtils.h` include). Absolute paths still pass through unchanged, so this is
backward-compatible for any caller already passing a resolved/absolute path.

`core/include/tc/utils/tcXml.h` — +9 −6, header-only.

## Verification
- macOS: XML round-trip test (save → load → attribute match) **PASS**, run with
  CWD set to `/tmp` — output landed in the app's `data/` dir, not the CWD,
  confirming `getDataPath` resolution.
- `tcXml.h` compiles standalone against a clean `main` checkout.
- Windows/Linux: not run on-device — relying on CI builds (the change only adds
  a call to the already-cross-platform `getDataPath`).
