### PR TITLE
fix(3d): correct EasyCam ortho/perspective clip-space z for D3D11/Metal/WebGPU

### DIFF
--- a/core/include/tc/3d/tcEasyCam.h
+++ b/core/include/tc/3d/tcEasyCam.h
@@ -68,6 +68,33 @@ public:
         } else {
             projection = Mat4::perspective(fov_, aspect, nearClip_, farClip_);
         }
+
+        // EasyCam builds its own projection Mat4 (used for both rendering and
+        // worldToScreen), bypassing sgl_ortho/sgl_perspective which normally
+        // adapt to the backend's clip-space convention. Mat4::ortho/perspective
+        // emit the GL convention (NDC z in [-1, 1]); D3D11/Metal/WebGPU expect
+        // [0, 1]. Without remapping, ortho geometry near the target plane lands
+        // in the clipped near half on D3D11 and disappears (perspective only
+        // survives because its non-linear depth keeps far geometry inside [0,1]).
+        switch (sg_query_backend()) {
+            case SG_BACKEND_D3D11:
+            case SG_BACKEND_METAL_IOS:
+            case SG_BACKEND_METAL_MACOS:
+            case SG_BACKEND_METAL_SIMULATOR:
+            case SG_BACKEND_WGPU: {
+                // Remap clip-space z from [-1, 1] to [0, 1]: z' = 0.5*z + 0.5*w.
+                const Mat4 zeroToOne(
+                    1, 0, 0,    0,
+                    0, 1, 0,    0,
+                    0, 0, 0.5f, 0.5f,
+                    0, 0, 0,    1
+                );
+                projection = zeroToOne * projection;
+                break;
+            }
+            default: break;  // GLCORE / GLES3 already use [-1, 1]
+        }
+
         // camUp is orthogonal to the view direction by construction, so lookAt
         // never degenerates (even looking straight down the world up axis).
         Mat4 view = Mat4::lookAt(eye, target_, camUp);


### PR DESCRIPTION
## Background

Rendering worked correctly on Linux (GL backends), but on Windows and macOS switching to **Ortho mode resulted in a black screen** — the geometry was being clipped away.

## Summary

`EasyCam` builds its own projection `Mat4` (used for both rendering and `worldToScreen`), bypassing `sgl_ortho`/`sgl_perspective` which normally adapt to the backend's clip-space convention. `Mat4::ortho`/`perspective` emit the **GL convention** (NDC z in `[-1, 1]`), but **D3D11/Metal/WebGPU** expect `[0, 1]`.

Without remapping, orthographic geometry near the target plane falls into the clipped near half on D3D11 and disappears (black screen). Perspective happened to survive only because its non-linear depth keeps far geometry inside `[0, 1]`.

## Fix

After building the projection matrix, query the active sokol backend and, for D3D11/Metal/WebGPU, remap clip-space z from `[-1, 1]` to `[0, 1]`:

```
z' = 0.5 * z + 0.5 * w
```

GLCORE / GLES3 already use `[-1, 1]`, so they are left untouched.

## Affected backends

| Backend | Before | After |
|---|---|---|
| GLCORE / GLES3 (Linux) | ✅ | ✅ (unchanged) |
| D3D11 (Windows) | ❌ ortho black screen | ✅ |
| Metal (iOS/macOS/Simulator) | ❌ ortho black screen | ✅ |
| WebGPU | ❌ | ✅ |

## Test plan

- [x] D3D11 (Windows) tested
- [x] Metal (macOS) tested
- [x] Confirm GL backends (Linux) are unaffected
- [ ] Check `worldToScreen` mapping stays consistent across backends