### PR TITLE
Defer saveScreenshot() so it captures the rendered frame

### DIFF
--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -1793,9 +1793,55 @@ inline void exitApp() {
 // ---------------------------------------------------------------------------
 
 
-// Capture screen to Pixels
+// Capture screen to Pixels.
+// NOTE: immediate readback — call this OUTSIDE draw() (e.g. at the end of
+// update() or from an events().afterFrame listener). During draw() nothing has
+// been rendered yet (drawing is deferred to present()), so on Linux you'd read
+// a blank framebuffer. If you just want a file of the current frame, prefer
+// saveScreenshot() which captures at the correct point automatically.
 inline bool grabScreen(Pixels& outPixels) {
     return captureWindow(outPixels);
+}
+
+namespace internal {
+    // Resolved absolute paths queued by saveScreenshot(), drained right after
+    // present() (see the afterFrame listener installed in _setup_cb).
+    inline std::vector<std::filesystem::path> pendingScreenshotPaths;
+    // Keeps the afterFrame drain subscription alive for the app's lifetime.
+    inline EventListener screenshotAfterFrameListener;
+}
+
+// Save a screenshot of the current frame to a file. Safe to call from anywhere
+// (setup/update/draw/event handlers): the actual capture is deferred to just
+// after present(), so it always grabs the fully-rendered frame — no black
+// captures on Linux when called inside draw().
+//
+// Returns true if the destination was prepared and the capture was queued;
+// false if the parent directory could not be created (e.g. no write
+// permission). The rare failure of the deferred write itself (permission/disk
+// after the directory check) is reported via logError("Screenshot").
+// Relative paths resolve against the data path. Supported formats: png/jpg/bmp.
+inline bool saveScreenshot(const std::filesystem::path& path) {
+    // Resolve relative paths up front so the deferred worker gets an absolute one.
+    std::filesystem::path resolved =
+        path.is_relative() ? std::filesystem::path(getDataPath(path.string())) : path;
+
+    // Auto-create the parent directory (mirrors VideoRecorder). This is the
+    // failure users want to catch synchronously (missing/unwritable folder).
+    std::error_code ec;
+    std::filesystem::path parent = resolved.parent_path();
+    if (!parent.empty()) {
+        std::filesystem::create_directories(parent, ec);
+        if (ec) {
+            logError("Screenshot") << "Cannot prepare destination directory: "
+                                   << parent << " (" << ec.message() << ")";
+            return false;
+        }
+    }
+
+    internal::pendingScreenshotPaths.push_back(std::move(resolved));
+    redraw();  // guarantee a present() (and thus afterFrame) even when paused
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -2010,6 +2056,21 @@ namespace internal {
         }
         #endif
 
+        // Drain deferred screenshot/MCP captures right after present(), where the
+        // swapchain is committed and we are outside any pass — the only safe
+        // readback point (see grabScreen()/saveScreenshot()).
+        internal::screenshotAfterFrameListener = events().afterFrame.listen([]() {
+            if (!internal::pendingScreenshotPaths.empty()) {
+                for (const auto& p : internal::pendingScreenshotPaths) {
+                    internal::captureWindowToFile(p);  // failures log via logError
+                }
+                internal::pendingScreenshotPaths.clear();
+            }
+            #ifndef __EMSCRIPTEN__
+            mcp::drainDeferredResponses();
+            #endif
+        });
+
         // Install the standard application menu on macOS so Cmd+Q etc. work
         // out of the box. No-op on other platforms.
         internal::installAppMenu();
@@ -2127,6 +2188,18 @@ namespace internal {
         } else {
             // EVENT_DRIVEN (0): draw only on redraw()
             shouldDraw = (redrawCount > 0);
+        }
+
+        // Force a frame when a capture is pending so present()/afterFrame runs
+        // and the deferred screenshot (or MCP get_screenshot) actually fires —
+        // otherwise a request arriving in a paused/event-driven app would never
+        // be served and a blocked MCP HTTP worker would hang.
+        if (!pendingScreenshotPaths.empty()
+            #ifndef __EMSCRIPTEN__
+            || mcp::hasDeferredResponses()
+            #endif
+        ) {
+            shouldDraw = true;
         }
 
         if (shouldDraw) {

--- a/core/include/tc/utils/tcMCP.h
+++ b/core/include/tc/utils/tcMCP.h
@@ -34,6 +34,66 @@ namespace trussc {
 namespace mcp {
 
 // ---------------------------------------------------------------------------
+// Deferred tool responses
+// ---------------------------------------------------------------------------
+// Some tools (e.g. get_screenshot) need state that only exists AFTER present()
+// — during the frame, drawing is still deferred and a readback would be blank.
+// Such a handler calls deferToolResultUntilAfterFrame(): processHttpQueue()
+// stashes the request instead of answering it, and drainDeferredResponses()
+// (invoked from an afterFrame listener) runs the producer at the safe readback
+// point and unblocks the waiting HTTP worker. All state below is touched only
+// on the main thread inside processHttpQueue()/handleToolsCall().
+
+namespace detail {
+
+struct DeferredResponse {
+    std::shared_ptr<std::promise<std::string>> response;  // unblocks the HTTP worker
+    std::function<std::string()> makeEnvelope;            // builds the JSON-RPC reply
+};
+
+struct DeferralState {
+    bool requested = false;                  // set by deferToolResultUntilAfterFrame()
+    std::function<json()> produce;           // tool content producer
+    bool hasEnvelope = false;                // set by handleToolsCall(), read by processHttpQueue()
+    std::function<std::string()> envelope;   // full JSON-RPC reply builder
+};
+inline DeferralState& deferralState() { static DeferralState s; return s; }
+
+inline std::vector<DeferredResponse>& deferredResponses() {
+    static std::vector<DeferredResponse> v;
+    return v;
+}
+
+} // namespace detail
+
+// Call inside a tool handler to defer its result until just after the next
+// present(). `produce` returns the tool's content json (same shape a normal
+// handler would return) and runs at that safe readback point.
+inline void deferToolResultUntilAfterFrame(std::function<json()> produce) {
+    detail::deferralState().requested = true;
+    detail::deferralState().produce = std::move(produce);
+}
+
+// Run all deferred tool producers and unblock their HTTP workers. Call from an
+// events().afterFrame listener (i.e. after present()).
+inline void drainDeferredResponses() {
+    auto& list = detail::deferredResponses();
+    if (list.empty()) return;
+    for (auto& d : list) {
+        std::string envelope;
+        try {
+            envelope = d.makeEnvelope();
+        } catch (const std::exception& e) {
+            envelope = std::string("{\"error\":\"deferred response failed: ") + e.what() + "\"}";
+        }
+        d.response->set_value(envelope);
+    }
+    list.clear();
+}
+
+inline bool hasDeferredResponses() { return !detail::deferredResponses().empty(); }
+
+// ---------------------------------------------------------------------------
 // Types & Interfaces
 // ---------------------------------------------------------------------------
 
@@ -191,21 +251,39 @@ private:
             return makeError(id, -32601, "Tool not found: " + name);
         }
 
-        try {
-            // Execute tool handler
-            json content = tools_[name].handler(args);
-
-            // Format result according to MCP spec
+        // Wrap a tool's content json into a full JSON-RPC result string.
+        auto formatResult = [this, id](const json& content) -> std::string {
             json result;
             if (content.is_array() && content.size() > 0 && content[0].contains("type")) {
-                 result = {{"content", content}};
+                result = {{"content", content}};
             } else {
-                 result = {{"content", {{
-                     {"type", "text"},
-                     {"text", content.dump()}
-                 }}}};
+                result = {{"content", {{
+                    {"type", "text"},
+                    {"text", content.dump()}
+                }}}};
             }
             return makeResult(id, result);
+        };
+
+        try {
+            auto& ds = detail::deferralState();
+            ds.requested = false;
+
+            // Execute tool handler (may call deferToolResultUntilAfterFrame())
+            json content = tools_[name].handler(args);
+
+            // Handler asked to produce its result after the next present().
+            if (ds.requested) {
+                auto produce = std::move(ds.produce);
+                ds.requested = false;
+                ds.hasEnvelope = true;
+                ds.envelope = [formatResult, produce]() -> std::string {
+                    return formatResult(produce());
+                };
+                return std::string();  // processHttpQueue() stashes the reply
+            }
+
+            return formatResult(content);
 
         } catch (const std::exception& e) {
             return makeError(id, -32000, std::string("Tool execution error: ") + e.what());
@@ -385,6 +463,17 @@ inline void startHttpServer(int port = 0) {
 
 // Stop HTTP server
 inline void stopHttpServer() {
+    // Unblock any HTTP workers still waiting on a deferred reply — no more frames
+    // will be presented, so their producers would never run (and a blocked
+    // worker would stall the server shutdown below).
+    {
+        auto& list = detail::deferredResponses();
+        for (auto& d : list) {
+            d.response->set_value("{\"error\":\"server shutting down\"}");
+        }
+        list.clear();
+    }
+
     auto& svr = detail::getHttpServer();
     if (svr) {
         svr->stop();
@@ -404,7 +493,17 @@ inline void stopHttpServer() {
 inline void processHttpQueue() {
     McpRequest req;
     while (detail::getHttpChannel().tryReceive(req)) {
+        auto& ds = detail::deferralState();
+        ds.hasEnvelope = false;
         std::string result = Server::instance().processMessage(req.body);
+        if (ds.hasEnvelope) {
+            // Tool deferred its reply until after present(): stash the promise
+            // and answer it from drainDeferredResponses(). The HTTP worker stays
+            // blocked on its future a few ms longer (correct, not a hang).
+            detail::deferredResponses().push_back({ req.response, std::move(ds.envelope) });
+            ds.hasEnvelope = false;
+            continue;
+        }
         if (result.empty()) {
             // Return empty JSON-RPC response for notifications
             result = "{}";

--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -72,33 +72,41 @@ inline void registerInspectionTools() {
 
     tool("get_screenshot", "Get screenshot as Base64 PNG")
         .bind(std::function<json()>([]() -> json {
-            // Capture screen to pixels
-            Pixels pixels;
-            if (!grabScreen(pixels)) {
-                return json{{"status", "error"}, {"message", "Failed to grab screen"}};
-            }
+            // Defer the actual capture+encode to just after present(): during a
+            // frame nothing has been rendered yet (drawing is deferred), so a
+            // readback here would be blank (black on Linux). The producer below
+            // runs at the afterFrame safe point and its result is what the MCP
+            // client receives.
+            mcp::deferToolResultUntilAfterFrame([]() -> json {
+                // Capture screen to pixels
+                Pixels pixels;
+                if (!grabScreen(pixels)) {
+                    return json{{"status", "error"}, {"message", "Failed to grab screen"}};
+                }
 
-            // Encode to PNG in memory
-            int pngSize = 0;
-            unsigned char* pngData = stbi_write_png_to_mem(
-                pixels.getData(), 0,
-                pixels.getWidth(), pixels.getHeight(), pixels.getChannels(),
-                &pngSize);
+                // Encode to PNG in memory
+                int pngSize = 0;
+                unsigned char* pngData = stbi_write_png_to_mem(
+                    pixels.getData(), 0,
+                    pixels.getWidth(), pixels.getHeight(), pixels.getChannels(),
+                    &pngSize);
 
-            if (!pngData) {
-                return json{{"status", "error"}, {"message", "Failed to encode PNG"}};
-            }
+                if (!pngData) {
+                    return json{{"status", "error"}, {"message", "Failed to encode PNG"}};
+                }
 
-            // Convert to Base64
-            std::string b64 = toBase64(pngData, pngSize);
+                // Convert to Base64
+                std::string b64 = toBase64(pngData, pngSize);
 
-            // Free PNG data
-            std::free(pngData);
+                // Free PNG data
+                std::free(pngData);
 
-            return json{
-                {"mimeType", "image/png"},
-                {"data", b64}
-            };
+                return json{
+                    {"mimeType", "image/png"},
+                    {"data", b64}
+                };
+            });
+            return json(nullptr);  // ignored — deferred result is sent instead
         }));
 
     tool("save_screenshot", "Save screenshot to file")

--- a/core/include/tcPlatform.h
+++ b/core/include/tcPlatform.h
@@ -168,12 +168,15 @@ bool getKeepScreenOn();
 // Returns true on success, false on failure
 bool captureWindow(Pixels& outPixels);
 
-// Capture current window and save to file
-// Returns true on success, false on failure
-// Save screenshot (uses OS window capture feature)
-// Relative paths are resolved relative to executable directory + data path
+// Internal: synchronous capture + file write (the actual worker behind the
+// public deferred saveScreenshot()). Must run at a safe readback point, i.e.
+// AFTER present() (see the afterFrame drain in TrussC.h). Callers pass an
+// already-resolved absolute path; the parent directory is assumed to exist.
+// Returns true on success, false on failure.
 // Supported formats: .png, .jpg/.jpeg, .tiff/.tif, .bmp
-bool saveScreenshot(const std::filesystem::path& path);
+namespace internal {
+bool captureWindowToFile(const std::filesystem::path& path);
+}
 
 // ---------------------------------------------------------------------------
 // System volume (0.0 - 1.0)

--- a/core/platform/android/tcPlatform_android.cpp
+++ b/core/platform/android/tcPlatform_android.cpp
@@ -256,9 +256,9 @@ bool captureWindow(Pixels& outPixels) {
     return true;
 }
 
-bool saveScreenshot(const std::filesystem::path& path) {
+bool internal::captureWindowToFile(const std::filesystem::path& path) {
     if (path.is_relative()) {
-        return saveScreenshot(getDataPath(path.string()));
+        return internal::captureWindowToFile(getDataPath(path.string()));
     }
     Pixels pixels;
     if (!captureWindow(pixels)) {

--- a/core/platform/ios/tcPlatform_ios.mm
+++ b/core/platform/ios/tcPlatform_ios.mm
@@ -171,9 +171,9 @@ bool captureWindow(Pixels& outPixels) {
     return true;
 }
 
-bool saveScreenshot(const std::filesystem::path& path) {
+bool internal::captureWindowToFile(const std::filesystem::path& path) {
     if (path.is_relative()) {
-        return saveScreenshot(getDataPath(path.string()));
+        return internal::captureWindowToFile(getDataPath(path.string()));
     }
     Pixels pixels;
     if (!captureWindow(pixels)) {

--- a/core/platform/linux/tcPlatform_linux.cpp
+++ b/core/platform/linux/tcPlatform_linux.cpp
@@ -162,9 +162,9 @@ bool captureWindow(Pixels& outPixels) {
     return true;
 }
 
-bool saveScreenshot(const std::filesystem::path& path) {
+bool internal::captureWindowToFile(const std::filesystem::path& path) {
     if (path.is_relative()) {
-        return saveScreenshot(getDataPath(path.string()));
+        return internal::captureWindowToFile(getDataPath(path.string()));
     }
     Pixels pixels;
     if (!captureWindow(pixels)) {

--- a/core/platform/mac/tcPlatform_mac.mm
+++ b/core/platform/mac/tcPlatform_mac.mm
@@ -292,10 +292,10 @@ bool captureWindow(Pixels& outPixels) {
     return true;
 }
 
-bool saveScreenshot(const std::filesystem::path& path) {
+bool internal::captureWindowToFile(const std::filesystem::path& path) {
     // Resolve relative paths
     if (path.is_relative()) {
-        return saveScreenshot(getDataPath(path.string()));
+        return internal::captureWindowToFile(getDataPath(path.string()));
     }
     // Capture to Pixels
     Pixels pixels;

--- a/core/platform/web/tcPlatform_web.cpp
+++ b/core/platform/web/tcPlatform_web.cpp
@@ -61,7 +61,7 @@ bool captureWindow(Pixels& outPixels) {
     return false;
 }
 
-bool saveScreenshot(const std::filesystem::path& path) {
+bool internal::captureWindowToFile(const std::filesystem::path& path) {
     // TODO: ダウンロードとして保存
     logWarning() << "[Screenshot] Emscripten では未実装";
     return false;

--- a/core/platform/win/tcPlatform_win.cpp
+++ b/core/platform/win/tcPlatform_win.cpp
@@ -362,9 +362,9 @@ bool captureWindow(Pixels& outPixels) {
 // ---------------------------------------------------------------------------
 // saveScreenshot - スクリーンショットをファイルに保存
 // ---------------------------------------------------------------------------
-bool saveScreenshot(const std::filesystem::path& path) {
+bool internal::captureWindowToFile(const std::filesystem::path& path) {
     if (path.is_relative()) {
-        return saveScreenshot(getDataPath(path.string()));
+        return internal::captureWindowToFile(getDataPath(path.string()));
     }
     // Capture to Pixels
     Pixels pixels;


### PR DESCRIPTION
## What
`saveScreenshot()` now captures just after `present()` instead of immediately,
so it works no matter where you call it — including inside `draw()`.

## Why
Drawing in TrussC is deferred to `present()`, so an immediate readback during
`draw()` saw an unrendered framebuffer: black on Linux, a stale frame on
macOS/Windows. The capture is now queued and written from an `afterFrame`
listener (the only safe readback point).

## Also in here
- MCP `get_screenshot` defers its response, so it returns the rendered frame too.
- The destination's parent directory is auto-created.
- `saveScreenshot()`'s `bool` now means "destination prepared & capture queued";
  rare write failures after that are logged.
- Platform workers renamed to `internal::captureWindowToFile()`.

## Tested
Capturing from inside `draw()` returns the final rendered frame on all three
desktop platforms:
- macOS — build + MCP `get_screenshot`/`save_screenshot`
- Linux — real hardware
- Windows — real hardware