### PR TITLE
feat(video): Android + iOS VideoWriter backends (mobile native recording)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -263,6 +263,7 @@ elseif(TC_PLATFORM_ANDROID)
         EGL
         log
         android
+        mediandk      # NDK MediaCodec/MediaMuxer for VideoWriter
     )
 
 elseif(TC_PLATFORM_RASPBIAN)

--- a/core/platform/android/tcVideoRecorder_android.cpp
+++ b/core/platform/android/tcVideoRecorder_android.cpp
@@ -1,32 +1,341 @@
 // =============================================================================
-// tcVideoRecorder_android.cpp - Android stub
+// tcVideoRecorder_android.cpp - Android NDK MediaCodec + MediaMuxer impl
 // =============================================================================
+// Mirrors the macOS AVAssetWriter / Windows Media Foundation / Linux GStreamer
+// backends: implements the three VideoWriter platform hooks from
+// tc/video/tcVideoRecorder.h
+//   - openPlatform()   : create an AMediaCodec encoder (H.264 / HEVC) + muxer
+//   - appendPlatform() : convert one RGBA8 (top-down) frame to NV12 and encode
+//   - closePlatform()  : flush (EOS), finalize the .mp4, release everything
 //
-// Placeholder so VideoWriter (and ScreenRecorder, which uses it) links on
-// Android. Recording is not implemented yet: openPlatform() reports the gap and
-// returns false, so callers get a clean "not supported" instead of a broken
-// file. A real backend would use the NDK media stack (AMediaCodec + AMediaMuxer,
-// API 21+, link libmediandk) and convert the RGBA8 top-down frames to YUV420 —
-// glReadPixels readback already provides the frames. Tracked as a follow-up.
+// Uses the pure-C NDK media stack (libmediandk) so the whole backend lives in
+// C++ with no JNI. Hardware encoders want YUV, so frames are converted RGBA ->
+// NV12 (COLOR_FormatYUV420SemiPlanar) on the CPU before being queued. ProRes is
+// AVFoundation-only and rejected here (no silent fallback, matching win/linux).
 // =============================================================================
 
 #if defined(__ANDROID__)
 
 #include "TrussC.h"
 
+#include <media/NdkMediaCodec.h>
+#include <media/NdkMediaMuxer.h>
+#include <media/NdkMediaFormat.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
 namespace trussc {
 
-struct VideoWriterPlatformData {};
+// Android OMX color format constant (not exposed by the NDK headers).
+static constexpr int32_t kColorFormatYUV420SemiPlanar = 21;  // NV12-style
 
-bool VideoWriter::openPlatform(const std::string&, int, int, float,
-                               const VideoRecordSettings&) {
-    logWarning("VideoWriter") << "video recording is not implemented on Android yet";
-    return false;
+// AMediaCodec dequeue sentinels / flags (stable values; NDK does not always
+// expose them as named constants across versions).
+static constexpr ssize_t  kInfoTryAgainLater        = -1;
+static constexpr ssize_t  kInfoOutputFormatChanged  = -2;
+static constexpr ssize_t  kInfoOutputBuffersChanged = -3;
+static constexpr uint32_t kFlagCodecConfig          = 2;
+static constexpr uint32_t kFlagEndOfStream          = 4;
+
+struct VideoWriterPlatformData {
+    AMediaCodec* codec = nullptr;
+    AMediaMuxer* muxer = nullptr;
+    int     fd = -1;
+    ssize_t track = -1;
+    bool    muxerStarted = false;
+    int     width = 0;
+    int     height = 0;
+    int     yStride = 0;      // encoder input row stride (>= width, e.g. 1088)
+    int     sliceHeight = 0;  // encoder input plane height (>= height)
+    bool    layoutResolved = false;  // stride/slice-height learned from capacity
+    bool    failed = false;
+    std::vector<uint8_t> nv12;  // reusable conversion scratch (stride-padded)
+};
+
+// ---------------------------------------------------------------------------
+// RGBA8 (top-down) -> NV12 (Y plane, then interleaved U,V). BT.601 limited.
+// Honors the encoder's input stride / slice-height (rows are padded), so the
+// content is not sheared on devices whose codec aligns the width (e.g. Exynos
+// pads 1080 -> 1088).
+// ---------------------------------------------------------------------------
+static void rgbaToNV12(const unsigned char* rgba, int w, int h,
+                       int yStride, int sliceHeight, uint8_t* out) {
+    uint8_t* yPlane = out;
+    uint8_t* uvPlane = out + (size_t)yStride * sliceHeight;
+    for (int j = 0; j < h; ++j) {
+        for (int i = 0; i < w; ++i) {
+            const unsigned char* p = rgba + ((size_t)j * w + i) * 4;
+            int r = p[0], g = p[1], b = p[2];
+            int y = (66 * r + 129 * g + 25 * b + 128) >> 8;
+            yPlane[(size_t)j * yStride + i] = (uint8_t)(y + 16);
+        }
+    }
+    // Chroma is subsampled 2x2: average each block for a cleaner result.
+    for (int j = 0; j < h; j += 2) {
+        for (int i = 0; i < w; i += 2) {
+            int sr = 0, sg = 0, sb = 0;
+            for (int dj = 0; dj < 2; ++dj) {
+                for (int di = 0; di < 2; ++di) {
+                    const unsigned char* p =
+                        rgba + (((size_t)(j + dj) * w) + (i + di)) * 4;
+                    sr += p[0]; sg += p[1]; sb += p[2];
+                }
+            }
+            int r = sr >> 2, g = sg >> 2, b = sb >> 2;
+            int u = (-38 * r - 74 * g + 112 * b + 128) >> 8;
+            int v = (112 * r - 94 * g - 18 * b + 128) >> 8;
+            size_t idx = (size_t)(j / 2) * yStride + i;  // 2 bytes per sample
+            uvPlane[idx + 0] = (uint8_t)(u + 128);  // U
+            uvPlane[idx + 1] = (uint8_t)(v + 128);  // V
+        }
+    }
 }
 
-bool VideoWriter::appendPlatform(const unsigned char*, double) { return false; }
+// ---------------------------------------------------------------------------
+// Drain available encoded output into the muxer. On the first FORMAT_CHANGED we
+// learn the real output format (with CSD) and start the muxer.
+// ---------------------------------------------------------------------------
+static bool drainOutput(VideoWriterPlatformData* pd, bool endOfStream) {
+    for (;;) {
+        AMediaCodecBufferInfo info;
+        ssize_t idx = AMediaCodec_dequeueOutputBuffer(
+            pd->codec, &info, endOfStream ? 10000 : 0);
 
-void VideoWriter::closePlatform() {}
+        if (idx == kInfoTryAgainLater) {
+            if (!endOfStream) return true;   // nothing pending right now
+            continue;                        // EOS: keep waiting for the tail
+        }
+        if (idx == kInfoOutputFormatChanged) {
+            AMediaFormat* fmt = AMediaCodec_getOutputFormat(pd->codec);
+            pd->track = AMediaMuxer_addTrack(pd->muxer, fmt);
+            AMediaFormat_delete(fmt);
+            if (pd->track < 0) {
+                logError("VideoWriter") << "muxer addTrack failed";
+                pd->failed = true;
+                return false;
+            }
+            if (AMediaMuxer_start(pd->muxer) != AMEDIA_OK) {
+                logError("VideoWriter") << "muxer start failed";
+                pd->failed = true;
+                return false;
+            }
+            pd->muxerStarted = true;
+            continue;
+        }
+        if (idx == kInfoOutputBuffersChanged) continue;  // deprecated, ignore
+        if (idx < 0) continue;
+
+        size_t outSize = 0;
+        uint8_t* buf = AMediaCodec_getOutputBuffer(pd->codec, idx, &outSize);
+
+        // Codec-config (SPS/PPS) is already carried in the output format's CSD.
+        if (info.flags & kFlagCodecConfig) info.size = 0;
+
+        if (info.size > 0 && pd->muxerStarted && buf) {
+            AMediaMuxer_writeSampleData(pd->muxer, pd->track, buf, &info);
+        }
+        AMediaCodec_releaseOutputBuffer(pd->codec, idx, false);
+
+        if (info.flags & kFlagEndOfStream) return true;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// openPlatform
+// ---------------------------------------------------------------------------
+bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
+                               float fps, const VideoRecordSettings& settings) {
+    const char* mime = nullptr;
+    switch (settings.codec) {
+        case VideoCodec::H264: mime = "video/avc";  break;
+        case VideoCodec::HEVC: mime = "video/hevc"; break;
+        case VideoCodec::ProRes422:
+        case VideoCodec::ProRes4444:
+            logError("VideoWriter")
+                << "ProRes is not available on Android (use H264 or HEVC)";
+            return false;
+    }
+
+    AMediaCodec* codec = AMediaCodec_createEncoderByType(mime);
+    if (!codec) {
+        logError("VideoWriter") << "no encoder for " << mime;
+        return false;
+    }
+
+    double rate = (fps > 0) ? fps : 30.0;
+    int bitrate = (settings.bitrate > 0)
+                      ? settings.bitrate
+                      : (int)((double)w * h * rate * 0.1);
+    int iFrameSec = (settings.keyframeInterval > 0)
+                        ? (int)((settings.keyframeInterval / rate) + 0.5)
+                        : 1;
+    if (iFrameSec < 1) iFrameSec = 1;
+
+    AMediaFormat* fmt = AMediaFormat_new();
+    AMediaFormat_setString(fmt, AMEDIAFORMAT_KEY_MIME, mime);
+    AMediaFormat_setInt32(fmt, AMEDIAFORMAT_KEY_WIDTH, w);
+    AMediaFormat_setInt32(fmt, AMEDIAFORMAT_KEY_HEIGHT, h);
+    AMediaFormat_setInt32(fmt, AMEDIAFORMAT_KEY_COLOR_FORMAT,
+                          kColorFormatYUV420SemiPlanar);
+    AMediaFormat_setInt32(fmt, AMEDIAFORMAT_KEY_BIT_RATE, bitrate);
+    AMediaFormat_setFloat(fmt, AMEDIAFORMAT_KEY_FRAME_RATE, (float)rate);
+    AMediaFormat_setInt32(fmt, AMEDIAFORMAT_KEY_I_FRAME_INTERVAL, iFrameSec);
+
+    media_status_t cfg = AMediaCodec_configure(
+        codec, fmt, nullptr, nullptr, AMEDIACODEC_CONFIGURE_FLAG_ENCODE);
+    AMediaFormat_delete(fmt);
+    if (cfg != AMEDIA_OK) {
+        logError("VideoWriter") << "encoder configure failed (" << mime << ")";
+        AMediaCodec_delete(codec);
+        return false;
+    }
+    if (AMediaCodec_start(codec) != AMEDIA_OK) {
+        logError("VideoWriter") << "encoder start failed";
+        AMediaCodec_delete(codec);
+        return false;
+    }
+
+    // The encoder reads the ByteBuffer with its own row stride / plane height
+    // (e.g. Tensor/Exynos aligns 1080 -> 1088); writing tightly packed shears
+    // the image. The exact layout is resolved from the first input buffer's
+    // capacity in appendPlatform (getInputFormat would report it but is API 28+;
+    // the capacity route stays on the minSdk-26 baseline). Start with a 16-byte
+    // aligned guess.
+    int32_t yStride = (w + 15) & ~15;
+    int32_t sliceHeight = h;
+
+    int fd = ::open(fullPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        logError("VideoWriter") << "cannot open output file " << fullPath;
+        AMediaCodec_stop(codec);
+        AMediaCodec_delete(codec);
+        return false;
+    }
+    AMediaMuxer* muxer = AMediaMuxer_new(fd, AMEDIAMUXER_OUTPUT_FORMAT_MPEG_4);
+    if (!muxer) {
+        logError("VideoWriter") << "muxer create failed";
+        ::close(fd);
+        AMediaCodec_stop(codec);
+        AMediaCodec_delete(codec);
+        return false;
+    }
+
+    auto* pd = new VideoWriterPlatformData();
+    pd->codec = codec;
+    pd->muxer = muxer;
+    pd->fd = fd;
+    pd->width = w;
+    pd->height = h;
+    pd->yStride = yStride;
+    pd->sliceHeight = sliceHeight;
+    pd->nv12.resize((size_t)yStride * sliceHeight * 3 / 2);
+    platform_ = pd;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// appendPlatform
+// ---------------------------------------------------------------------------
+bool VideoWriter::appendPlatform(const unsigned char* rgba, double timeSec) {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd || !pd->codec || pd->failed) return false;
+
+    // Wait (briefly) for an input buffer — offline writers can outrun the codec.
+    ssize_t inIdx = -1;
+    for (int spins = 0; spins < 1000; ++spins) {
+        inIdx = AMediaCodec_dequeueInputBuffer(pd->codec, 10000);
+        if (inIdx >= 0) break;
+        if (!drainOutput(pd, false)) return false;   // make room
+    }
+    if (inIdx < 0) {
+        logError("VideoWriter") << "no encoder input buffer (timeout)";
+        pd->failed = true;
+        return false;
+    }
+
+    size_t cap = 0;
+    uint8_t* in = AMediaCodec_getInputBuffer(pd->codec, inIdx, &cap);
+    if (!in) {
+        logError("VideoWriter") << "null input buffer";
+        pd->failed = true;
+        return false;
+    }
+
+    // Resolve the encoder's real input row stride once, from the buffer
+    // capacity: cap ~= yStride * sliceHeight * 3/2. Assume the height is not
+    // padded (sliceHeight == height, true on Tensor/Exynos) and round to the
+    // nearest stride. The capacity can be a few bytes short of the full padded
+    // plane, so we never require an exact size — we queue min(need, cap).
+    if (!pd->layoutResolved) {
+        int est = (int)std::llround((double)cap / (1.5 * (double)pd->height));
+        int ys = (est >= pd->width) ? est : ((pd->width + 15) & ~15);
+        ys = (ys + 1) & ~1;  // keep even
+        pd->yStride = ys;
+        pd->sliceHeight = pd->height;
+        pd->nv12.resize((size_t)ys * pd->height * 3 / 2);
+        pd->layoutResolved = true;
+        logNotice("VideoWriter")
+            << "encoder input stride=" << ys << " slice-height=" << pd->height
+            << " (cap=" << cap << ")";
+    }
+
+    rgbaToNV12(rgba, pd->width, pd->height, pd->yStride, pd->sliceHeight,
+               pd->nv12.data());
+    size_t qsize = pd->nv12.size() < cap ? pd->nv12.size() : cap;
+    memcpy(in, pd->nv12.data(), qsize);
+
+    int64_t ptsUs = (int64_t)(timeSec * 1e6);
+    if (AMediaCodec_queueInputBuffer(pd->codec, inIdx, 0, qsize, ptsUs, 0)
+            != AMEDIA_OK) {
+        logError("VideoWriter") << "queueInputBuffer failed";
+        pd->failed = true;
+        return false;
+    }
+
+    return drainOutput(pd, false);
+}
+
+// ---------------------------------------------------------------------------
+// closePlatform - signal EOS, flush the tail, finalize and release.
+// ---------------------------------------------------------------------------
+void VideoWriter::closePlatform() {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd) return;
+
+    if (pd->codec && !pd->failed) {
+        // Queue an end-of-stream marker on an empty input buffer.
+        ssize_t inIdx = -1;
+        for (int spins = 0; spins < 1000 && inIdx < 0; ++spins) {
+            inIdx = AMediaCodec_dequeueInputBuffer(pd->codec, 10000);
+            if (inIdx < 0) drainOutput(pd, false);
+        }
+        if (inIdx >= 0) {
+            AMediaCodec_queueInputBuffer(pd->codec, inIdx, 0, 0, 0,
+                                         kFlagEndOfStream);
+            drainOutput(pd, true);
+        }
+    }
+
+    if (pd->muxer) {
+        if (pd->muxerStarted) AMediaMuxer_stop(pd->muxer);
+        AMediaMuxer_delete(pd->muxer);
+    }
+    if (pd->codec) {
+        AMediaCodec_stop(pd->codec);
+        AMediaCodec_delete(pd->codec);
+    }
+    if (pd->fd >= 0) ::close(pd->fd);
+
+    delete pd;
+    platform_ = nullptr;
+}
 
 } // namespace trussc
 

--- a/core/platform/ios/tcPlatform_ios.mm
+++ b/core/platform/ios/tcPlatform_ios.mm
@@ -141,31 +141,80 @@ bool captureWindow(Pixels& outPixels) {
         return false;
     }
 
-    id<MTLTexture> texture = drawable.texture;
-    if (!texture) {
+    id<MTLTexture> srcTexture = drawable.texture;
+    if (!srcTexture) {
         logError() << "[Screenshot] Failed to get Metal texture";
         return false;
     }
 
-    NSUInteger width = texture.width;
-    NSUInteger height = texture.height;
+    NSUInteger width = srcTexture.width;
+    NSUInteger height = srcTexture.height;
+    MTLPixelFormat pixelFormat = srcTexture.pixelFormat;
 
-    outPixels.allocate((int)width, (int)height, 4);
+    // sokol sets framebufferOnly=YES on the CAMetalLayer, so reading the
+    // drawable texture directly asserts under Metal validation. Blit into a
+    // shared-storage staging texture, then read that (mirrors the mac path).
+    id<MTLDevice> device = srcTexture.device;
+    MTLTextureDescriptor* desc =
+        [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
+                                                           width:width
+                                                          height:height
+                                                       mipmapped:NO];
+    desc.usage = MTLTextureUsageShaderRead;
+    desc.storageMode = MTLStorageModeShared;
+    id<MTLTexture> stagingTexture = [device newTextureWithDescriptor:desc];
+    if (!stagingTexture) {
+        logError() << "[Screenshot] failed to create staging texture";
+        return false;
+    }
+
+    static id<MTLCommandQueue> s_blitQueue = nil;
+    if (!s_blitQueue || s_blitQueue.device != device) {
+        s_blitQueue = [device newCommandQueue];
+    }
+    id<MTLCommandBuffer>      cmdBuf  = [s_blitQueue commandBuffer];
+    id<MTLBlitCommandEncoder> blitEnc = [cmdBuf blitCommandEncoder];
+    [blitEnc copyFromTexture:srcTexture
+                 sourceSlice:0 sourceLevel:0
+                sourceOrigin:MTLOriginMake(0, 0, 0)
+                  sourceSize:MTLSizeMake(width, height, 1)
+                   toTexture:stagingTexture
+            destinationSlice:0 destinationLevel:0
+           destinationOrigin:MTLOriginMake(0, 0, 0)];
+    [blitEnc endEncoding];
+    [cmdBuf commit];
+    [cmdBuf waitUntilCompleted];
 
     MTLRegion region = MTLRegionMake2D(0, 0, width, height);
     NSUInteger bytesPerRow = width * 4;
+    std::vector<uint8_t> rawData(bytesPerRow * height);
+    [stagingTexture getBytes:rawData.data()
+                 bytesPerRow:bytesPerRow
+                  fromRegion:region
+                 mipmapLevel:0];
 
-    [texture getBytes:outPixels.getData()
-          bytesPerRow:bytesPerRow
-           fromRegion:region
-          mipmapLevel:0];
+    outPixels.allocate((int)width, (int)height, 4);
+    unsigned char* dst = outPixels.getData();
 
-    // BGRA -> RGBA conversion
-    unsigned char* data = outPixels.getData();
-    for (NSUInteger i = 0; i < width * height; i++) {
-        unsigned char temp = data[i * 4 + 0];
-        data[i * 4 + 0] = data[i * 4 + 2];
-        data[i * 4 + 2] = temp;
+    if (pixelFormat == MTLPixelFormatRGB10A2Unorm) {
+        // Modern iPhones use a 10-bit wide-color drawable. Unpack to RGBA8.
+        // Layout: [A:2 (31-30)][B:10 (29-20)][G:10 (19-10)][R:10 (9-0)]
+        const uint32_t* src = (const uint32_t*)rawData.data();
+        for (NSUInteger i = 0; i < width * height; i++) {
+            uint32_t pixel = src[i];
+            dst[i * 4 + 0] = (uint8_t)(((pixel >>  0) & 0x3FF) >> 2);  // R
+            dst[i * 4 + 1] = (uint8_t)(((pixel >> 10) & 0x3FF) >> 2);  // G
+            dst[i * 4 + 2] = (uint8_t)(((pixel >> 20) & 0x3FF) >> 2);  // B
+            dst[i * 4 + 3] = (uint8_t)(((pixel >> 30) & 0x3) * 85);    // A
+        }
+    } else {
+        // BGRA8 fallback -> RGBA8
+        memcpy(dst, rawData.data(), bytesPerRow * height);
+        for (NSUInteger i = 0; i < width * height; i++) {
+            unsigned char temp = dst[i * 4 + 0];
+            dst[i * 4 + 0] = dst[i * 4 + 2];
+            dst[i * 4 + 2] = temp;
+        }
     }
 
     return true;

--- a/core/platform/ios/tcVideoRecorder_ios.mm
+++ b/core/platform/ios/tcVideoRecorder_ios.mm
@@ -1,34 +1,245 @@
 // =============================================================================
-// tcVideoRecorder_ios.mm - iOS stub
+// tcVideoRecorder_ios.mm - iOS AVFoundation (AVAssetWriter) implementation
 // =============================================================================
-//
-// Placeholder so VideoWriter (and ScreenRecorder) links on iOS. Recording is
-// not implemented yet: openPlatform() returns false.
-//
-// A real backend is straightforward: AVAssetWriter works on iOS just like the
-// macOS path (tcVideoRecorder_mac.mm), so this can largely reuse that code once
-// an iOS device is available to verify on. Tracked as a follow-up.
+// Implements the VideoWriter platform hooks from tc/video/tcVideoRecorder.h.
+// AVAssetWriter is shared between macOS and iOS, so this mirrors
+// platform/mac/tcVideoRecorder_mac.mm (kept as a separate file to match the
+// per-platform layout of the video player). H.264 / HEVC encode in hardware;
+// ProRes is accepted only where the OS provides it (canAddInput gates it).
 // =============================================================================
 
 #if defined(__APPLE__)
 #import <TargetConditionals.h>
 #if TARGET_OS_IOS
 
+#import <AVFoundation/AVFoundation.h>
+#import <CoreVideo/CoreVideo.h>
+#import <CoreMedia/CoreMedia.h>
+
 #include "TrussC.h"
+#include <cmath>
 
 namespace trussc {
 
-struct VideoWriterPlatformData {};
+struct VideoWriterPlatformData {
+    AVAssetWriter* writer = nil;
+    AVAssetWriterInput* input = nil;
+    AVAssetWriterInputPixelBufferAdaptor* adaptor = nil;
+    int width = 0;
+    int height = 0;
+    double fps = 30.0;
+    int64_t frameIndex = 0;
+    bool failed = false;
+};
 
-bool VideoWriter::openPlatform(const std::string&, int, int, float,
-                               const VideoRecordSettings&) {
-    logWarning("VideoWriter") << "video recording is not implemented on iOS yet";
-    return false;
+bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
+                               float fps, const VideoRecordSettings& settings) {
+    @autoreleasepool {
+        NSString* codecKey = AVVideoCodecTypeH264;
+        AVFileType fileType = AVFileTypeMPEG4;
+        bool useBitrate = true;
+        switch (settings.codec) {
+            case VideoCodec::H264:
+                codecKey = AVVideoCodecTypeH264; break;
+            case VideoCodec::HEVC:
+                codecKey = AVVideoCodecTypeHEVC; break;
+            case VideoCodec::ProRes422:
+                codecKey = AVVideoCodecTypeAppleProRes422;
+                fileType = AVFileTypeQuickTimeMovie; useBitrate = false; break;
+            case VideoCodec::ProRes4444:
+                codecKey = AVVideoCodecTypeAppleProRes4444;
+                fileType = AVFileTypeQuickTimeMovie; useBitrate = false; break;
+        }
+        if (fileType == AVFileTypeQuickTimeMovie &&
+            fullPath.size() >= 4 &&
+            fullPath.compare(fullPath.size() - 4, 4, ".mov") != 0) {
+            logWarning("VideoWriter")
+                << "ProRes is written as QuickTime; prefer a .mov path ("
+                << fullPath << ")";
+        }
+
+        NSString* nsPath = [NSString stringWithUTF8String:fullPath.c_str()];
+        // The app bundle is read-only on iOS, and getDataPath() resolves there.
+        // Redirect bundle-relative outputs to the writable Documents directory
+        // so startRecording("clip.mp4") just works on device.
+        NSString* bundlePath = [[NSBundle mainBundle] bundlePath];
+        if ([nsPath hasPrefix:bundlePath]) {
+            NSString* docs = [NSSearchPathForDirectoriesInDomains(
+                NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+            if (docs) {
+                nsPath = [docs stringByAppendingPathComponent:[nsPath lastPathComponent]];
+                logNotice("VideoWriter")
+                    << "iOS: writing to Documents -> " << nsPath.UTF8String;
+            }
+        }
+        NSURL* url = [NSURL fileURLWithPath:nsPath];
+        [[NSFileManager defaultManager] removeItemAtURL:url error:nil];
+
+        NSError* err = nil;
+        AVAssetWriter* writer =
+            [[AVAssetWriter alloc] initWithURL:url fileType:fileType error:&err];
+        if (!writer) {
+            logError("VideoWriter")
+                << "AVAssetWriter init failed: "
+                << (err ? err.localizedDescription.UTF8String : "unknown");
+            return false;
+        }
+
+        NSMutableDictionary* outSettings = [@{
+            AVVideoCodecKey: codecKey,
+            AVVideoWidthKey: @(w),
+            AVVideoHeightKey: @(h),
+        } mutableCopy];
+
+        if (useBitrate) {
+            int br = (settings.bitrate > 0)
+                         ? settings.bitrate
+                         : (int)((double)w * h * (fps > 0 ? fps : 30.0) * 0.1);
+            NSMutableDictionary* compression =
+                [@{ AVVideoAverageBitRateKey: @(br) } mutableCopy];
+            if (settings.keyframeInterval > 0) {
+                compression[AVVideoMaxKeyFrameIntervalKey] = @(settings.keyframeInterval);
+            }
+            outSettings[AVVideoCompressionPropertiesKey] = compression;
+        }
+
+        AVAssetWriterInput* input =
+            [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
+                                               outputSettings:outSettings];
+        input.expectsMediaDataInRealTime = NO;
+
+        NSDictionary* sourceAttrs = @{
+            (NSString*)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
+            (NSString*)kCVPixelBufferWidthKey: @(w),
+            (NSString*)kCVPixelBufferHeightKey: @(h),
+            (NSString*)kCVPixelBufferIOSurfacePropertiesKey: @{},
+        };
+        AVAssetWriterInputPixelBufferAdaptor* adaptor =
+            [AVAssetWriterInputPixelBufferAdaptor
+                assetWriterInputPixelBufferAdaptorWithAssetWriterInput:input
+                                            sourcePixelBufferAttributes:sourceAttrs];
+
+        if (![writer canAddInput:input]) {
+            logError("VideoWriter") << "writer cannot add video input (codec "
+                                    << videoCodecName(settings.codec) << ")";
+            return false;
+        }
+        [writer addInput:input];
+
+        if (![writer startWriting]) {
+            logError("VideoWriter")
+                << "startWriting failed: "
+                << (writer.error ? writer.error.localizedDescription.UTF8String
+                                 : "unknown");
+            return false;
+        }
+        [writer startSessionAtSourceTime:kCMTimeZero];
+
+        auto* pd = new VideoWriterPlatformData();
+        pd->writer = writer;
+        pd->input = input;
+        pd->adaptor = adaptor;
+        pd->width = w;
+        pd->height = h;
+        pd->fps = (fps > 0) ? fps : 30.0;
+        platform_ = pd;
+        return true;
+    }
 }
 
-bool VideoWriter::appendPlatform(const unsigned char*, double) { return false; }
+bool VideoWriter::appendPlatform(const unsigned char* rgba, double timeSec) {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd || !pd->writer || pd->failed) return false;
 
-void VideoWriter::closePlatform() {}
+    @autoreleasepool {
+        int spins = 0;
+        while (!pd->input.readyForMoreMediaData && spins < 5000) {
+            [NSThread sleepForTimeInterval:0.001];
+            ++spins;
+        }
+        if (!pd->input.readyForMoreMediaData) {
+            logError("VideoWriter") << "input not ready (timeout)";
+            pd->failed = true;
+            return false;
+        }
+
+        CVPixelBufferRef pb = NULL;
+        CVPixelBufferPoolRef pool = pd->adaptor.pixelBufferPool;
+        if (pool) {
+            CVPixelBufferPoolCreatePixelBuffer(NULL, pool, &pb);
+        }
+        if (!pb) {
+            NSDictionary* attrs = @{
+                (NSString*)kCVPixelBufferCGImageCompatibilityKey: @YES,
+                (NSString*)kCVPixelBufferCGBitmapContextCompatibilityKey: @YES,
+                (NSString*)kCVPixelBufferIOSurfacePropertiesKey: @{},
+            };
+            CVPixelBufferCreate(kCFAllocatorDefault, pd->width, pd->height,
+                                kCVPixelFormatType_32BGRA,
+                                (__bridge CFDictionaryRef)attrs, &pb);
+        }
+        if (!pb) {
+            logError("VideoWriter") << "could not create pixel buffer";
+            pd->failed = true;
+            return false;
+        }
+
+        CVPixelBufferLockBaseAddress(pb, 0);
+        uint8_t* dst = (uint8_t*)CVPixelBufferGetBaseAddress(pb);
+        size_t dstStride = CVPixelBufferGetBytesPerRow(pb);
+        const int w = pd->width;
+        const int h = pd->height;
+        for (int y = 0; y < h; ++y) {
+            const unsigned char* srow = rgba + (size_t)y * w * 4;
+            uint8_t* drow = dst + (size_t)y * dstStride;
+            for (int x = 0; x < w; ++x) {
+                drow[x * 4 + 0] = srow[x * 4 + 2];  // B
+                drow[x * 4 + 1] = srow[x * 4 + 1];  // G
+                drow[x * 4 + 2] = srow[x * 4 + 0];  // R
+                drow[x * 4 + 3] = srow[x * 4 + 3];  // A
+            }
+        }
+        CVPixelBufferUnlockBaseAddress(pb, 0);
+
+        CMTime t = CMTimeMakeWithSeconds(timeSec, 600);
+        BOOL ok = [pd->adaptor appendPixelBuffer:pb withPresentationTime:t];
+        CVPixelBufferRelease(pb);
+
+        if (!ok) {
+            logError("VideoWriter")
+                << "appendPixelBuffer failed: "
+                << (pd->writer.error
+                        ? pd->writer.error.localizedDescription.UTF8String
+                        : "unknown");
+            pd->failed = true;
+            return false;
+        }
+        ++pd->frameIndex;
+        return true;
+    }
+}
+
+void VideoWriter::closePlatform() {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd) return;
+
+    @autoreleasepool {
+        if (pd->writer && pd->writer.status == AVAssetWriterStatusWriting) {
+            [pd->input markAsFinished];
+            dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+            [pd->writer finishWritingWithCompletionHandler:^{
+                dispatch_semaphore_signal(sem);
+            }];
+            dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+        }
+        pd->writer = nil;
+        pd->input = nil;
+        pd->adaptor = nil;
+    }
+
+    delete pd;
+    platform_ = nullptr;
+}
 
 } // namespace trussc
 

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -3012,6 +3012,17 @@ categories:
         sketch: false
         snippet: "grabScreen(${1:pixels})"
 
+      - name: saveScreenshot
+        return: "bool"
+        signatures:
+          - params: "const std::filesystem::path& path"
+            params_simple: "path"
+        description: "Save a screenshot of the rendered frame (png/jpg/bmp). Safe to call from anywhere; capture is deferred to after present(). Returns true when the destination was prepared and the capture queued (parent dir created/writable), not that the file is already written."
+        description_ja: "描画済みフレームのスクショを保存（png/jpg/bmp）。どこから呼んでもよく、キャプチャはpresent()後に遅延実行。戻り値trueは「保存先を準備しキューに積めた（親フォルダ生成・書き込み可）」の意味で、ファイル書き込み完了ではない"
+        description_ko: "렌더링된 프레임의 스크린샷 저장(png/jpg/bmp). 어디서든 호출 가능하며 캡처는 present() 이후로 지연. 반환값 true는 '대상 준비 및 캡처 큐 등록 성공(상위 폴더 생성·쓰기 가능)'을 의미하며 파일 기록 완료가 아님"
+        sketch: false
+        snippet: "saveScreenshot(${1:\"shot.png\"})"
+
       - name: startRecording
         return: "bool"
         signatures:
@@ -3044,6 +3055,28 @@ categories:
         description_ko: "녹화 중인지 확인"
         sketch: false
         snippet: "isRecording()"
+
+      - name: recordingFrameCount
+        return: "int"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Number of frames captured so far in the current recording"
+        description_ja: "現在の録画でこれまでにキャプチャしたフレーム数"
+        description_ko: "현재 녹화에서 지금까지 캡처한 프레임 수"
+        sketch: false
+        snippet: "recordingFrameCount()"
+
+      - name: recordingPath
+        return: "const string&"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Output file path of the current recording"
+        description_ja: "現在の録画の出力ファイルパス"
+        description_ko: "현재 녹화의 출력 파일 경로"
+        sketch: false
+        snippet: "recordingPath()"
 
       - name: isFullscreen
         return: "bool"
@@ -8093,6 +8126,32 @@ constants:
     description_ja: "中央マウスボタン"
     description_ko: "가운데 마우스 버튼"
     sketch: true
+
+  # VideoCodec constants (for VideoRecordSettings.codec)
+  - name: "VideoCodec::H264"
+    value: "0"
+    description: "H.264 / AVC — broad compatibility (default)"
+    description_ja: "H.264 / AVC — 互換性が広い（デフォルト）"
+    description_ko: "H.264 / AVC — 폭넓은 호환성 (기본값)"
+    sketch: false
+  - name: "VideoCodec::HEVC"
+    value: "1"
+    description: "H.265 / HEVC — smaller files, hardware-encoded"
+    description_ja: "H.265 / HEVC — ファイルが小さい、ハードウェアエンコード"
+    description_ko: "H.265 / HEVC — 더 작은 파일, 하드웨어 인코딩"
+    sketch: false
+  - name: "VideoCodec::ProRes422"
+    value: "2"
+    description: "Apple ProRes 422 — editing-grade, macOS/iOS only (.mov)"
+    description_ja: "Apple ProRes 422 — 編集向け高品質、macOS/iOSのみ（.mov）"
+    description_ko: "Apple ProRes 422 — 편집용 고품질, macOS/iOS 전용 (.mov)"
+    sketch: false
+  - name: "VideoCodec::ProRes4444"
+    value: "3"
+    description: "Apple ProRes 4444 — highest quality + alpha, macOS/iOS only (.mov)"
+    description_ja: "Apple ProRes 4444 — 最高品質＋アルファ、macOS/iOSのみ（.mov）"
+    description_ko: "Apple ProRes 4444 — 최고 품질 + 알파, macOS/iOS 전용 (.mov)"
+    sketch: false
 
 # ==========================================================================
 # Keywords (for TrussSketch syntax highlighting - AngelScript)


### PR DESCRIPTION
## Summary
Native video recording on **Android** and **iOS**, completing the mobile side of the VideoWriter / ScreenRecorder feature (mac/win/linux already landed). Both verified on real hardware.

## Android (NDK MediaCodec + MediaMuxer)
- H.264 / HEVC via the hardware encoder, muxed to `.mp4`. No JNI — pure NDK media stack (`libmediandk`).
- RGBA8 → NV12 conversion; input row stride resolved from the encoder's buffer capacity (Tensor/Exynos aligns 1080→1088) so frames aren't sheared.
- ProRes rejected (AVFoundation-only), matching win/linux.

## iOS (AVAssetWriter)
- Ports the mac AVFoundation backend (H.264 / HEVC; ProRes gated by `canAddInput`).
- The app bundle is read-only on iOS → bundle-relative outputs redirect to `Documents`, so `startRecording("clip.mp4")` works on device.
- **Also fixes `captureWindow()` on iOS** (shared by `grabScreen`/ScreenRecorder, `saveScreenshot`, and MCP `get_screenshot`): modern iPhones use a 10-bit `RGB10A2Unorm` drawable that was read as BGRA8, so captures came out green. Now blits to a staging texture and unpacks RGB10A2→RGBA8 (BGRA8 fallback), mirroring the mac path — **this fixes iOS screenshots too**.

## Docs
Fills recording-API gaps in `api-definition.yaml`: `VideoCodec` constants, `recordingFrameCount()` / `recordingPath()`, and a `saveScreenshot()` entry documenting its current semantics (the bool means *destination prepared & capture queued*, since the capture is deferred to after `present()`). Regenerating trussc.org / TrussSketch docs is a separate-repo follow-up.

## Verification
- **Android**: recorded on a Pixel/Tensor device, pulled the `.mp4`, confirmed decoded frames match the on-screen render (colors, geometry, no shear).
- **iOS**: recorded on iPhone 16 (iOS 26.5), pulled the `.mp4`, confirmed decoded frames match (correct colors after the readback fix, geometry).

## Not included
- Web/wasm recording stays a stub: the browser has no C++-reachable native encoder (WebCodecs is JS) and WebGPU can't read back pixels from C++ — a separate JS-based effort.
