### PR TITLE
fix: screen recorder — correct capture + clean target-fps decimation

### DIFF
--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -1766,15 +1766,30 @@ inline void exitApp() {
 
 namespace internal {
 #if defined(__APPLE__)
+    // A completed GPU readback the consumer copies into ITS OWN destination,
+    // with a single getBytes and no intermediate buffer. Lets the screen recorder
+    // read straight into the encoder's CVPixelBuffer (BGRA, no swap) and
+    // screenshots read into a Pixels buffer (RGBA). `staging` is the bridged
+    // id<MTLTexture>, valid only for the duration of the completion callback.
+    struct CaptureReadback {
+        void* staging = nullptr;   // id<MTLTexture> (bridged, not retained here)
+        int   width = 0;
+        int   height = 0;
+        bool  isRGB10A2 = false;
+        // Copy the readback into dst (dstStride bytes per row). wantRGBA=false
+        // keeps native BGRA8 order (matches the encoder's CVPixelBuffer);
+        // wantRGBA=true yields RGBA8 (for Pixels / screenshots).
+        void readInto(unsigned char* dst, int dstStride, bool wantRGBA) const;
+    };
+
     // macOS: asynchronous window capture. Issues the GPU readback blit and
-    // returns immediately; `completion` is invoked later (on a Metal background
-    // thread) with RGBA8 pixels (tightly packed, top-down) once the readback
-    // finishes. Lets ScreenRecorder capture every frame without the per-frame
+    // returns immediately; `completion` runs later (on a Metal background thread)
+    // with a CaptureReadback once the GPU finishes — no per-frame
     // waitUntilCompleted stall. Returns false if there is no frame to capture.
     // (Implemented in platform/mac/tcPlatform_mac.mm; captureWindow() is just
     // this plus an inline wait.)
     bool captureWindowAsync(
-        const std::function<void(const unsigned char* rgba, int w, int h)>& completion);
+        const std::function<void(const CaptureReadback&)>& completion);
 #endif
 }
 

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -27,6 +27,7 @@
 #include <vector>
 #include <chrono>
 #include <atomic>
+#include <functional>
 #include <fstream>
 #include <unordered_set>
 
@@ -1763,6 +1764,19 @@ inline void exitApp() {
 // Screenshot
 // ---------------------------------------------------------------------------
 
+namespace internal {
+#if defined(__APPLE__)
+    // macOS: asynchronous window capture. Issues the GPU readback blit and
+    // returns immediately; `completion` is invoked later (on a Metal background
+    // thread) with RGBA8 pixels (tightly packed, top-down) once the readback
+    // finishes. Lets ScreenRecorder capture every frame without the per-frame
+    // waitUntilCompleted stall. Returns false if there is no frame to capture.
+    // (Implemented in platform/mac/tcPlatform_mac.mm; captureWindow() is just
+    // this plus an inline wait.)
+    bool captureWindowAsync(
+        const std::function<void(const unsigned char* rgba, int w, int h)>& completion);
+#endif
+}
 
 // Capture screen to Pixels.
 // NOTE: immediate readback — call this OUTSIDE draw() (e.g. at the end of

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -315,6 +315,15 @@ namespace internal {
     // Saved clear color for resume after FBO suspend (set by clear())
     inline sg_color swapchainClearValue = { 0.0f, 0.0f, 0.0f, 1.0f };
 
+    // The Metal CAMetalDrawable acquired for THIS frame's swapchain pass. sokol's
+    // sapp_get_swapchain() advances to the next drawable on every call (it must be
+    // called exactly once per frame), so end-of-frame capture must NOT call it
+    // again — it would grab a different, unrendered drawable. Instead the swapchain
+    // pass setup records the drawable it actually rendered into here, and
+    // captureWindow() reads back from this one. (Metal-only; on D3D11/GL the
+    // swapchain handle is a stable backbuffer/FBO so this stays null and is unused.)
+    inline const void* lastSwapchainDrawable = nullptr;
+
     // inFboPass is declared earlier (before tcRenderContext.h)
 
     // FBO clearColor function pointer (set in tcFbo.h)

--- a/core/include/tc/app/tcGlobal.cpp
+++ b/core/include/tc/app/tcGlobal.cpp
@@ -230,6 +230,9 @@ void ensureSwapchainPass() {
         pass.action.depth.load_action = SG_LOADACTION_CLEAR;
         pass.action.depth.clear_value = 1.0f;
         pass.swapchain = sglue_swapchain();
+        // Record the drawable we render into so end-of-frame capture reads back
+        // THIS one (sapp_get_swapchain() advances the Metal drawable per call).
+        internal::lastSwapchainDrawable = pass.swapchain.metal.current_drawable;
         sg_begin_pass(&pass);
         internal::inSwapchainPass = true;
     }
@@ -280,6 +283,7 @@ void resumeSwapchainPass() {
         pass.action.depth.load_action = SG_LOADACTION_CLEAR;
         pass.action.depth.clear_value = 1.0f;
         pass.swapchain = sglue_swapchain();
+        internal::lastSwapchainDrawable = pass.swapchain.metal.current_drawable;
         sg_begin_pass(&pass);
         internal::inSwapchainPass = true;
     }

--- a/core/include/tc/video/tcVideoRecorder.h
+++ b/core/include/tc/video/tcVideoRecorder.h
@@ -328,7 +328,8 @@ private:
         source_ = src;
         fbo_ = fbo;
         startElapsed_ = getElapsedTimef();
-        lastCaptureElapsed_ = -1.0f;
+        nextCaptureTime_ = -1.0f;
+        lastFrameTime_ = -1.0f;
         afterFrameListener_ = events().afterFrame.listen([this]() { onAfterFrame(); });
         exitListener_ = events().exit.listen([this]() { stop(); });
         return true;
@@ -337,13 +338,26 @@ private:
     void onAfterFrame() {
         if (!writer_.isOpen()) return;
         float now = getElapsedTimef();
-        float fps = writer_.getFps();
-        // Throttle to the target fps (drop frames that arrive too soon).
-        if (lastCaptureElapsed_ >= 0.0f &&
-            (now - lastCaptureElapsed_) < (1.0f / fps) * 0.999f) {
-            return;
+        float interval = 1.0f / writer_.getFps();
+
+        // Decimate the (often higher-rate) frame stream to the target fps by
+        // capturing the frame NEAREST each target slot. nextCaptureTime_ advances
+        // by exactly one interval (drift-free); we capture once the slot falls
+        // within half a frame of now, so a frame landing a hair before its slot
+        // (e.g. every-other frame on a 120Hz display, where 16.67ms sat right on
+        // the old threshold) still counts instead of aliasing the rate down. The
+        // half-frame tolerance is the source frame time dt, not a fudge constant,
+        // so it stays correct for any source:target ratio (120->60, 120->30,
+        // 144->60, or a source slower than the target).
+        float dt = (lastFrameTime_ >= 0.0f) ? (now - lastFrameTime_) : interval;
+        lastFrameTime_ = now;
+        if (nextCaptureTime_ >= 0.0f && (now + 0.5f * dt) < nextCaptureTime_) {
+            return;   // this frame isn't the closest one to the next slot yet
         }
-        lastCaptureElapsed_ = now;
+        nextCaptureTime_ = (nextCaptureTime_ < 0.0f ? now : nextCaptureTime_) + interval;
+        if (nextCaptureTime_ <= now) {
+            nextCaptureTime_ = now + interval;   // source slower than target: resync
+        }
         double t = (double)(now - startElapsed_);   // wall-clock PTS
         if (source_ == Source::Fbo && fbo_) {
             writer_.addFrameAt(*fbo_, t);
@@ -381,7 +395,8 @@ private:
     Source source_ = Source::None;
     const Fbo* fbo_ = nullptr;
     float startElapsed_ = 0.0f;
-    float lastCaptureElapsed_ = -1.0f;
+    float nextCaptureTime_ = -1.0f;   // scheduled time of the next frame to capture
+    float lastFrameTime_ = -1.0f;     // previous afterFrame time (for source dt)
     EventListener afterFrameListener_;
     EventListener exitListener_;
     std::mutex writerMutex_;          // serializes encoder access (completion threads + stop)

--- a/core/include/tc/video/tcVideoRecorder.h
+++ b/core/include/tc/video/tcVideoRecorder.h
@@ -31,6 +31,23 @@
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <functional>
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <chrono>
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+// macOS-only: ScreenRecorder captures the swapchain asynchronously to avoid a
+// per-frame GPU stall. Elsewhere it falls back to the synchronous grabScreen().
+#if defined(__APPLE__) && (!defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE)
+    #define TC_ASYNC_SCREEN_CAPTURE 1
+#else
+    #define TC_ASYNC_SCREEN_CAPTURE 0
+#endif
 
 namespace trussc {
 
@@ -183,6 +200,20 @@ public:
         return appendRGBA(scratch_.data(), timeSec);
     }
 
+    // Append a tightly-packed RGBA8 buffer directly (no Pixels wrapper). Used by
+    // ScreenRecorder's async capture, where pixels arrive in a raw GPU readback
+    // buffer on a background thread.
+    bool addFrameAt(const unsigned char* rgba, int w, int h, double timeSec) {
+        if (!open_) return false;
+        if (w != width_ || h != height_) {
+            logError("VideoWriter")
+                << "frame size " << w << "x" << h
+                << " != writer " << width_ << "x" << height_;
+            return false;
+        }
+        return appendRGBA(rgba, timeSec);
+    }
+
 private:
     bool appendRGBA(const unsigned char* rgba, double timeSec) {
         if (!open_ || !rgba) return false;
@@ -237,11 +268,23 @@ public:
 
     // Stop capturing and finalize the file. Safe to call multiple times.
     void stop() {
-        afterFrameListener_ = EventListener{};
+        afterFrameListener_ = EventListener{};   // no new captures get queued
         exitListener_ = EventListener{};
+#if TC_ASYNC_SCREEN_CAPTURE
+        // Drain async captures still encoding on background threads before we
+        // close the writer (their completion handlers append into it).
+        for (int spins = 0;
+             inFlight_.load(std::memory_order_acquire) > 0 && spins < 2000;
+             ++spins) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+#endif
         source_ = Source::None;
         fbo_ = nullptr;
-        writer_.close();
+        {
+            std::lock_guard<std::mutex> lk(writerMutex_);
+            writer_.close();
+        }
     }
 
     bool isRecording() const { return writer_.isOpen(); }
@@ -279,10 +322,26 @@ private:
         double t = (double)(now - startElapsed_);   // wall-clock PTS
         if (source_ == Source::Fbo && fbo_) {
             writer_.addFrameAt(*fbo_, t);
-        } else {
-            Pixels px;
-            if (grabScreen(px) && px.isAllocated()) writer_.addFrameAt(px, t);
+            return;
         }
+#if TC_ASYNC_SCREEN_CAPTURE
+        // Async: issue the GPU readback and return — no main-thread stall. The
+        // completion handler (Metal background thread) encodes the frame. PTS t
+        // is captured now so wall-clock timing is unaffected by encode latency.
+        inFlight_.fetch_add(1, std::memory_order_relaxed);
+        bool started = internal::captureWindowAsync(
+            [this, t](const unsigned char* rgba, int w, int h) {
+                {
+                    std::lock_guard<std::mutex> lk(writerMutex_);
+                    if (writer_.isOpen()) writer_.addFrameAt(rgba, w, h, t);
+                }
+                inFlight_.fetch_sub(1, std::memory_order_acq_rel);
+            });
+        if (!started) inFlight_.fetch_sub(1, std::memory_order_acq_rel);
+#else
+        Pixels px;
+        if (grabScreen(px) && px.isAllocated()) writer_.addFrameAt(px, t);
+#endif
     }
 
     VideoWriter writer_;
@@ -292,6 +351,8 @@ private:
     float lastCaptureElapsed_ = -1.0f;
     EventListener afterFrameListener_;
     EventListener exitListener_;
+    std::mutex writerMutex_;          // serializes encoder access (completion threads + stop)
+    std::atomic<int> inFlight_{0};    // async captures not yet encoded (macOS)
 };
 
 // ---------------------------------------------------------------------------

--- a/core/include/tc/video/tcVideoRecorder.h
+++ b/core/include/tc/video/tcVideoRecorder.h
@@ -214,6 +214,26 @@ public:
         return appendRGBA(rgba, timeSec);
     }
 
+#if TC_ASYNC_SCREEN_CAPTURE
+    // Zero-intermediate path (macOS): lock the encoder's next pixel buffer for
+    // direct readback (returns its base address + row stride), then submit it at
+    // a PTS. The screen recorder reads the GPU capture straight into this buffer
+    // instead of into a temporary Pixels/RGBA buffer the encoder then re-copies.
+    unsigned char* lockFrame(int& strideOut) {
+        if (!open_) return nullptr;
+        return lockFramePlatform(strideOut);
+    }
+    bool submitFrame(double timeSec) {
+        if (!open_) return false;
+        if (!submitFramePlatform(timeSec)) {
+            logError("VideoWriter") << "encoder rejected frame " << frameCount_;
+            return false;
+        }
+        ++frameCount_;
+        return true;
+    }
+#endif
+
 private:
     bool appendRGBA(const unsigned char* rgba, double timeSec) {
         if (!open_ || !rgba) return false;
@@ -230,6 +250,11 @@ private:
                       const VideoRecordSettings& settings);
     bool appendPlatform(const unsigned char* rgba, double timeSec);
     void closePlatform();
+#if TC_ASYNC_SCREEN_CAPTURE
+    // Direct-buffer hooks for the zero-intermediate capture path (macOS).
+    unsigned char* lockFramePlatform(int& strideOut);   // lock & return encoder buffer
+    bool submitFramePlatform(double timeSec);            // append the locked buffer
+#endif
 
     VideoWriterPlatformData* platform_ = nullptr;
     std::string path_;
@@ -325,15 +350,23 @@ private:
             return;
         }
 #if TC_ASYNC_SCREEN_CAPTURE
-        // Async: issue the GPU readback and return — no main-thread stall. The
-        // completion handler (Metal background thread) encodes the frame. PTS t
-        // is captured now so wall-clock timing is unaffected by encode latency.
+        // Async + zero-intermediate: issue the GPU readback and return — no
+        // main-thread stall. When it completes (Metal background thread), read the
+        // staging straight into the encoder's pixel buffer (BGRA, no swap) and
+        // submit. PTS t is captured now so wall-clock timing is unaffected by
+        // encode latency.
         inFlight_.fetch_add(1, std::memory_order_relaxed);
         bool started = internal::captureWindowAsync(
-            [this, t](const unsigned char* rgba, int w, int h) {
+            [this, t](const internal::CaptureReadback& rb) {
                 {
                     std::lock_guard<std::mutex> lk(writerMutex_);
-                    if (writer_.isOpen()) writer_.addFrameAt(rgba, w, h, t);
+                    if (writer_.isOpen()) {
+                        int stride = 0;
+                        if (unsigned char* dst = writer_.lockFrame(stride)) {
+                            rb.readInto(dst, stride, /*wantRGBA=*/false);
+                            writer_.submitFrame(t);
+                        }
+                    }
                 }
                 inFlight_.fetch_sub(1, std::memory_order_acq_rel);
             });

--- a/core/platform/mac/tcPlatform_mac.mm
+++ b/core/platform/mac/tcPlatform_mac.mm
@@ -195,44 +195,78 @@ std::string getExecutableDir() {
 // スクリーンショット機能（Metal API を使用）
 // ---------------------------------------------------------------------------
 
-bool captureWindow(Pixels& outPixels) {
-    // Read back the drawable this frame ACTUALLY rendered into, recorded by the
-    // swapchain pass setup. We must NOT call sapp_get_swapchain() here: it advances
-    // to the next (unrendered) Metal drawable, which gave the stale/scrambled
-    // captures. Fall back to sapp_get_swapchain() only if no pass ran yet.
+// Read a shared-storage staging texture into a tightly-packed RGBA8 buffer,
+// converting BGRA8 / RGB10A2 as needed. Runs on whatever thread the caller is on
+// (main thread for screenshots, a Metal completion thread for async recording).
+static void readStagingToRGBA(id<MTLTexture> staging,
+                              NSUInteger width, NSUInteger height,
+                              MTLPixelFormat pixelFormat,
+                              std::vector<uint8_t>& outRGBA) {
+    NSUInteger bytesPerRow = width * 4;
+    std::vector<uint8_t> rawData(bytesPerRow * height);
+    [staging getBytes:rawData.data()
+          bytesPerRow:bytesPerRow
+           fromRegion:MTLRegionMake2D(0, 0, width, height)
+          mipmapLevel:0];
+
+    outRGBA.resize((size_t)width * height * 4);
+    unsigned char* dst = outRGBA.data();
+    if (pixelFormat == MTLPixelFormatRGB10A2Unorm) {
+        // RGB10A2 bit layout: [A:2 (31-30)][B:10 (29-20)][G:10 (19-10)][R:10 (9-0)]
+        const uint32_t* src = (const uint32_t*)rawData.data();
+        for (NSUInteger i = 0; i < width * height; i++) {
+            uint32_t pixel = src[i];
+            uint32_t r10 = (pixel >>  0) & 0x3FF;
+            uint32_t g10 = (pixel >> 10) & 0x3FF;
+            uint32_t b10 = (pixel >> 20) & 0x3FF;
+            uint32_t a2  = (pixel >> 30) & 0x3;
+            dst[i * 4 + 0] = (uint8_t)(r10 >> 2);
+            dst[i * 4 + 1] = (uint8_t)(g10 >> 2);
+            dst[i * 4 + 2] = (uint8_t)(b10 >> 2);
+            dst[i * 4 + 3] = (uint8_t)(a2 * 85);   // 0→0, 1→85, 2→170, 3→255
+        }
+    } else {
+        // BGRA8 -> RGBA8
+        memcpy(dst, rawData.data(), bytesPerRow * height);
+        for (NSUInteger i = 0; i < width * height; i++) {
+            unsigned char temp = dst[i * 4 + 0];
+            dst[i * 4 + 0] = dst[i * 4 + 2];
+            dst[i * 4 + 2] = temp;
+        }
+    }
+}
+
+bool internal::captureWindowAsync(
+    const std::function<void(const unsigned char*, int, int)>& completion) {
+    // Read back the drawable this frame ACTUALLY rendered into (recorded by the
+    // swapchain pass). NOT sapp_get_swapchain() — that advances to the next,
+    // unrendered drawable. Fall back only if no pass ran yet.
     const void* drawablePtr = internal::lastSwapchainDrawable;
-    if (!drawablePtr) {
-        drawablePtr = sapp_get_swapchain().metal.current_drawable;
-    }
+    if (!drawablePtr) drawablePtr = sapp_get_swapchain().metal.current_drawable;
     id<CAMetalDrawable> drawable = (__bridge id<CAMetalDrawable>)drawablePtr;
-    if (!drawable) {
-        logError() << "[Screenshot] Metal drawable が取得できません";
-        return false;
-    }
-
+    if (!drawable) return false;
     id<MTLTexture> srcTexture = drawable.texture;
-    if (!srcTexture) {
-        logError() << "[Screenshot] Metal テクスチャが取得できません";
-        return false;
-    }
+    if (!srcTexture) return false;
 
-    NSUInteger width = srcTexture.width;
+    NSUInteger width  = srcTexture.width;
     NSUInteger height = srcTexture.height;
     MTLPixelFormat pixelFormat = srcTexture.pixelFormat;
-
-    // sokol が CAMetalLayer に framebufferOnly=YES をセットしているため、
-    // drawable.texture から直接 getBytes するとアサートする (Metal validation 有効時)。
-    // shared-storage の staging texture に blit してから読み出す。
-    // Reuse the staging texture across calls (recreate only when the device or
-    // dimensions/format change). Continuous recording calls this every frame, so
-    // a per-frame newTextureWithDescriptor was needless allocation churn.
     id<MTLDevice> device = srcTexture.device;
-    static id<MTLTexture> s_stagingTexture = nil;
-    if (!s_stagingTexture
-        || s_stagingTexture.device != device
-        || s_stagingTexture.width != width
-        || s_stagingTexture.height != height
-        || s_stagingTexture.pixelFormat != pixelFormat) {
+
+    // sokol sets framebufferOnly=YES on the layer, so getBytes on the drawable
+    // asserts — blit into a shared-storage staging texture first. Use a small
+    // ring so an in-flight async readback isn't clobbered by the next frame's
+    // blit (recording keeps a couple captures in flight). Issued only from the
+    // main thread (afterFrame), so the static ring needs no locking.
+    static const int kRing = 3;
+    static id<MTLTexture> s_ring[kRing] = { nil, nil, nil };
+    static int s_ringIdx = 0;
+    int slot = s_ringIdx;
+    s_ringIdx = (s_ringIdx + 1) % kRing;
+    id<MTLTexture> staging = s_ring[slot];
+    if (!staging || staging.device != device
+        || staging.width != width || staging.height != height
+        || staging.pixelFormat != pixelFormat) {
         MTLTextureDescriptor* desc =
             [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
                                                                width:width
@@ -240,26 +274,17 @@ bool captureWindow(Pixels& outPixels) {
                                                            mipmapped:NO];
         desc.usage = MTLTextureUsageShaderRead;
         desc.storageMode = MTLStorageModeShared;
-        s_stagingTexture = [device newTextureWithDescriptor:desc];
+        staging = [device newTextureWithDescriptor:desc];
+        s_ring[slot] = staging;
     }
-    id<MTLTexture> stagingTexture = s_stagingTexture;
-    if (!stagingTexture) {
-        logError() << "[Screenshot] staging texture の作成に失敗しました";
-        return false;
-    }
+    if (!staging) return false;
 
-    // Use sokol_gfx's own Metal command queue, NOT a private one. Command buffers
-    // on a single MTLCommandQueue execute in commit order. captureWindow runs at
-    // afterFrame (after present()'s sg_commit()), so the frame's render command
-    // buffer is already committed on this queue; our blit, committed afterward on
-    // the SAME queue, is guaranteed to run after the render finishes. A private
-    // queue had no ordering relative to the render and raced — on GPU-heavy frames
-    // the blit beat the render and copied a recycled drawable's stale contents
-    // (temporal scramble in continuous recording).
+    // Blit on sokol's own queue so it is ordered AFTER the frame's render (a
+    // single MTLCommandQueue executes command buffers in commit order). A private
+    // queue raced ahead of the render and copied stale drawable contents.
     id<MTLCommandQueue> queue = (__bridge id<MTLCommandQueue>)sg_mtl_command_queue();
     static id<MTLCommandQueue> s_fallbackQueue = nil;
     if (!queue) {
-        // Metal not active (shouldn't happen here) — fall back to a private queue.
         if (!s_fallbackQueue || s_fallbackQueue.device != device) {
             s_fallbackQueue = [device newCommandQueue];
         }
@@ -269,57 +294,49 @@ bool captureWindow(Pixels& outPixels) {
     id<MTLCommandBuffer>      cmdBuf  = [queue commandBuffer];
     id<MTLBlitCommandEncoder> blitEnc = [cmdBuf blitCommandEncoder];
     [blitEnc copyFromTexture:srcTexture
-                 sourceSlice:0
-                 sourceLevel:0
+                 sourceSlice:0 sourceLevel:0
                 sourceOrigin:MTLOriginMake(0, 0, 0)
                   sourceSize:MTLSizeMake(width, height, 1)
-                   toTexture:stagingTexture
-            destinationSlice:0
-            destinationLevel:0
+                   toTexture:staging
+            destinationSlice:0 destinationLevel:0
            destinationOrigin:MTLOriginMake(0, 0, 0)];
     [blitEnc endEncoding];
+
+    // Read back + deliver when the GPU finishes — no main-thread waitUntilCompleted
+    // stall. The block retains `staging` and copies `completion`, so both outlive
+    // this function until the handler runs.
+    std::function<void(const unsigned char*, int, int)> comp = completion;
+    NSUInteger w = width, h = height;
+    MTLPixelFormat fmt = pixelFormat;
+    [cmdBuf addCompletedHandler:^(id<MTLCommandBuffer> cb) {
+        (void)cb;
+        std::vector<uint8_t> rgba;
+        readStagingToRGBA(staging, w, h, fmt, rgba);
+        comp(rgba.data(), (int)w, (int)h);
+    }];
     [cmdBuf commit];
-    [cmdBuf waitUntilCompleted];
-
-    MTLRegion region = MTLRegionMake2D(0, 0, width, height);
-    NSUInteger bytesPerRow = width * 4;
-    std::vector<uint8_t> rawData(bytesPerRow * height);
-
-    [stagingTexture getBytes:rawData.data()
-                 bytesPerRow:bytesPerRow
-                  fromRegion:region
-                 mipmapLevel:0];
-
-    // Allocate output pixels (always RGBA8)
-    outPixels.allocate((int)width, (int)height, 4);
-    unsigned char* dst = outPixels.getData();
-
-    if (pixelFormat == MTLPixelFormatRGB10A2Unorm) {
-        // RGB10A2 bit layout: [A:2 (31-30)][B:10 (29-20)][G:10 (19-10)][R:10 (9-0)]
-        const uint32_t* src = (const uint32_t*)rawData.data();
-        for (NSUInteger i = 0; i < width * height; i++) {
-            uint32_t pixel = src[i];
-            uint32_t r10 = (pixel >>  0) & 0x3FF;  // bits 0-9
-            uint32_t g10 = (pixel >> 10) & 0x3FF;  // bits 10-19
-            uint32_t b10 = (pixel >> 20) & 0x3FF;  // bits 20-29
-            uint32_t a2  = (pixel >> 30) & 0x3;    // bits 30-31
-            // Convert 10-bit (0-1023) to 8-bit, 2-bit (0-3) to 8-bit
-            dst[i * 4 + 0] = (uint8_t)(r10 >> 2);
-            dst[i * 4 + 1] = (uint8_t)(g10 >> 2);
-            dst[i * 4 + 2] = (uint8_t)(b10 >> 2);
-            dst[i * 4 + 3] = (uint8_t)(a2 * 85);   // 0→0, 1→85, 2→170, 3→255
-        }
-    } else {
-        // BGRA8 fallback
-        memcpy(dst, rawData.data(), bytesPerRow * height);
-        for (NSUInteger i = 0; i < width * height; i++) {
-            unsigned char temp = dst[i * 4 + 0];  // B
-            dst[i * 4 + 0] = dst[i * 4 + 2];     // R
-            dst[i * 4 + 2] = temp;                // B
-        }
-    }
-
     return true;
+}
+
+bool captureWindow(Pixels& outPixels) {
+    // Synchronous wrapper over the async primitive: issue the capture and block
+    // until the pixels land. Screenshots / MCP / exit use this — they need the
+    // bytes before returning (so the file is written / the response is ready).
+    bool ok = false;
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    bool started = internal::captureWindowAsync(
+        [&outPixels, &ok, sem](const unsigned char* rgba, int w, int h) {
+            outPixels.allocate(w, h, 4);
+            memcpy(outPixels.getData(), rgba, (size_t)w * h * 4);
+            ok = true;
+            dispatch_semaphore_signal(sem);
+        });
+    if (!started) {
+        logError() << "[Screenshot] Metal drawable が取得できません";
+        return false;
+    }
+    dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+    return ok;
 }
 
 bool internal::captureWindowToFile(const std::filesystem::path& path) {

--- a/core/platform/mac/tcPlatform_mac.mm
+++ b/core/platform/mac/tcPlatform_mac.mm
@@ -223,15 +223,26 @@ bool captureWindow(Pixels& outPixels) {
     // sokol が CAMetalLayer に framebufferOnly=YES をセットしているため、
     // drawable.texture から直接 getBytes するとアサートする (Metal validation 有効時)。
     // shared-storage の staging texture に blit してから読み出す。
+    // Reuse the staging texture across calls (recreate only when the device or
+    // dimensions/format change). Continuous recording calls this every frame, so
+    // a per-frame newTextureWithDescriptor was needless allocation churn.
     id<MTLDevice> device = srcTexture.device;
-    MTLTextureDescriptor* desc =
-        [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
-                                                           width:width
-                                                          height:height
-                                                       mipmapped:NO];
-    desc.usage = MTLTextureUsageShaderRead;
-    desc.storageMode = MTLStorageModeShared;
-    id<MTLTexture> stagingTexture = [device newTextureWithDescriptor:desc];
+    static id<MTLTexture> s_stagingTexture = nil;
+    if (!s_stagingTexture
+        || s_stagingTexture.device != device
+        || s_stagingTexture.width != width
+        || s_stagingTexture.height != height
+        || s_stagingTexture.pixelFormat != pixelFormat) {
+        MTLTextureDescriptor* desc =
+            [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
+                                                               width:width
+                                                              height:height
+                                                           mipmapped:NO];
+        desc.usage = MTLTextureUsageShaderRead;
+        desc.storageMode = MTLStorageModeShared;
+        s_stagingTexture = [device newTextureWithDescriptor:desc];
+    }
+    id<MTLTexture> stagingTexture = s_stagingTexture;
     if (!stagingTexture) {
         logError() << "[Screenshot] staging texture の作成に失敗しました";
         return false;

--- a/core/platform/mac/tcPlatform_mac.mm
+++ b/core/platform/mac/tcPlatform_mac.mm
@@ -195,49 +195,60 @@ std::string getExecutableDir() {
 // スクリーンショット機能（Metal API を使用）
 // ---------------------------------------------------------------------------
 
-// Read a shared-storage staging texture into a tightly-packed RGBA8 buffer,
-// converting BGRA8 / RGB10A2 as needed. Runs on whatever thread the caller is on
-// (main thread for screenshots, a Metal completion thread for async recording).
-static void readStagingToRGBA(id<MTLTexture> staging,
-                              NSUInteger width, NSUInteger height,
-                              MTLPixelFormat pixelFormat,
-                              std::vector<uint8_t>& outRGBA) {
-    NSUInteger bytesPerRow = width * 4;
-    std::vector<uint8_t> rawData(bytesPerRow * height);
-    [staging getBytes:rawData.data()
-          bytesPerRow:bytesPerRow
-           fromRegion:MTLRegionMake2D(0, 0, width, height)
-          mipmapLevel:0];
+// Copy a completed staging readback into the caller's destination buffer with a
+// single getBytes (no intermediate buffer for the common BGRA8 case). For BGRA8
+// + wantRGBA=false (the recorder feeding a BGRA CVPixelBuffer) this is one copy,
+// zero swizzle. Runs on whatever thread the consumer is on.
+void internal::CaptureReadback::readInto(unsigned char* dst, int dstStride,
+                                         bool wantRGBA) const {
+    id<MTLTexture> tex = (__bridge id<MTLTexture>)staging;
+    const NSUInteger w = (NSUInteger)width;
+    const NSUInteger h = (NSUInteger)height;
 
-    outRGBA.resize((size_t)width * height * 4);
-    unsigned char* dst = outRGBA.data();
-    if (pixelFormat == MTLPixelFormatRGB10A2Unorm) {
-        // RGB10A2 bit layout: [A:2 (31-30)][B:10 (29-20)][G:10 (19-10)][R:10 (9-0)]
-        const uint32_t* src = (const uint32_t*)rawData.data();
-        for (NSUInteger i = 0; i < width * height; i++) {
-            uint32_t pixel = src[i];
-            uint32_t r10 = (pixel >>  0) & 0x3FF;
-            uint32_t g10 = (pixel >> 10) & 0x3FF;
-            uint32_t b10 = (pixel >> 20) & 0x3FF;
-            uint32_t a2  = (pixel >> 30) & 0x3;
-            dst[i * 4 + 0] = (uint8_t)(r10 >> 2);
-            dst[i * 4 + 1] = (uint8_t)(g10 >> 2);
-            dst[i * 4 + 2] = (uint8_t)(b10 >> 2);
-            dst[i * 4 + 3] = (uint8_t)(a2 * 85);   // 0→0, 1→85, 2→170, 3→255
+    if (isRGB10A2) {
+        // 10-bit packed: must unpack via a temp. Layout per 32-bit pixel:
+        // [A:2 (31-30)][B:10 (29-20)][G:10 (19-10)][R:10 (9-0)].
+        std::vector<uint8_t> raw((size_t)w * 4 * h);
+        [tex getBytes:raw.data()
+          bytesPerRow:w * 4
+           fromRegion:MTLRegionMake2D(0, 0, w, h)
+          mipmapLevel:0];
+        const uint32_t* src = (const uint32_t*)raw.data();
+        for (NSUInteger y = 0; y < h; y++) {
+            uint8_t* drow = dst + (size_t)y * dstStride;
+            for (NSUInteger x = 0; x < w; x++) {
+                uint32_t p = src[y * w + x];
+                uint8_t r = (uint8_t)(((p >>  0) & 0x3FF) >> 2);
+                uint8_t g = (uint8_t)(((p >> 10) & 0x3FF) >> 2);
+                uint8_t b = (uint8_t)(((p >> 20) & 0x3FF) >> 2);
+                uint8_t a = (uint8_t)(((p >> 30) & 0x3) * 85);
+                if (wantRGBA) { drow[x*4+0]=r; drow[x*4+1]=g; drow[x*4+2]=b; drow[x*4+3]=a; }
+                else          { drow[x*4+0]=b; drow[x*4+1]=g; drow[x*4+2]=r; drow[x*4+3]=a; }
+            }
         }
-    } else {
-        // BGRA8 -> RGBA8
-        memcpy(dst, rawData.data(), bytesPerRow * height);
-        for (NSUInteger i = 0; i < width * height; i++) {
-            unsigned char temp = dst[i * 4 + 0];
-            dst[i * 4 + 0] = dst[i * 4 + 2];
-            dst[i * 4 + 2] = temp;
+        return;
+    }
+
+    // BGRA8: getBytes straight into dst (respecting the destination row stride).
+    [tex getBytes:dst
+      bytesPerRow:dstStride
+       fromRegion:MTLRegionMake2D(0, 0, w, h)
+      mipmapLevel:0];
+    if (wantRGBA) {
+        // In-place B<->R swap (no extra buffer).
+        for (NSUInteger y = 0; y < h; y++) {
+            uint8_t* drow = dst + (size_t)y * dstStride;
+            for (NSUInteger x = 0; x < w; x++) {
+                uint8_t b = drow[x*4+0];
+                drow[x*4+0] = drow[x*4+2];
+                drow[x*4+2] = b;
+            }
         }
     }
 }
 
 bool internal::captureWindowAsync(
-    const std::function<void(const unsigned char*, int, int)>& completion) {
+    const std::function<void(const internal::CaptureReadback&)>& completion) {
     // Read back the drawable this frame ACTUALLY rendered into (recorded by the
     // swapchain pass). NOT sapp_get_swapchain() — that advances to the next,
     // unrendered drawable. Fall back only if no pass ran yet.
@@ -302,17 +313,21 @@ bool internal::captureWindowAsync(
            destinationOrigin:MTLOriginMake(0, 0, 0)];
     [blitEnc endEncoding];
 
-    // Read back + deliver when the GPU finishes — no main-thread waitUntilCompleted
-    // stall. The block retains `staging` and copies `completion`, so both outlive
-    // this function until the handler runs.
-    std::function<void(const unsigned char*, int, int)> comp = completion;
+    // Deliver a readback handle when the GPU finishes — no main-thread
+    // waitUntilCompleted stall. The block retains `staging` and copies
+    // `completion`, so both outlive this function until the handler runs. The
+    // consumer reads the staging straight into its own destination buffer.
+    std::function<void(const internal::CaptureReadback&)> comp = completion;
     NSUInteger w = width, h = height;
-    MTLPixelFormat fmt = pixelFormat;
+    bool isRGB10A2 = (pixelFormat == MTLPixelFormatRGB10A2Unorm);
     [cmdBuf addCompletedHandler:^(id<MTLCommandBuffer> cb) {
         (void)cb;
-        std::vector<uint8_t> rgba;
-        readStagingToRGBA(staging, w, h, fmt, rgba);
-        comp(rgba.data(), (int)w, (int)h);
+        internal::CaptureReadback rb;
+        rb.staging   = (__bridge void*)staging;   // valid: block retains `staging`
+        rb.width     = (int)w;
+        rb.height    = (int)h;
+        rb.isRGB10A2 = isRGB10A2;
+        comp(rb);
     }];
     [cmdBuf commit];
     return true;
@@ -325,9 +340,9 @@ bool captureWindow(Pixels& outPixels) {
     bool ok = false;
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
     bool started = internal::captureWindowAsync(
-        [&outPixels, &ok, sem](const unsigned char* rgba, int w, int h) {
-            outPixels.allocate(w, h, 4);
-            memcpy(outPixels.getData(), rgba, (size_t)w * h * 4);
+        [&outPixels, &ok, sem](const internal::CaptureReadback& rb) {
+            outPixels.allocate(rb.width, rb.height, 4);
+            rb.readInto(outPixels.getData(), rb.width * 4, /*wantRGBA=*/true);
             ok = true;
             dispatch_semaphore_signal(sem);
         });

--- a/core/platform/mac/tcPlatform_mac.mm
+++ b/core/platform/mac/tcPlatform_mac.mm
@@ -196,9 +196,15 @@ std::string getExecutableDir() {
 // ---------------------------------------------------------------------------
 
 bool captureWindow(Pixels& outPixels) {
-    // sokol_app から現在の swapchain を取得
-    sapp_swapchain sc = sapp_get_swapchain();
-    id<CAMetalDrawable> drawable = (__bridge id<CAMetalDrawable>)sc.metal.current_drawable;
+    // Read back the drawable this frame ACTUALLY rendered into, recorded by the
+    // swapchain pass setup. We must NOT call sapp_get_swapchain() here: it advances
+    // to the next (unrendered) Metal drawable, which gave the stale/scrambled
+    // captures. Fall back to sapp_get_swapchain() only if no pass ran yet.
+    const void* drawablePtr = internal::lastSwapchainDrawable;
+    if (!drawablePtr) {
+        drawablePtr = sapp_get_swapchain().metal.current_drawable;
+    }
+    id<CAMetalDrawable> drawable = (__bridge id<CAMetalDrawable>)drawablePtr;
     if (!drawable) {
         logError() << "[Screenshot] Metal drawable が取得できません";
         return false;
@@ -231,12 +237,25 @@ bool captureWindow(Pixels& outPixels) {
         return false;
     }
 
-    static id<MTLCommandQueue> s_blitQueue = nil;
-    if (!s_blitQueue || s_blitQueue.device != device) {
-        s_blitQueue = [device newCommandQueue];
+    // Use sokol_gfx's own Metal command queue, NOT a private one. Command buffers
+    // on a single MTLCommandQueue execute in commit order. captureWindow runs at
+    // afterFrame (after present()'s sg_commit()), so the frame's render command
+    // buffer is already committed on this queue; our blit, committed afterward on
+    // the SAME queue, is guaranteed to run after the render finishes. A private
+    // queue had no ordering relative to the render and raced — on GPU-heavy frames
+    // the blit beat the render and copied a recycled drawable's stale contents
+    // (temporal scramble in continuous recording).
+    id<MTLCommandQueue> queue = (__bridge id<MTLCommandQueue>)sg_mtl_command_queue();
+    static id<MTLCommandQueue> s_fallbackQueue = nil;
+    if (!queue) {
+        // Metal not active (shouldn't happen here) — fall back to a private queue.
+        if (!s_fallbackQueue || s_fallbackQueue.device != device) {
+            s_fallbackQueue = [device newCommandQueue];
+        }
+        queue = s_fallbackQueue;
     }
 
-    id<MTLCommandBuffer>      cmdBuf  = [s_blitQueue commandBuffer];
+    id<MTLCommandBuffer>      cmdBuf  = [queue commandBuffer];
     id<MTLBlitCommandEncoder> blitEnc = [cmdBuf blitCommandEncoder];
     [blitEnc copyFromTexture:srcTexture
                  sourceSlice:0

--- a/core/platform/mac/tcVideoRecorder_mac.mm
+++ b/core/platform/mac/tcVideoRecorder_mac.mm
@@ -30,6 +30,7 @@ struct VideoWriterPlatformData {
     double fps = 30.0;
     int64_t frameIndex = 0;
     bool failed = false;
+    CVPixelBufferRef pendingPB = NULL;   // locked buffer between lockFrame/submitFrame
 };
 
 // ---------------------------------------------------------------------------
@@ -224,6 +225,81 @@ bool VideoWriter::appendPlatform(const unsigned char* rgba, double timeSec) {
         return true;
     }
 }
+
+#if TC_ASYNC_SCREEN_CAPTURE
+// ---------------------------------------------------------------------------
+// lockFramePlatform / submitFramePlatform - zero-intermediate capture path.
+// The recorder reads the GPU capture straight into the encoder's CVPixelBuffer
+// (BGRA), so there is no temporary Pixels buffer to copy through. Called on the
+// capture completion thread, serialized by the recorder's writer mutex.
+// ---------------------------------------------------------------------------
+unsigned char* VideoWriter::lockFramePlatform(int& strideOut) {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd || !pd->writer || pd->failed || pd->pendingPB) return nullptr;
+
+    // Briefly wait for the encoder input to accept more data.
+    int spins = 0;
+    while (!pd->input.readyForMoreMediaData && spins < 5000) {
+        [NSThread sleepForTimeInterval:0.001];
+        ++spins;
+    }
+    if (!pd->input.readyForMoreMediaData) {
+        logError("VideoWriter") << "input not ready (timeout)";
+        pd->failed = true;
+        return nullptr;
+    }
+
+    CVPixelBufferRef pb = NULL;
+    if (pd->adaptor.pixelBufferPool) {
+        CVPixelBufferPoolCreatePixelBuffer(NULL, pd->adaptor.pixelBufferPool, &pb);
+    }
+    if (!pb) {
+        NSDictionary* attrs = @{
+            (NSString*)kCVPixelBufferCGImageCompatibilityKey: @YES,
+            (NSString*)kCVPixelBufferCGBitmapContextCompatibilityKey: @YES,
+            (NSString*)kCVPixelBufferIOSurfacePropertiesKey: @{},
+        };
+        CVPixelBufferCreate(kCFAllocatorDefault, pd->width, pd->height,
+                            kCVPixelFormatType_32BGRA,
+                            (__bridge CFDictionaryRef)attrs, &pb);
+    }
+    if (!pb) {
+        logError("VideoWriter") << "could not create pixel buffer";
+        pd->failed = true;
+        return nullptr;
+    }
+
+    CVPixelBufferLockBaseAddress(pb, 0);
+    pd->pendingPB = pb;
+    strideOut = (int)CVPixelBufferGetBytesPerRow(pb);
+    return (unsigned char*)CVPixelBufferGetBaseAddress(pb);
+}
+
+bool VideoWriter::submitFramePlatform(double timeSec) {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd || !pd->pendingPB) return false;
+
+    CVPixelBufferRef pb = pd->pendingPB;
+    pd->pendingPB = NULL;
+    CVPixelBufferUnlockBaseAddress(pb, 0);
+
+    CMTime t = CMTimeMakeWithSeconds(timeSec, 600);
+    BOOL ok = [pd->adaptor appendPixelBuffer:pb withPresentationTime:t];
+    CVPixelBufferRelease(pb);
+
+    if (!ok) {
+        logError("VideoWriter")
+            << "appendPixelBuffer failed: "
+            << (pd->writer.error
+                    ? pd->writer.error.localizedDescription.UTF8String
+                    : "unknown");
+        pd->failed = true;
+        return false;
+    }
+    ++pd->frameIndex;
+    return true;
+}
+#endif // TC_ASYNC_SCREEN_CAPTURE
 
 // ---------------------------------------------------------------------------
 // closePlatform - mark finished and flush the file synchronously


### PR DESCRIPTION
## What
The screen recorder produced scrambled/frozen video and captured below the
target frame rate. This fixes both, and removes the per-frame main-thread stall.

## Changes
- fix(mac): capture the swapchain drawable the frame actually rendered into.
  sapp_get_swapchain() advances the Metal drawable on every call; a second call
  at end-of-frame read a different, unrendered drawable → scrambled/frozen
  recordings & screenshots on GPU-heavy frames.
- perf(mac): reuse the staging texture; capture asynchronously (no per-frame
  waitUntilCompleted); read straight into the encoder's CVPixelBuffer
  (3 CPU copies/frame → 1). Removes the stall that dragged render 120→~37fps
  while recording.
- fix(recorder): decimate to the target fps by nearest-frame, not a fragile
  threshold. The old (1/fps)*0.999 throttle aliased 120Hz→60 down to ~48fps and
  overshot non-2x ratios (120→30 gave 40fps). Drift-free accumulator, no magic
  constant, correct for any source:target ratio.

## Verification
- macOS/Metal: no freeze/scramble, screenshots intact, 60fps→59.5, 30fps→30.0.
- Windows/D3D11 + Linux/GL: build + run OK. The async/zero-copy fast paths are
  macOS-only (#if TC_ASYNC_SCREEN_CAPTURE); the decimation fix is plain C++ and
  benefits high-refresh displays on every platform.
