### PR TITLE
MCP server hardening + macOS recorder capture fixes (dev → main)

### DIFF
--- a/addons/tcxImGui/src/tcImGuiTools.h
+++ b/addons/tcxImGui/src/tcImGuiTools.h
@@ -2,7 +2,7 @@
 
 // =============================================================================
 // tcImGuiTools.h - ImGui MCP Tools
-// Auto-expose ImGui widgets as MCP tools (enabled via enableDebugger())
+// Auto-expose ImGui widgets as MCP tools (enabled via registerDebuggerTools())
 //
 // Uses ImGui Test Engine hooks (IMGUI_ENABLE_TEST_ENGINE) to collect
 // widget info each frame, then provides MCP tools to query and interact

--- a/addons/tcxNodeInspector/example-basic/src/tcApp.cpp
+++ b/addons/tcxNodeInspector/example-basic/src/tcApp.cpp
@@ -5,7 +5,6 @@ void tcApp::setup() {
 
     // Input-injection MCP tools (mouse_click / key_press / ...), so an AI
     // agent can drive the demo. No-ops unless TRUSSC_MCP is set.
-    mcp::enableDebugger();
     mcp::registerDebuggerTools();
 
     // A dedicated container we can rebuild without touching the app's own root.

--- a/addons/tcxNodeInspector/example-serialize/src/tcApp.cpp
+++ b/addons/tcxNodeInspector/example-serialize/src/tcApp.cpp
@@ -4,7 +4,6 @@ void tcApp::setup() {
     setWindowTitle("reflect -> inspector + JSON");
 
     // MCP input tools, so an AI agent can drive the demo (no-op without TRUSSC_MCP).
-    mcp::enableDebugger();
     mcp::registerDebuggerTools();
 
     // A scene container, with one sprite to inspect / serialize.

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -2049,8 +2049,16 @@ namespace internal {
                 mcpPort = std::atoi(envPort);
             }
 
+            // Host defaults to localhost (loopback-only). Set TRUSSC_MCP_HOST
+            // (e.g. 0.0.0.0) to expose externally — requires TRUSSC_MCP_TOKEN,
+            // otherwise startHttpServer refuses to bind (fail-closed).
+            const char* envHost = std::getenv("TRUSSC_MCP_HOST");
+            std::string mcpHost = envHost ? envHost : "localhost";
+            const char* envToken = std::getenv("TRUSSC_MCP_TOKEN");
+            std::string mcpToken = envToken ? envToken : "";
+
             // Start HTTP server for MCP transport
-            mcp::startHttpServer(mcpPort);
+            mcp::startHttpServer(mcpPort, mcpHost, mcpToken);
 
             logNotice("System") << "MCP HTTP server started";
         }

--- a/core/include/tc/utils/tcMCP.h
+++ b/core/include/tc/utils/tcMCP.h
@@ -64,7 +64,21 @@ inline std::vector<DeferredResponse>& deferredResponses() {
     return v;
 }
 
+// Set by registerDebuggerTools() (which is web-available), so this flag must
+// live outside the server-only #ifndef block below.
+inline std::atomic<bool>& isDebuggerEnabled() {
+    static std::atomic<bool> enabled{false};
+    return enabled;
+}
+
 } // namespace detail
+
+// Check if debugger tools are registered (input injection / scene mutation).
+// The flag is set by registerDebuggerTools() — registering IS the opt-in, so
+// apps/addons can query this to tell whether the debugger surface is exposed.
+inline bool isDebuggerEnabled() {
+    return detail::isDebuggerEnabled().load();
+}
 
 // Call inside a tool handler to defer its result until just after the next
 // present(). `produce` returns the tool's content json (same shape a normal
@@ -381,11 +395,6 @@ inline std::atomic<int>& getHttpPort() {
     return port;
 }
 
-inline std::atomic<bool>& isDebuggerEnabled() {
-    static std::atomic<bool> enabled{false};
-    return enabled;
-}
-
 // Bearer token required on /mcp requests. Empty = no auth (localhost default).
 inline std::string& mcpAuthToken() {
     static std::string token;
@@ -547,13 +556,6 @@ inline int getHttpPort() {
 // isDebuggerEnabled() flag). This shim is a no-op kept for source compatibility.
 [[deprecated("registerDebuggerTools() now opts in by itself; remove this call. Will be removed in v1.0.0")]]
 inline void enableDebugger() {}
-
-// Check if debugger tools are registered (input injection / scene mutation).
-// The flag is set by registerDebuggerTools() — registering IS the opt-in, so
-// apps/addons can query this to tell whether the debugger surface is exposed.
-inline bool isDebuggerEnabled() {
-    return detail::isDebuggerEnabled().load();
-}
 
 #endif // __EMSCRIPTEN__
 

--- a/core/include/tc/utils/tcMCP.h
+++ b/core/include/tc/utils/tcMCP.h
@@ -386,18 +386,52 @@ inline std::atomic<bool>& isDebuggerEnabled() {
     return enabled;
 }
 
+// Bearer token required on /mcp requests. Empty = no auth (localhost default).
+inline std::string& mcpAuthToken() {
+    static std::string token;
+    return token;
+}
+
 } // namespace detail
 
-// Start HTTP server on specified port (0 = OS auto-assign)
-inline void startHttpServer(int port = 0) {
+// Start HTTP server.
+//   port  : 0 = OS auto-assign, else fixed port
+//   host  : "localhost" (default) keeps it loopback-only; pass "0.0.0.0" to
+//           expose on all interfaces.
+//   token : bearer token required on /mcp. MUST be non-empty when host is not
+//           a loopback address — binding non-local without a token is refused
+//           (fail-closed) so input injection is never silently network-exposed.
+inline void startHttpServer(int port = 0, const std::string& host = "localhost",
+                            const std::string& token = "") {
     auto& svr = detail::getHttpServer();
     if (svr) return; // Already running
 
+    const bool isLoopback = (host == "localhost" || host == "127.0.0.1" || host == "::1");
+    if (!isLoopback && token.empty()) {
+        trussc::logError("MCP")
+            << "Refusing to bind MCP server to non-local host '" << host
+            << "' without a token. Set TRUSSC_MCP_TOKEN to expose it (the MCP "
+               "surface can inject input and mutate the scene).";
+        return;
+    }
+    detail::mcpAuthToken() = token;
+
     svr = std::make_unique<httplib::Server>();
 
-    // POST /mcp — JSON-RPC requests
+    // POST /mcp — JSON-RPC requests. No CORS header: MCP clients are native and
+    // ignore CORS, while a wildcard origin would let any web page in the user's
+    // browser drive the local server. (OPTIONS preflight handler dropped too.)
     svr->Post("/mcp", [](const httplib::Request& req, httplib::Response& res) {
-        res.set_header("Access-Control-Allow-Origin", "*");
+        // Bearer auth when a token is configured (always so for non-loopback).
+        const std::string& tok = detail::mcpAuthToken();
+        if (!tok.empty()) {
+            auto it = req.headers.find("Authorization");
+            if (it == req.headers.end() || it->second != ("Bearer " + tok)) {
+                res.status = 401;
+                res.set_content("{\"error\":\"unauthorized\"}", "application/json");
+                return;
+            }
+        }
 
         auto p = std::make_shared<std::promise<std::string>>();
         auto f = p->get_future();
@@ -414,14 +448,6 @@ inline void startHttpServer(int port = 0) {
         res.set_content(result, "application/json");
     });
 
-    // OPTIONS /mcp — CORS preflight
-    svr->Options("/mcp", [](const httplib::Request&, httplib::Response& res) {
-        res.set_header("Access-Control-Allow-Origin", "*");
-        res.set_header("Access-Control-Allow-Methods", "POST, OPTIONS");
-        res.set_header("Access-Control-Allow-Headers", "Content-Type");
-        res.status = 204;
-    });
-
     // GET / — Server info
     svr->Get("/", [](const httplib::Request&, httplib::Response& res) {
         json info = {
@@ -432,29 +458,29 @@ inline void startHttpServer(int port = 0) {
         res.set_content(info.dump(), "application/json");
     });
 
-    detail::getHttpThread() = std::make_unique<std::thread>([port]() {
+    detail::getHttpThread() = std::make_unique<std::thread>([port, host]() {
         auto& svr = detail::getHttpServer();
         if (!svr) return;
 
         int actualPort = 0;
         if (port > 0) {
             // Bind to specific port
-            if (!svr->bind_to_port("localhost", port)) {
-                trussc::logError("MCP") << "Failed to bind HTTP server to port " << port;
+            if (!svr->bind_to_port(host.c_str(), port)) {
+                trussc::logError("MCP") << "Failed to bind HTTP server to " << host << ":" << port;
                 return;
             }
             actualPort = port;
         } else {
             // Let OS assign a free port
-            actualPort = svr->bind_to_any_port("localhost");
+            actualPort = svr->bind_to_any_port(host.c_str());
             if (actualPort < 0) {
-                trussc::logError("MCP") << "Failed to bind HTTP server to any port";
+                trussc::logError("MCP") << "Failed to bind HTTP server to any port on " << host;
                 return;
             }
         }
         detail::getHttpPort().store(actualPort);
 
-        std::cerr << "[MCP] HTTP server listening on http://localhost:"
+        std::cerr << "[MCP] HTTP server listening on http://" << host << ":"
                   << actualPort << "/mcp" << std::endl;
 
         svr->listen_after_bind();

--- a/core/include/tc/utils/tcMCP.h
+++ b/core/include/tc/utils/tcMCP.h
@@ -543,6 +543,11 @@ inline int getHttpPort() {
     return detail::getHttpPort().load();
 }
 
+// Deprecated: registerDebuggerTools() is now the opt-in by itself (it sets the
+// isDebuggerEnabled() flag). This shim is a no-op kept for source compatibility.
+[[deprecated("registerDebuggerTools() now opts in by itself; remove this call. Will be removed in v1.0.0")]]
+inline void enableDebugger() {}
+
 // Check if debugger tools are registered (input injection / scene mutation).
 // The flag is set by registerDebuggerTools() — registering IS the opt-in, so
 // apps/addons can query this to tell whether the debugger surface is exposed.

--- a/core/include/tc/utils/tcMCP.h
+++ b/core/include/tc/utils/tcMCP.h
@@ -517,15 +517,9 @@ inline int getHttpPort() {
     return detail::getHttpPort().load();
 }
 
-// Enable debugger tools (mouse, keyboard input injection)
-inline void enableDebugger() {
-    if (detail::isDebuggerEnabled().load()) return;
-    detail::isDebuggerEnabled().store(true);
-    // Actual tool registration happens in tcStandardTools.h
-    // This is called before registerDebuggerTools()
-}
-
-// Check if debugger is enabled
+// Check if debugger tools are registered (input injection / scene mutation).
+// The flag is set by registerDebuggerTools() — registering IS the opt-in, so
+// apps/addons can query this to tell whether the debugger surface is exposed.
 inline bool isDebuggerEnabled() {
     return detail::isDebuggerEnabled().load();
 }

--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -200,10 +200,14 @@ inline void registerInspectionTools() {
 }
 
 // ---------------------------------------------------------------------------
-// Debugger Tools (input injection, opt-in via mcp::enableDebugger())
+// Debugger Tools (input injection, opt-in via mcp::registerDebuggerTools())
 // ---------------------------------------------------------------------------
 
 inline void registerDebuggerTools() {
+
+    // Registering the debugger surface IS the opt-in to input injection /
+    // scene mutation. Mark it so isDebuggerEnabled() reflects reality.
+    detail::isDebuggerEnabled().store(true);
 
     // --- Mouse Tools ---
 

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -216,4 +216,20 @@ Configure your MCP client with the HTTP URL:
 | ImGui (widget interaction) | `imgui_get_widgets`, `imgui_click`, `imgui_input`, `imgui_checkbox` | Requires tcxImGui addon + `mcp::registerDebuggerTools()` |
 | Custom | `mcp::tool(...)` | Your code |
 
-MCP communicates over localhost only. For remote access, use SSH tunneling or similar.
+### Network exposure
+
+By default the MCP server binds to **localhost only** and sends no CORS headers,
+so it is reachable only by native MCP clients on the same machine (a wildcard
+CORS origin would otherwise let any web page in your browser drive it). For
+remote access, SSH tunnelling is the simplest safe option.
+
+To expose it directly instead, set both:
+
+| Variable | Effect |
+|----------|--------|
+| `TRUSSC_MCP_HOST` | Bind address — e.g. `0.0.0.0` for all interfaces (default `localhost`) |
+| `TRUSSC_MCP_TOKEN` | Bearer token required on every `/mcp` request (`Authorization: Bearer <token>`) |
+
+Binding a non-loopback host **without** `TRUSSC_MCP_TOKEN` is refused
+(fail-closed) — the MCP surface can inject input and mutate the scene, so it is
+never silently exposed to the network.

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -49,7 +49,7 @@ TrussC uses **HTTP transport** for MCP. All JSON-RPC messages are sent as HTTP P
 | `get_node_tree` | `id`, `depth` (both optional) | Dump the node tree (or a subtree) as JSON: per node `{type, name, id, members, mods, children}`. Members are the `TC_REFLECT`ed values — rotation as euler degrees, colors as `[r,g,b,a]` floats 0-1, Vec3 as `[x,y,z]`, enums as their label string. `mods` lists each attached Mod as `{type, members}`. `depth` limits recursion (~270 bytes/node — on large scenes, explore with `depth` + drill into subtrees by `id`; cut-off nodes carry a `childCount`) |
 | `get_selected_node` | (none) | The currently selected node (same shape, no children), or `null` |
 
-### Debugger Tools (opt-in via `mcp::enableDebugger()`)
+### Debugger Tools (opt-in via `mcp::registerDebuggerTools()`)
 | Tool | Arguments | Description |
 |------|-----------|-------------|
 | `mouse_move` | `x`, `y`, `button` (optional) | Move cursor; with `button` held, emits a drag |
@@ -67,14 +67,17 @@ GUI (e.g. with the `tcxNodeInspector` addon's gizmo), then `get_node_tree` to
 read the exact values back and bake them into code — or drive the scene the
 other way with `set_node_members`.
 
-To enable debugger tools, call `mcp::enableDebugger()` in your `setup()`:
+To enable debugger tools, call `mcp::registerDebuggerTools()` in your `setup()`.
+Registering the tools *is* the opt-in — there is no separate enable step, and
+`mcp::isDebuggerEnabled()` will report `true` once they are registered:
 
 ```cpp
 void tcApp::setup() {
-    mcp::enableDebugger();
     mcp::registerDebuggerTools();
 }
 ```
+
+These tools are inert unless the MCP server is also running (`TRUSSC_MCP=1`).
 
 ### ImGui Tools (requires tcxImGui addon)
 
@@ -157,7 +160,7 @@ curl -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"save_screenshot","arguments":{"path":"/tmp/test.png"}}}'
 
-# Mouse click (requires enableDebugger())
+# Mouse click (requires registerDebuggerTools())
 curl -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"tools/call","id":3,"params":{"name":"mouse_click","arguments":{"x":100,"y":200}}}'
@@ -209,7 +212,7 @@ Configure your MCP client with the HTTP URL:
 | Category | Tools | Enabled by |
 |----------|-------|------------|
 | Inspection (read-only) | `get_screenshot`, `save_screenshot`, `get_node_tree`, `get_selected_node` | Automatic when MCP is enabled |
-| Debugger (input injection / scene mutation) | `mouse_click`, `mouse_press`, `mouse_release`, `key_press`, `mouse_move`, `mouse_scroll`, `key_release`, `select_node`, `set_node_members` | `mcp::enableDebugger()` + `mcp::registerDebuggerTools()` |
+| Debugger (input injection / scene mutation) | `mouse_click`, `mouse_press`, `mouse_release`, `key_press`, `mouse_move`, `mouse_scroll`, `key_release`, `select_node`, `set_node_members` | `mcp::registerDebuggerTools()` |
 | ImGui (widget interaction) | `imgui_get_widgets`, `imgui_click`, `imgui_input`, `imgui_checkbox` | Requires tcxImGui addon + `mcp::registerDebuggerTools()` |
 | Custom | `mcp::tool(...)` | Your code |
 

--- a/docs/api-definition.yaml
+++ b/docs/api-definition.yaml
@@ -3246,6 +3246,17 @@ categories:
         sketch: false
         snippet: "intersectRect(${1:x1}, ${2:y1}, ${3:w1}, ${4:h1}, ${5:x2}, ${6:y2}, ${7:w2}, ${8:h2}, ${9:ox}, ${10:oy}, ${11:ow}, ${12:oh})"
 
+      - name: "mcp::registerDebuggerTools"
+        return: "void"
+        signatures:
+          - params: ""
+            params_simple: ""
+        description: "Opt in to the MCP debugger tools, letting an AI agent drive the app: input injection (mouse_click, key_press, mouse_move, scroll) plus node selection and scene mutation (select_node, set_node_members). Call once in setup(); calling it IS the opt-in (there is no separate enable step). The tools do nothing unless the MCP server is running (TRUSSC_MCP=1), so it is safe to leave in. Read-only inspection — screenshots and the node tree — needs no opt-in and is always available when MCP is on."
+        description_ja: "MCP のデバッガツールを有効化し、AI エージェントがアプリを操作できるようにする：入力注入（mouse_click, key_press, mouse_move, scroll）に加え、ノード選択・シーン書き換え（select_node, set_node_members）。setup() で一度呼ぶだけで opt-in 完了（別途の有効化呼び出しは不要）。MCP サーバ起動時（TRUSSC_MCP=1）以外は何もしないので、入れっぱなしでも安全。スクリーンショットやノードツリーの読み取りは opt-in 不要で、MCP が有効なら常に使える。"
+        description_ko: "MCP 디버거 도구를 활성화하여 AI 에이전트가 앱을 조작할 수 있게 한다: 입력 주입(mouse_click, key_press, mouse_move, scroll)과 노드 선택·씬 변경(select_node, set_node_members). setup()에서 한 번 호출하면 그것이 곧 opt-in이다(별도의 활성화 단계 없음). MCP 서버가 실행 중(TRUSSC_MCP=1)이 아니면 아무 동작도 하지 않으므로 그대로 두어도 안전하다. 스크린샷과 노드 트리 같은 읽기 전용 조회는 opt-in이 필요 없으며 MCP가 켜져 있으면 항상 사용할 수 있다."
+        sketch: false
+        snippet: "mcp::registerDebuggerTools()"
+
   # ==========================================================================
   # File
   # ==========================================================================

--- a/examples/sound/audioDeviceExample/src/tcApp.cpp
+++ b/examples/sound/audioDeviceExample/src/tcApp.cpp
@@ -43,7 +43,6 @@ void tcApp::setup() {
     // Only active when TRUSSC_MCP=1 is set in the environment.
     // MCP is desktop-only — Web builds skip it.
 #ifndef __EMSCRIPTEN__
-    mcp::enableDebugger();
     mcp::registerDebuggerTools();
     imgui_tools::registerImGuiTools();
 #endif


### PR DESCRIPTION
## Summary

Brings `dev` into `main`. Two independent areas of work.

### 1. MCP server hardening & opt-in cleanup

- **`mcp::enableDebugger()` removed as a required step.** Registering the
  debugger tools is now the single opt-in: `mcp::registerDebuggerTools()` sets
  the `isDebuggerEnabled()` flag itself. The old `enableDebugger()` was a
  no-op that nothing read. It is kept as a `[[deprecated]]` no-op shim for
  source compatibility (existing apps still compile, with a warning) and will
  be removed in v1.0.0.
- **Wildcard CORS dropped.** The MCP endpoint previously sent
  `Access-Control-Allow-Origin: *` plus an OPTIONS preflight handler, which let
  any web page in the user's browser drive the local server. Native MCP clients
  ignore CORS, so both are removed. This only affects the `/mcp` routes — any
  HTTP server an app runs for other purposes is untouched.
- **Opt-in external exposure.** New env vars `TRUSSC_MCP_HOST` (default
  `localhost`) and `TRUSSC_MCP_TOKEN`. Binding a non-loopback host **without** a
  token is refused (fail-closed); when a token is set, every `/mcp` request must
  carry a matching `Authorization: Bearer <token>`.
- Docs (`AI_AUTOMATION.md`), samples, and `api-definition.yaml` updated.

### 2. macOS screen-recorder capture fixes / perf

Carried along on `dev`:
- Capture the rendered swapchain drawable, not a re-acquired one
- Reuse the capture staging texture across frames
- Capture frames asynchronously; read straight into the encoder's pixel buffer
- Decimate to target fps by nearest-frame instead of a fragile threshold

## Verification

- Built `addons/tcxNodeInspector/example-basic` (macOS).
- MCP behaviour, verified at runtime:
  - localhost / no token → `200` (unchanged default)
  - `0.0.0.0` / no token → refuses to bind (nothing listening)
  - `0.0.0.0` / token → `401` on missing/wrong bearer, `200` on the correct one
  - CORS header gone on `POST /mcp`; `OPTIONS /mcp` → `404`

## Breaking / behavioural changes

- `mcp::enableDebugger()` is deprecated (no-op shim). Code calling it compiles
  with a warning; remove the call. Shim removed in v1.0.0.
- Browser access to the MCP endpoint via wildcard CORS no longer works (there is
  no official browser MCP client).

Merge commit (not squash), per repo convention.
