### PR TITLE
fix: stop sokol_gl per-layer full vertex re-append (GPU buffer blowup)

### DIFF
--- a/core/include/sokol/TRUSSC_MODIFICATIONS.md
+++ b/core/include/sokol/TRUSSC_MODIFICATIONS.md
@@ -144,6 +144,15 @@ TrussC-specific public functions use the `sgl_tc_` prefix to distinguish from up
 - `_sgl_draw()`: uses `sg_append_buffer` instead of `sg_update_buffer`
 - Vertex buffer offsets tracked per draw call via `base_vertex`
 - GPU buffer recreated on overflow if released
+- **Single upload per frame (shared across layer draws):** `_sgl_draw()` appends
+  the full vertex set to the GPU buffer only on the FIRST call of a frame and
+  reuses the returned base offset for the remaining layer draws (cache keyed on
+  `frame_id` / vertex count / `vbuf.id`, fields `upload_*`; invalidated by
+  `sgl_tc_context_reset`). Without this, flushing N layers (e.g. one per deferred
+  PBR/shader draw, see `flushDeferredShaderDraws`) re-appended V vertices N times,
+  so `append_pos` reached N×V and `_sgl_grow_gpu_buffer` doubled the GPU buffer
+  until allocation failed (Metal `id:52` / `METAL_CREATE_BUFFER_FAILED`), killing
+  all sgl rendering. Regression test: `core/tests/sglLayerUpload` (dummy backend).
 
 ### 11. Auto-grow Buffers
 

--- a/core/include/sokol/util/sokol_gl_tc.h
+++ b/core/include/sokol/util/sokol_gl_tc.h
@@ -2589,6 +2589,16 @@ typedef struct {
     int pending_grow_vertices;  /* [TrussC fork] deferred grow: if >0, grow buffer at start of next _sgl_draw */
     sg_buffer retired_bufs[4];  /* [TrussC fork] retire list: old GPU buffers awaiting destruction */
     int retired_count;
+    /* [TrussC fork] per-frame single-upload cache. All layer draws within one
+       frame share ONE GPU vertex upload: the first _sgl_draw() appends the full
+       vertex set and records (frame, count, base_offset, vbuf); subsequent layer
+       draws reuse that base_offset instead of re-appending every vertex. Without
+       this, flushing N layers re-uploads V vertices N times (O(N*V)), which grows
+       the GPU buffer until allocation fails (id:52 / METAL_CREATE_BUFFER_FAILED). */
+    uint32_t upload_frame_id;
+    int      upload_vertex_count;
+    int      upload_base_offset;
+    uint32_t upload_vbuf_id;
     sgl_pipeline def_pip;
     sg_bindings bind;
 
@@ -3730,41 +3740,65 @@ static void _sgl_draw(_sgl_context_t* ctx, int layer_id) {
         uint32_t cur_smp_id = SG_INVALID_ID;
         int cur_uniform_index = -1;
 
-        /* [TrussC fork] append ALL vertex data (commands reference absolute base_vertex) */
-        const size_t data_size = (size_t)ctx->vertices.next * sizeof(_sgl_vertex_t);
-        const sg_range range = { ctx->vertices.ptr, data_size };
+        /* [TrussC fork] Single upload per frame, shared across layer draws.
+           The vertex set is identical for every layer draw in a frame, so we
+           append it to the GPU buffer exactly once and reuse the returned base
+           offset. Re-appending per layer is what blew the buffer up to O(N*V).
+           The cache is keyed on (frame_id, vertex count, vbuf id): a new frame,
+           newly recorded vertices (suspend/resume), or a recreated/grown buffer
+           all force a fresh upload. */
+        int base_offset;
+        bool reuse_upload = (ctx->vbuf.id != SG_INVALID_ID)
+                         && (ctx->upload_vbuf_id == ctx->vbuf.id)
+                         && (ctx->upload_frame_id == ctx->frame_id)
+                         && (ctx->upload_vertex_count == ctx->vertices.next);
+        if (reuse_upload) {
+            base_offset = ctx->upload_base_offset;
+        } else {
+            /* [TrussC fork] append ALL vertex data (commands reference absolute base_vertex) */
+            const size_t data_size = (size_t)ctx->vertices.next * sizeof(_sgl_vertex_t);
+            const sg_range range = { ctx->vertices.ptr, data_size };
 
-        /* [TrussC fork] pre-check buffer capacity before append to avoid validation panic */
-        if (data_size > 0 && sg_query_buffer_state(ctx->vbuf) == SG_RESOURCESTATE_VALID) {
-            sg_buffer_desc buf_desc = sg_query_buffer_desc(ctx->vbuf);
-            size_t append_pos = (size_t)sg_query_buffer_info(ctx->vbuf).append_pos;
-            if (buf_desc.size < append_pos + data_size) {
-                int needed = (int)((buf_desc.size + data_size) / sizeof(_sgl_vertex_t)) + 1;
-                /* [TrussC fork] 旧バッファは retire リストに退避されるので
-                   D3D11 でも即座に grow + 再アップロードが可能 */
+            /* [TrussC fork] pre-check buffer capacity before append to avoid validation panic */
+            if (data_size > 0 && sg_query_buffer_state(ctx->vbuf) == SG_RESOURCESTATE_VALID) {
+                sg_buffer_desc buf_desc = sg_query_buffer_desc(ctx->vbuf);
+                size_t append_pos = (size_t)sg_query_buffer_info(ctx->vbuf).append_pos;
+                if (buf_desc.size < append_pos + data_size) {
+                    /* grow target is the actual cursor (append_pos), not the whole
+                       buffer size — buf_desc.size double-counts already-uploaded data. */
+                    int needed = (int)((append_pos + data_size) / sizeof(_sgl_vertex_t)) + 1;
+                    /* [TrussC fork] 旧バッファは retire リストに退避されるので
+                       D3D11 でも即座に grow + 再アップロードが可能 */
+                    if (!_sgl_grow_gpu_buffer(ctx, needed)) {
+                        sg_pop_debug_group();
+                        return;
+                    }
+                }
+            }
+
+            base_offset = sg_append_buffer(ctx->vbuf, &range);
+            if (sg_query_buffer_overflow(ctx->vbuf)) {
+                /* [TrussC fork] GPU buffer too small — grow and retry */
+                size_t append_pos = (size_t)sg_query_buffer_info(ctx->vbuf).append_pos;
+                int needed = (int)((append_pos + data_size) / sizeof(_sgl_vertex_t)) + 1;
                 if (!_sgl_grow_gpu_buffer(ctx, needed)) {
                     sg_pop_debug_group();
                     return;
                 }
+                base_offset = sg_append_buffer(ctx->vbuf, &range);
+                if (sg_query_buffer_overflow(ctx->vbuf)) {
+                    sg_pop_debug_group();
+                    return;
+                }
             }
-        }
 
-        int base_offset = sg_append_buffer(ctx->vbuf, &range);
-        if (sg_query_buffer_overflow(ctx->vbuf)) {
-            /* [TrussC fork] GPU buffer too small — grow and retry */
-            int needed = (int)(sg_query_buffer_desc(ctx->vbuf).size / sizeof(_sgl_vertex_t) + (size_t)ctx->vertices.next);
-            if (!_sgl_grow_gpu_buffer(ctx, needed)) {
-                sg_pop_debug_group();
-                return;
-            }
-            base_offset = sg_append_buffer(ctx->vbuf, &range);
-            if (sg_query_buffer_overflow(ctx->vbuf)) {
-                sg_pop_debug_group();
-                return;
-            }
+            /* [TrussC fork] remember this upload so the remaining layer draws of
+               this frame reuse it instead of re-appending the same vertices. */
+            ctx->upload_frame_id     = ctx->frame_id;
+            ctx->upload_vertex_count = ctx->vertices.next;
+            ctx->upload_base_offset  = base_offset;
+            ctx->upload_vbuf_id      = ctx->vbuf.id;
         }
-        /* convert byte offset to vertex offset */
-        const int vtx_offset = base_offset / (int)sizeof(_sgl_vertex_t);
 
         /* Render commands from cmd_start onwards (skip already-drawn commands) */
         for (int i = cmd_start; i < ctx->commands.next; i++) {
@@ -4754,6 +4788,10 @@ static void _sgl_reset_buffers(_sgl_context_t* ctx) {
     ctx->base_vertex = 0;
     ctx->draw_base_cmd = 0;
     ctx->draw_base_vertex = 0;
+    /* [TrussC fork] invalidate the single-upload cache: a reset starts a brand
+       new vertex set within the SAME frame, so a future draw whose vertex count
+       coincides with the cached one must NOT reuse the stale base offset. */
+    ctx->upload_vbuf_id = SG_INVALID_ID;
     ctx->matrix_dirty = true;
 }
 

--- a/core/platform/ios/tcPlatform_ios.mm
+++ b/core/platform/ios/tcPlatform_ios.mm
@@ -134,8 +134,13 @@ std::string getExecutableDir() {
 // ---------------------------------------------------------------------------
 
 bool captureWindow(Pixels& outPixels) {
-    sapp_swapchain sc = sapp_get_swapchain();
-    id<CAMetalDrawable> drawable = (__bridge id<CAMetalDrawable>)sc.metal.current_drawable;
+    // Read back the drawable this frame ACTUALLY rendered into (recorded by the
+    // swapchain pass). NOT sapp_get_swapchain() — that advances to the next,
+    // unrendered drawable, scrambling captures on GPU-heavy frames. Fall back
+    // only if no pass ran yet. (Mirrors the macOS fix.)
+    const void* drawablePtr = internal::lastSwapchainDrawable;
+    if (!drawablePtr) drawablePtr = sapp_get_swapchain().metal.current_drawable;
+    id<CAMetalDrawable> drawable = (__bridge id<CAMetalDrawable>)drawablePtr;
     if (!drawable) {
         logError() << "[Screenshot] Failed to get Metal drawable";
         return false;

--- a/core/tests/README.md
+++ b/core/tests/README.md
@@ -1,10 +1,9 @@
 # core/tests
 
-Headless **behavioral regression tests** for the TrussC core. Each test is a
-console TrussC project whose `main()` returns non-zero on failure. CI builds and
-runs every `core/tests/*/` here (`build_all.py --core-tests-only`); a non-zero
-exit fails the job. This is the same convention bundled addons use
-(`addons/*/tests/`).
+Headless **behavioral regression tests** for the TrussC core. Each test's
+`main()` returns non-zero on failure. CI builds and runs every `core/tests/*/`
+here (`build_all.py --core-tests-only`); a non-zero exit fails the job. This is
+the same convention bundled addons use (`addons/*/tests/`).
 
 This is the *behavioral* tier — it complements, and does not replace, the
 **build canaries** in `examples/tests/` (e.g. `AllFeaturesExample`), which prove
@@ -20,6 +19,18 @@ the API still compiles/links/instantiates but do not assert runtime behaviour.
   (it runs the per-frame `drainMainThreadQueue()`, so `runOnMainThread` works).
 - **Assertion-based**, clear names, exit code = pass/fail.
 
+## Two test shapes
+
+1. **trusscli project tests** (default) — a `src/` dir; built via `trusscli` and
+   linked against libTrussC. `threadSafety/` is one.
+2. **Standalone CMake unit tests** — a committed `CMakeLists.txt` with source at
+   the dir root (no `src/`); built with plain `cmake`, **not** linked against
+   libTrussC. Use this when a test must compile a library directly with options
+   that would clash with the copy already baked into libTrussC — e.g. driving
+   `sokol_gl` on `SOKOL_DUMMY_BACKEND` (no GPU) to assert GPU-resource
+   accounting. `build_all.py` tells the two apart by the committed `CMakeLists.txt`
+   + absence of `src/`, and runs both under `--core-tests-only`.
+
 ## Keep it curated (avoid rot)
 
 - Default workflow: **when you fix a bug, add the regression test that would have
@@ -32,3 +43,8 @@ the API still compiles/links/instantiates but do not assert runtime behaviour.
 - `threadSafety/` — main-thread affinity: `runOnMainThread` defers + delivers on
   the main thread, `Event` `Deliver::Main` marshals worker-fired notifies onto the
   main thread, and `Node::destroy()` is safe from any thread.
+- `sglLayerUpload/` — *(standalone, dummy backend)* the sokol_gl `_sgl_draw()`
+  vertex upload is done **once per frame** and shared across layer draws, instead
+  of re-appending the whole vertex set per layer. Guards against the O(N layers ×
+  V vertices) GPU-buffer blow-up that grew the buffer until allocation failed
+  (Metal `id:52`), the root cause of disappearing deferred 2D/PBR content.

--- a/core/tests/sglLayerUpload/.gitignore
+++ b/core/tests/sglLayerUpload/.gitignore
@@ -1,0 +1,4 @@
+# Standalone CMake test: keep CMakeLists.txt (it is committed, unlike trusscli
+# projects). Only ignore build output.
+build/
+build-*/

--- a/core/tests/sglLayerUpload/CMakeLists.txt
+++ b/core/tests/sglLayerUpload/CMakeLists.txt
@@ -1,0 +1,24 @@
+# core/tests/sglLayerUpload — standalone headless regression test.
+#
+# This is intentionally NOT a TrussC project: it compiles its own copy of
+# sokol_gfx/sokol_gl with SOKOL_DUMMY_BACKEND (no GPU, no window, no frameworks),
+# which would clash with libTrussC's platform-backend sokol implementation. It is
+# therefore built with plain CMake (no trusscli), and build_all.py detects it by
+# the presence of this committed CMakeLists.txt.
+cmake_minimum_required(VERSION 3.16)
+project(sglLayerUpload C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+add_executable(sglLayerUpload main.c)
+
+# core/include/sokol (this file lives at core/tests/sglLayerUpload/)
+target_include_directories(sglLayerUpload PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include/sokol)
+
+if(NOT MSVC)
+    # -Wno-unused-function: the dummy-backend sokol compile leaves a couple of
+    # helpers (e.g. _sgl_clamp) unreferenced; that's third-party header noise.
+    target_compile_options(sglLayerUpload PRIVATE -Wall -Wextra -Wno-unused-function)
+endif()

--- a/core/tests/sglLayerUpload/CMakeLists.txt
+++ b/core/tests/sglLayerUpload/CMakeLists.txt
@@ -21,4 +21,8 @@ if(NOT MSVC)
     # -Wno-unused-function: the dummy-backend sokol compile leaves a couple of
     # helpers (e.g. _sgl_clamp) unreferenced; that's third-party header noise.
     target_compile_options(sglLayerUpload PRIVATE -Wall -Wextra -Wno-unused-function)
+    # libm: sokol_gl's matrix helpers use sinf/cosf/sqrtf. macOS links libm
+    # implicitly and MSVC pulls it from the CRT, but GNU/Linux ld needs it
+    # explicitly or the standalone test fails to link (undefined references).
+    target_link_libraries(sglLayerUpload PRIVATE m)
 endif()

--- a/core/tests/sglLayerUpload/README.md
+++ b/core/tests/sglLayerUpload/README.md
@@ -1,0 +1,103 @@
+# sglLayerUpload — sokol_gl per-frame single-upload regression test
+
+Standalone, headless regression test for the sokol_gl (`sokol_gl_tc.h`) vertex
+buffer blow-up fixed on branch `fix/buffer-increase-bug`.
+
+## The bug it guards
+
+`flushDeferredShaderDraws()` (swapchain) and `flushFboDeferredPbr()` (FBO) draw
+each sokol_gl **layer** with `sgl_(context_)draw_layer()`. Every deferred PBR /
+shader draw bumps the layer counter, so a busy frame flushes many layers (N).
+
+The TrussC fork's `_sgl_draw()` used `sg_append_buffer()` and re-appended the
+**entire** recorded vertex set (V vertices) on *every* call. So one frame uploaded
+`N × V` vertices, and `_sgl_grow_gpu_buffer()` doubled the GPU buffer to keep up
+(2.5 → 5 → 10 → … MB) until the backend refused the allocation:
+
+```
+[sg][error][id:52] METAL_CREATE_BUFFER_FAILED
+```
+
+…after which that sgl context renders nothing for the rest of the run (deferred 2D
+and PBR content silently vanishes). Low-vertex scenes never hit it; it needs both
+a high layer count and a non-trivial vertex count.
+
+**The fix:** `_sgl_draw()` appends the vertex set **once per frame** and reuses
+the returned base offset for the remaining layer draws — O(V), not O(N×V). See
+mod #10 in `core/include/sokol/TRUSSC_MODIFICATIONS.md`.
+
+## What CI checks automatically (this test)
+
+This test drives sokol_gl on `SOKOL_DUMMY_BACKEND` — **no GPU, no window, no
+frameworks**. The dummy backend has no real device but still tracks the exact
+numbers that blew up: `append_pos` (bytes uploaded this frame) and the GPU buffer
+size. So the regression is fully deterministic and runs on every OS in CI.
+
+It asserts:
+1. Empty layers → exactly **one** upload per frame (`append_pos == V`), not N×V.
+2. GPU buffer does **not** grow as the layer count grows.
+3. Non-empty layers → the single upload covers the **full** accumulated set.
+4. A new frame **re-uploads** (cache keyed on frame id, not stale).
+5. `sgl_tc_context_reset()` **invalidates** the cache (no stale base offset reuse).
+
+It is **NOT** a render-correctness test — it cannot see pixels. It only proves the
+upload *accounting* is fixed. Pixel correctness needs real GPUs (see below).
+
+### Run it
+
+CI runs it via the core-test gate (it is auto-detected as a standalone test —
+committed `CMakeLists.txt`, no `src/`):
+
+```bash
+python3 examples/build_all.py --core-tests-only --verbose
+```
+
+Or directly:
+
+```bash
+cd core/tests/sglLayerUpload
+cmake -S . -B build && cmake --build build
+./build/sglLayerUpload        # Windows: build\Release\sglLayerUpload.exe
+```
+
+Expected tail on success (exit code 0):
+
+```
+empty layers: exactly one upload per frame (no N*V)          PASS
+empty layers: GPU buffer does not grow with layer count      PASS
+non-empty layers: one upload of the full vertex set          PASS
+new frame re-uploads its vertices (not stale)                PASS
+context reset invalidates cache (re-appends, no stale reuse) PASS
+
+PASSED (0 failures)
+```
+
+Against the pre-fix `sokol_gl_tc.h`, checks 1–4 FAIL with `append_pos` many times
+`V` — that is the bug, and the reason this test exists.
+
+## What still needs a REAL device (NOT covered by CI)
+
+CI proves the *accounting* is fixed on all backends, but it cannot prove that the
+reused base offset still draws the **correct pixels** on a real GPU. That part was
+verified manually:
+
+- **Metal / macOS** — verified (PBR meshes + sokol_gl 2D render correctly).
+- **D3D11 / Windows** and **GL / Linux** — please verify on real hardware.
+
+### Manual real-device check
+
+There is no automated GPU test (the core tests are headless by charter). To check
+a backend by hand, run any app that, **per frame**, issues *many* deferred draws
+(each deferred PBR mesh or `tc::Shader` draw bumps an sgl layer) **together with**
+a non-trivial amount of sokol_gl 2D geometry (e.g. lots of `drawRect`/lines, a big
+`drawBitmapString`, or filled paths). A few hundred deferred draws + thousands of
+2D vertices is enough.
+
+- **Before the fix:** within seconds the log prints `id:52 METAL_CREATE_BUFFER_FAILED`
+  (or the D3D11/GL equivalent buffer-allocation failure) **once**, and the deferred
+  2D/PBR content disappears for the rest of the run.
+- **After the fix:** no `id:52`, content persists, and GPU memory stays flat.
+
+A quick way to manufacture the load: take a 3D PBR example, draw a few hundred
+meshes (so layer count climbs) and overlay a large amount of 2D each frame, then
+let it run for ~30 s while watching stderr for buffer-allocation errors.

--- a/core/tests/sglLayerUpload/main.c
+++ b/core/tests/sglLayerUpload/main.c
@@ -1,0 +1,181 @@
+// =============================================================================
+// core/tests/sglLayerUpload — regression test for the sokol_gl "per-layer full
+// re-append" GPU vertex-buffer blow-up (fix/buffer-increase-bug).
+//
+// THE BUG: flushDeferredShaderDraws()/flushFboDeferredPbr() draw each sokol_gl
+// layer with sgl_(context_)draw_layer(). The TrussC fork's _sgl_draw() used
+// sg_append_buffer() and re-appended the ENTIRE vertex set on every call. With
+// N layers (one per deferred PBR/shader draw) and V vertices recorded, one frame
+// uploaded N*V vertices and grew the GPU buffer 2x at a time until the backend
+// refused the allocation (Metal: id:52 / METAL_CREATE_BUFFER_FAILED), killing
+// all sgl rendering. Root cause of the 2026-suzuki-rain fog vanishing.
+//
+// THE FIX: _sgl_draw() uploads the vertex set ONCE per frame and reuses the
+// returned base offset for the remaining layer draws (O(V), not O(N*V)).
+//
+// WHY THIS IS HEADLESS / GPU-LESS: it drives sokol_gl on SOKOL_DUMMY_BACKEND,
+// which has no GPU but tracks the exact accounting that blows up — append_pos
+// (bytes uploaded this frame) and the GPU buffer size. So the regression is
+// fully deterministic in CI. It is NOT a pixel/render-correctness test; that
+// still needs real Metal/D3D11/GL devices (see the project note).
+//
+// Compiled as a standalone target (NOT a TrussC project) precisely because it
+// must define its own SOKOL_IMPL with the dummy backend, which would clash with
+// libTrussC's platform-backend sokol implementation.
+//
+// Console, exit code = pass/fail (build_all.py runs it under --core-tests-only).
+// =============================================================================
+
+#define SOKOL_IMPL
+#define SOKOL_DUMMY_BACKEND
+#include "sokol_log.h"
+#include "sokol_gfx.h"
+#include "util/sokol_gl_tc.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int g_fail = 0;
+static void check(const char* name, bool ok) {
+    printf("%-60s %s\n", name, ok ? "PASS" : "FAIL");
+    fflush(stdout);
+    if (!ok) ++g_fail;
+}
+
+static const int STRIDE = (int)sizeof(_sgl_vertex_t);
+
+// --- helpers ---------------------------------------------------------------
+
+static void push_tris(int n_tris) {
+    sgl_begin_triangles();
+    for (int i = 0; i < n_tris; i++) {
+        sgl_v2f(0.0f, 0.0f);
+        sgl_v2f(1.0f, 0.0f);
+        sgl_v2f(0.0f, 1.0f);
+    }
+    sgl_end();
+}
+
+static size_t append_pos(sgl_context ctx_id) {
+    _sgl_context_t* ctx = _sgl_lookup_context(ctx_id.id);
+    return (size_t)sg_query_buffer_info(ctx->vbuf).append_pos;
+}
+static size_t gpu_size(sgl_context ctx_id) {
+    _sgl_context_t* ctx = _sgl_lookup_context(ctx_id.id);
+    return sg_query_buffer_desc(ctx->vbuf).size;
+}
+
+// Flush layers [0..maxLayer], mimicking flushDeferredShaderDraws().
+static void flush_layers(sgl_context ctx, int maxLayer) {
+    for (int L = 0; L <= maxLayer; L++) sgl_context_draw_layer(ctx, L);
+}
+
+// =============================================================================
+
+int main(void) {
+    sg_setup(&(sg_desc){ .environment = (sg_environment){0}, .logger.func = slog_func });
+    sgl_setup(&(sgl_desc_t){ .logger.func = slog_func });
+    sgl_context ctx = sgl_make_context(&(sgl_context_desc_t){
+        .max_vertices = 1<<16, .max_commands = 1<<14 });
+    sgl_set_context(ctx);
+
+    // -------------------------------------------------------------------------
+    // 1) The core regression: empty layers must NOT each re-upload all vertices.
+    //    Upload-per-frame must equal V (one upload), independent of layer count,
+    //    and the GPU buffer must stay bounded.
+    // -------------------------------------------------------------------------
+    {
+        const int fogTris = 1000;             // V = 3000 verts of "fog"
+        const size_t V = (size_t)fogTris * 3 * STRIDE;
+        bool oneUploadAllN = true;
+        bool bufDoesNotGrowWithN = true;
+        size_t bufAtSmallestN = 0;
+        int Ns[] = { 1, 10, 100, 600 };
+        for (int i = 0; i < 4; i++) {
+            int N = Ns[i];
+            sgl_layer(0);
+            push_tris(fogTris);
+            for (int L = 1; L <= N; L++) sgl_layer(L);   // N empty layers
+            flush_layers(ctx, N);
+            size_t pos = append_pos(ctx);
+            size_t buf = gpu_size(ctx);
+            printf("  [empty]   N=%4d  append_pos=%9zu (want %zu)  gpu_buf=%zu\n",
+                   N, pos, V, buf);
+            if (pos != V) oneUploadAllN = false;             // pre-fix: ~N*V
+            // The GPU buffer must NOT grow as layer count increases. Pre-fix it
+            // doubled every frame (2.5->5->10->...->GBs) until allocation failed.
+            if (i == 0) bufAtSmallestN = buf;
+            else if (buf > bufAtSmallestN) bufDoesNotGrowWithN = false;
+            sg_commit();                                     // frame boundary
+        }
+        check("empty layers: exactly one upload per frame (no N*V)", oneUploadAllN);
+        check("empty layers: GPU buffer does not grow with layer count", bufDoesNotGrowWithN);
+    }
+
+    // -------------------------------------------------------------------------
+    // 2) Non-empty layers: the single upload must cover the FULL accumulated
+    //    vertex set (fog + per-layer geometry), still exactly once.
+    // -------------------------------------------------------------------------
+    {
+        const int fogTris = 500, perLayerTris = 2, N = 300;
+        const size_t total = (size_t)(fogTris + N * perLayerTris) * 3 * STRIDE;
+        sgl_layer(0);
+        push_tris(fogTris);
+        for (int L = 1; L <= N; L++) { sgl_layer(L); push_tris(perLayerTris); }
+        flush_layers(ctx, N);
+        size_t pos = append_pos(ctx);
+        printf("  [nonempty] N=%d  append_pos=%zu (want %zu)\n", N, pos, total);
+        check("non-empty layers: one upload of the full vertex set", pos == total);
+        sg_commit();
+    }
+
+    // -------------------------------------------------------------------------
+    // 3) Next frame must RE-upload (cache keyed on frame_id; not stale, not 0).
+    // -------------------------------------------------------------------------
+    {
+        const int fogTris = 800;
+        const size_t V = (size_t)fogTris * 3 * STRIDE;
+        // frame A
+        sgl_layer(0); push_tris(fogTris);
+        for (int L = 1; L <= 50; L++) sgl_layer(L);
+        flush_layers(ctx, 50);
+        sg_commit();
+        // frame B
+        sgl_layer(0); push_tris(fogTris);
+        for (int L = 1; L <= 50; L++) sgl_layer(L);
+        flush_layers(ctx, 50);
+        size_t pos = append_pos(ctx);
+        printf("  [frame2]   append_pos=%zu (want %zu)\n", pos, V);
+        check("new frame re-uploads its vertices (not stale)", pos == V);
+        sg_commit();
+    }
+
+    // -------------------------------------------------------------------------
+    // 4) sgl_tc_context_reset() within a frame must invalidate the upload cache:
+    //    a fresh vertex set whose count coincides with the previous one must NOT
+    //    reuse the stale base offset (it must append again at a new offset).
+    // -------------------------------------------------------------------------
+    {
+        const int tris = 600;
+        const size_t C = (size_t)tris * 3 * STRIDE;
+        sgl_layer(0); push_tris(tris);
+        flush_layers(ctx, 0);
+        size_t pos1 = append_pos(ctx);                 // == C
+        sgl_tc_context_reset(ctx);                     // reset counters, same frame
+        sgl_layer(0); push_tris(tris);                 // SAME count as before
+        flush_layers(ctx, 0);
+        size_t pos2 = append_pos(ctx);                 // must have appended again
+        printf("  [reset]    pos1=%zu  pos2=%zu (want %zu)\n", pos1, pos2, 2 * C);
+        check("context reset invalidates cache (re-appends, no stale reuse)",
+              pos1 == C && pos2 == 2 * C);
+        sg_commit();
+    }
+
+    sgl_destroy_context(ctx);
+    sgl_shutdown();
+    sg_shutdown();
+
+    printf("\n%s (%d failure%s)\n", g_fail ? "FAILED" : "PASSED",
+           g_fail, g_fail == 1 ? "" : "s");
+    return g_fail ? 1 : 0;
+}

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -133,6 +133,25 @@ def find_core_tests(root_dir):
                 test_paths.append(tdir)
     return test_paths
 
+def find_core_unit_tests(root_dir):
+    # Standalone headless unit tests for the core: core/tests/*/ dirs that ship
+    # their OWN committed CMakeLists.txt (built with plain cmake, NOT trusscli).
+    # Used for tests that must compile sokol/etc. directly (e.g. with the dummy
+    # backend) and therefore cannot link libTrussC. Distinguished from trusscli
+    # project tests (which have a src/ dir and a generated, gitignored CMakeLists).
+    tests_dir = os.path.join(root_dir, "core", "tests")
+    test_paths = []
+    if os.path.exists(tests_dir):
+        for name in sorted(os.listdir(tests_dir)):
+            tdir = os.path.join(tests_dir, name)
+            # Standalone == committed CMakeLists.txt and no src/ (trusscli project
+            # tests have src/ and only a generated, gitignored CMakeLists.txt).
+            if (os.path.isdir(tdir)
+                    and os.path.exists(os.path.join(tdir, "CMakeLists.txt"))
+                    and not os.path.exists(os.path.join(tdir, "src"))):
+                test_paths.append(tdir)
+    return test_paths
+
 def find_test_binary(test_dir, platform_info):
     # trusscli names the binary after the project dir. addons/*/tests -> "tests";
     # core/tests/<name> -> "<name>". On macOS a TrussC app is
@@ -189,7 +208,34 @@ def build_and_run_test(test_dir, pg_bin, platform_info, args):
         return False, "run"
     return True, None
 
-def run_test_suite(tests, label, pg_bin, platform_info, args):
+def build_and_run_unit_test(test_dir, pg_bin, platform_info, args):
+    # Build a standalone CMake test (its own committed CMakeLists.txt, no
+    # trusscli), then RUN it (non-zero exit = failure). pg_bin is unused.
+    build_dir_name = platform_info["build_dir"]
+    cmd_config = ["cmake", "-S", ".", "-B", build_dir_name]
+    if platform_info["cmake_generator"]:
+        cmd_config.extend(["-G", platform_info["cmake_generator"]])
+    if not run_command(cmd_config, cwd=test_dir, verbose=args.verbose):
+        return False, "configure"
+
+    cmd_build = ["cmake", "--build", build_dir_name, "--config", "Release"]
+    if "Visual Studio" not in (platform_info["cmake_generator"] or ""):
+        import multiprocessing
+        cmd_build.extend(["-j", str(multiprocessing.cpu_count())])
+    if not run_command(cmd_build, cwd=test_dir, verbose=args.verbose):
+        return False, "build"
+
+    binary = find_test_binary(test_dir, platform_info)
+    if not binary:
+        Colors.print("  Test binary not found after build!", Colors.RED)
+        return False, "binary-missing"
+
+    Colors.print(f"  Running {os.path.relpath(binary, test_dir)} ...", Colors.YELLOW)
+    if not run_command([binary], cwd=test_dir, verbose=True):  # always stream test output
+        return False, "run"
+    return True, None
+
+def run_test_suite(tests, label, pg_bin, platform_info, args, builder=build_and_run_test):
     # Build AND run a set of console test projects (addon or core). Streams each
     # test's output; returns 0 if all pass, 1 if any fails.
     Colors.print(f"Found {len(tests)} {label} test harness(es)", Colors.YELLOW)
@@ -198,7 +244,7 @@ def run_test_suite(tests, label, pg_bin, platform_info, args):
     for i, tdir in enumerate(tests):
         name = os.path.relpath(tdir, ROOT_DIR)
         Colors.print(f"[{i+1}/{len(tests)}] Building & running: {name}", Colors.YELLOW)
-        ok, stage = build_and_run_test(tdir, pg_bin, platform_info, args)
+        ok, stage = builder(tdir, pg_bin, platform_info, args)
         if ok:
             Colors.print("  Passed!", Colors.GREEN)
         else:
@@ -264,12 +310,22 @@ def main():
         sys.exit(run_test_suite(tests, "addon", pg_bin, platform_info, args))
 
     # Core behavioral tests (core/tests/*/): same build+run gate, owned by core.
+    # Two flavours: trusscli project tests (src/, link libTrussC) and standalone
+    # CMake unit tests (committed CMakeLists.txt, no libTrussC link — e.g. sokol
+    # dummy-backend tests). Both run; the job fails if either has a failure.
     if args.core_tests_only:
         tests = find_core_tests(ROOT_DIR)
-        if not tests:
+        unit_tests = find_core_unit_tests(ROOT_DIR)
+        if not tests and not unit_tests:
             Colors.print("No core tests found (core/tests/*/); nothing to do.", Colors.YELLOW)
             sys.exit(0)
-        sys.exit(run_test_suite(tests, "core", pg_bin, platform_info, args))
+        rc = 0
+        if tests:
+            rc |= run_test_suite(tests, "core", pg_bin, platform_info, args)
+        if unit_tests:
+            rc |= run_test_suite(unit_tests, "core unit", pg_bin, platform_info, args,
+                                 builder=build_and_run_unit_test)
+        sys.exit(rc)
 
     if args.test_only:
         test_example = os.path.join(ROOT_DIR, "examples", "tests", "AllFeaturesExample")


### PR DESCRIPTION
## What

Fixes a sokol_gl GPU vertex-buffer blow-up that eventually kills all `sokol_gl` rendering.

`flushDeferredShaderDraws()` (swapchain) and `flushFboDeferredPbr()` (FBO) draw one `sokol_gl` **layer** per deferred PBR/shader draw, so a busy frame flushes many layers (N). The TrussC fork's `_sgl_draw()` used `sg_append_buffer()` and re-appended the **entire** recorded vertex set (V vertices) on *every* call — so one frame uploaded `N × V` vertices, and `_sgl_grow_gpu_buffer()` doubled the GPU buffer until the backend refused the allocation:

```
[sg][error][id:52] METAL_CREATE_BUFFER_FAILED
```

After that, the sgl context renders nothing for the rest of the run (deferred 2D / PBR content silently vanishes). Only scenes with both a high layer count and a non-trivial vertex count hit it.

## Fix

`_sgl_draw()` now uploads the vertex set **once per frame** and reuses the returned base offset for the remaining layer draws — `O(V)` instead of `O(N × V)`. The single-upload cache is keyed on `(frame_id, vertex count, vbuf id)`; invalidated on buffer recreate/grow and by `sgl_tc_context_reset()`.

Also: grow target uses `append_pos` instead of `buf_desc.size`; drop unused `vtx_offset`; documented as mod #10 in `TRUSSC_MODIFICATIONS.md`.

## Test

New `core/tests/sglLayerUpload/` — standalone, headless regression test on `SOKOL_DUMMY_BACKEND` (no GPU/window). Asserts one upload per frame regardless of layer count, buffer doesn't grow with N, full set uploaded, frames re-upload, reset invalidates cache. `build_all.py` extended to discover & run standalone CMake tests under `--core-tests-only` (CI, 3 OS). Not a render-correctness test — manual procedure in the test README.

## Verification

- Accounting (dummy backend): before N=600 → ×252 (28.8 MB), buffer 80 MB; after → ×1 (0.11 MB), flat 2.5 MB. Unfixed header FAILS 4/5, fixed PASSES 5/5.
- CI green on macOS / Windows / Linux.
- Real-device render verified by hand on Metal / D3D11 / GL (no `id:52`).
