### PR TITLE
feat: save/restore blend mode in pushStyle/popStyle

### DIFF
--- a/core/include/tc/graphics/tcRenderContext.h
+++ b/core/include/tc/graphics/tcRenderContext.h
@@ -253,6 +253,9 @@ public:
     // -----------------------------------------------------------------------
 
     void pushStyle() {
+        // Capture the live blend mode (it lives in internal::currentBlendMode, not in
+        // style_) so it is saved/restored alongside color/fill/stroke.
+        style_.blend = internal::currentBlendMode;
         styleStack_.push_back(style_);
     }
 
@@ -260,13 +263,28 @@ public:
         if (!styleStack_.empty()) {
             style_ = styleStack_.back();
             styleStack_.pop_back();
+            applyBlend(style_.blend);
         }
     }
 
     // Reset style to default values (white color, fill enabled, etc.)
     void resetStyle() {
         style_ = Style();
+        applyBlend(style_.blend);
     }
+
+private:
+    // Restore the 2D blend pipeline only when the mode actually changed (a redundant
+    // load is otherwise a no-op that sokol_gl batches away, but we skip it anyway).
+    // No-op inside an FBO pass, which uses its own accumulating pipeline.
+    void applyBlend(BlendMode mode) {
+        if (mode == internal::currentBlendMode) return;
+        internal::currentBlendMode = mode;
+        if (!internal::inFboPass) {
+            internal::loadPipeline(internal::active2D(mode));
+        }
+    }
+public:
 
     // Main implementation (Vec3)
     void translate(Vec3 pos) {
@@ -881,6 +899,10 @@ private:
         Direction textAlignH = Direction::Left;
         Direction textAlignV = Direction::Top;
         float bitmapLineHeight = bitmapfont::CHAR_TEX_HEIGHT;
+        // Mirror of internal::currentBlendMode. blend state itself lives outside the
+        // RenderContext (it maps to an sgl pipeline), so push/popStyle capture and
+        // restore it explicitly rather than via this field's value alone.
+        BlendMode blend = BlendMode::Alpha;
     };
 
     // Current style


### PR DESCRIPTION
## What
`pushStyle`/`popStyle` now save and restore the blend mode, matching
openFrameworks' `ofPushStyle`. `resetStyle` likewise resets blend to `Alpha`.

## Why
oF's `ofStyle` includes `blendingMode`, but TrussC's `Style` did not — blend
lived only in `internal::currentBlendMode`, outside the style stack. So a node
that set `BlendMode::Add` leaked it to siblings even when the caller wrapped the
draw in `pushStyle`/`popStyle`. blend was the only draw-style state living
outside `Style` (color/fill/stroke/cap/join/curve/textAlign were already saved).

## How
- Add `BlendMode blend` to `Style`.
- `pushStyle()` captures `internal::currentBlendMode` into the saved style.
- `popStyle()`/`resetStyle()` restore via a guarded `applyBlend()`: the 2D
  pipeline is reloaded only when the mode actually changed, and it's a no-op
  inside an FBO pass.
- `scissor` stays intentionally separate (different lifetime/use).

## Performance
The common per-node `Add → push → … → pop → Alpha` pattern stays cheap: the
guard skips unchanged restores, and a pipeline load with no draw between creates
no sokol_gl command, so consecutive `Add` nodes still collapse to a single GPU
pipeline bind.

## Behavior change
`pushStyle`/`popStyle` now include blend; `resetStyle` resets blend to `Alpha`.
Code relying on blend surviving these calls will see the new (oF-consistent)
behavior.

## Verification
- Builds: core + `blendingExample` (macOS).
- Windowed functional test (live swapchain): basic save/restore, nested
  push/pop, no-change no-op, and `resetStyle` reset — **7/7 pass**.
