### PR TITLE
fix: make StrokeMesh setters return *this for method chaining

### DIFF
--- a/core/include/tc/graphics/tcStrokeMesh.h
+++ b/core/include/tc/graphics/tcStrokeMesh.h
@@ -51,94 +51,105 @@ public:
     // Settings
     // =========================================================================
 
-    void setWidth(float width) {
+    StrokeMesh& setWidth(float width) {
         strokeWidth_ = width;
         bDirty_ = true;
+        return *this;
     }
 
-    void setColor(const Color& color) {
+    StrokeMesh& setColor(const Color& color) {
         strokeColor_ = color;
         bDirty_ = true;
+        return *this;
     }
 
-    void setCapType(CapType type) {
+    StrokeMesh& setCapType(CapType type) {
         capType_ = type;
         bDirty_ = true;
+        return *this;
     }
 
-    void setJoinType(JoinType type) {
+    StrokeMesh& setJoinType(JoinType type) {
         joinType_ = type;
         bDirty_ = true;
+        return *this;
     }
 
     // How much sharpness to allow with Miter Join
-    void setMiterLimit(float limit) {
+    StrokeMesh& setMiterLimit(float limit) {
         miterLimit_ = limit;
         bDirty_ = true;
+        return *this;
     }
 
     // =========================================================================
     // Input
     // =========================================================================
 
-    void addVertex(float x, float y, float z = 0) {
-        addVertex(Vec3{x, y, z});
+    StrokeMesh& addVertex(float x, float y, float z = 0) {
+        return addVertex(Vec3{x, y, z});
     }
 
-    void addVertex(const Vec3& p) {
+    StrokeMesh& addVertex(const Vec3& p) {
         if (polylines_.empty()) {
             polylines_.push_back(Path());
         }
         polylines_[0].addVertex(p);
         bDirty_ = true;
+        return *this;
     }
 
-    void addVertex(const Vec2& p) {
-        addVertex(Vec3{p.x, p.y, 0});
+    StrokeMesh& addVertex(const Vec2& p) {
+        return addVertex(Vec3{p.x, p.y, 0});
     }
 
     // Add vertex and width together (for variable width strokes)
-    void addVertexWithWidth(float x, float y, float width) {
-        addVertexWithWidth(Vec3{x, y, 0}, width);
+    StrokeMesh& addVertexWithWidth(float x, float y, float width) {
+        return addVertexWithWidth(Vec3{x, y, 0}, width);
     }
 
-    void addVertexWithWidth(const Vec3& p, float width) {
+    StrokeMesh& addVertexWithWidth(const Vec3& p, float width) {
         if (polylines_.empty()) {
             polylines_.push_back(Path());
         }
         polylines_[0].addVertex(p);
         widths_.push_back(width);
         bDirty_ = true;
+        return *this;
     }
 
     // Set width array directly
-    void setWidths(const std::vector<float>& w) {
+    StrokeMesh& setWidths(const std::vector<float>& w) {
         widths_ = w;
         bDirty_ = true;
+        return *this;
     }
 
     // Set and overwrite existing shape
-    void setShape(const Path& polyline) {
+    StrokeMesh& setShape(const Path& polyline) {
         polylines_.clear();
         polylines_.push_back(polyline);
         widths_.clear();
         bClosed_ = polyline.isClosed();
         bDirty_ = true;
+        return *this;
     }
 
     // Whether to make closed shape
-    void setClosed(bool closed) {
+    StrokeMesh& setClosed(bool closed) {
         bClosed_ = closed;
         bDirty_ = true;
+        return *this;
     }
 
     // Clear
-    void clear() {
+    StrokeMesh& clear() {
         polylines_.clear();
         polylines_.push_back(Path());
         widths_.clear();
         mesh_.clear();
         bDirty_ = true;
+        return *this;
     }
 
     // =========================================================================


### PR DESCRIPTION
## What
StrokeMesh's mutating setters now return `StrokeMesh&` instead of `void`, enabling the builder-style method chaining the API already advertises.

Affected: `setWidth`, `setColor`, `setCapType`, `setJoinType`, `setMiterLimit`, `addVertex` (all overloads), `addVertexWithWidth` (both), `setWidths`, `setShape`, `setClosed`, `clear`.

## Why
The setters returned `void`, which contradicted two things:
- `docs/api-definition.yaml` already declares these as `return: "StrokeMesh&"` with "(method chaining)" descriptions — so the docs promised chaining the implementation didn't provide.
- The project convention (CLAUDE.md): "Setters should return `*this` for method chaining where appropriate."

So `mesh.setColor(c).setWidth(4).addVertex(a).addVertex(b)` failed to compile despite being the documented usage. This makes the implementation match the contract.

## Compatibility
Source-compatible: returning a reference where `void` was returned does not break existing statement-form calls (`stroke.setCapType(...);`). No call sites depended on the `void` return.

## Verification
Built `examples/graphics/strokeMeshExample` (uses StrokeMesh extensively) on macOS — builds clean.