### PR TITLE
fix: make trusscli build --release work + fix trusscli build --web (#153)

### DIFF
--- a/tools/src/ProjectGenerator.cpp
+++ b/tools/src/ProjectGenerator.cpp
@@ -995,6 +995,13 @@ bool ProjectGenerator::runCrossCompilePresets(const string& path) {
     if (settings_.generateIosBuild) presets.push_back("ios");
 #endif
     if (settings_.generateAndroidBuild) presets.push_back("android");
+    // Web is a cross-compile target too: configure its build dir here so that
+    // `trusscli build --web` (and IDE tooling) has a ready build-web. Without
+    // this, update only configures the native preset and `cmake --build
+    // --preset web` fails with "build-web is not a directory". The web preset
+    // carries the Emscripten toolchainFile, so a plain `cmake --preset web`
+    // configures correctly without needing `emcmake`.
+    if (settings_.generateWebBuild) presets.push_back("web");
 
     // Map preset name to build directory
     auto getBuildDir = [](const string& preset) -> string {

--- a/tools/src/main.cpp
+++ b/tools/src/main.cpp
@@ -3132,6 +3132,23 @@ static int cmdClean(const vector<string>& args) {
 // Subcommand: build
 // =============================================================================
 
+// Read CMAKE_BUILD_TYPE from an existing CMake cache. Returns "" if the cache
+// (or the variable) is absent. Used to decide whether a reconfigure is needed
+// to change the build type on single-config generators.
+static string readCachedBuildType(const string& buildDir) {
+    ifstream cache(buildDir + "/CMakeCache.txt");
+    if (!cache) return "";
+    string line;
+    while (getline(cache, line)) {
+        // Format: CMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+        if (line.rfind("CMAKE_BUILD_TYPE:", 0) == 0) {
+            auto eq = line.find('=');
+            if (eq != string::npos) return line.substr(eq + 1);
+        }
+    }
+    return "";
+}
+
 static int cmdBuild(const vector<string>& args) {
     string explicitPath;
     string targetPreset;
@@ -3243,6 +3260,11 @@ static int cmdBuild(const vector<string>& args) {
 
     // cmake --build --preset <target> --parallel[=N] [--config Release] [--clean-first]
     vector<string> cmd = {cmake, "--build", "--preset", targetPreset, parallelArg};
+    // --config only affects multi-config generators (Xcode, Visual Studio). The
+    // native presets are single-config (Unix Makefiles / Ninja), where --config
+    // is silently ignored; there the build type is fixed at configure time by
+    // CMAKE_BUILD_TYPE, which we pin below. Kept here so --release also works on
+    // any future multi-config native preset.
     if (release) { cmd.push_back("--config"); cmd.push_back("Release"); }
     if (clean) cmd.push_back("--clean-first");
 
@@ -3250,16 +3272,43 @@ static int cmdBuild(const vector<string>& args) {
     string savedCwd = fs::current_path().string();
     fs::current_path(projectPath);
 
-    int rc = 0;
-    // --warnings: reconfigure the cache so trussc_app.cmake turns on -Wall/-Wextra
-    // for the app's own sources. `cmake --build` can't pass -D, so configure first.
-    // The cache var is sticky: it stays on for later builds until a configure
-    // without --warnings (or `trusscli update`) resets it.
+    // `cmake --build` cannot pass -D, so any cache change needs a configure pass
+    // (`cmake --preset`) first. Accumulate the flags and run it only if needed.
+    vector<string> cfg = {cmake, "--preset", targetPreset};
+    bool needConfigure = false;
+
+    // --warnings: turn on -Wall/-Wextra for the app's own sources. The cache var
+    // is sticky: it stays on for later builds until a configure without it (or
+    // `trusscli update`) resets it.
     if (warnings) {
         cout << "[warnings] Enabling -Wall -Wextra for this project's sources...\n";
-        vector<string> cfg = {cmake, "--preset", targetPreset, "-DTRUSSC_WARNINGS=ON"};
-        rc = runProcess(cfg);
+        cfg.push_back("-DTRUSSC_WARNINGS=ON");
+        needConfigure = true;
     }
+
+    // --release on a single-config native preset: the `--config Release` above is
+    // ignored, so pin the build type via CMAKE_BUILD_TYPE at configure time.
+    // Only manage the native preset — web/android bake their own build type
+    // (MinSizeRel / Release) into the preset and must keep it. We touch the cache
+    // only when it actually needs to change, so a plain build stays configure-free
+    // on the common path (no cache, or already the project default).
+    if (kNativePreset && targetPreset == kNativePreset) {
+        string cachedType = readCachedBuildType(string("build-") + targetPreset);
+        if (release && cachedType != "Release") {
+            cout << "[release] Configuring Release build (CMAKE_BUILD_TYPE=Release)...\n";
+            cfg.push_back("-DCMAKE_BUILD_TYPE=Release");
+            needConfigure = true;
+        } else if (!release && cachedType == "Release") {
+            // Undo a sticky Release left by a previous --release build so a plain
+            // build is never silently a Release build.
+            cout << "[release] Reverting to default RelWithDebInfo build...\n";
+            cfg.push_back("-DCMAKE_BUILD_TYPE=RelWithDebInfo");
+            needConfigure = true;
+        }
+    }
+
+    int rc = 0;
+    if (needConfigure) rc = runProcess(cfg);
     if (rc == 0) rc = runProcess(cmd);
     fs::current_path(savedCwd);
 


### PR DESCRIPTION
## Summary

Fixes #153. Two related `trusscli build` fixes.

### 1. `--release` was a no-op on all native platforms (8b931d81)

`--release` was implemented as `cmake --build --config Release`, which only
works on multi-config generators (Xcode, Visual Studio). Every native preset
is single-config (Unix Makefiles on macOS/Linux, Ninja on Windows), where
`--config` is silently ignored and the build type is fixed at configure time
by `CMAKE_BUILD_TYPE`. No native preset set it, so builds fell back to the
`RelWithDebInfo` default and `--release` did nothing (introduced in #34,
never functional).

Fix: pin the build type at configure time, mirroring the `--warnings`
reconfigure pattern.
- `--release` reconfigures with `-DCMAKE_BUILD_TYPE=Release`.
- The cache is read first, so the reconfigure runs only when the type
  actually changes — a steady-state plain build stays configure-free (fast path).
- A plain build after `--release` reverts a sticky `Release` back to
  `RelWithDebInfo`, so a normal build is never silently a Release build.
- Scoped to the native preset; web/android keep their baked build type.

### 2. `trusscli build --web` failed with "build-web is not a directory" (5fc09d46)

`update` configured only the native preset and the ios/android cross-compile
presets, never the web preset, while `cleanBuildDirectories` removes
`build-web` on every update. So the subsequent `cmake --build --preset web`
had nothing to build. Fix: treat web like the other cross-compile targets and
configure it in `runCrossCompilePresets`. The web preset carries the
Emscripten toolchainFile, so a plain `cmake --preset web` configures without
`emcmake`.

## Verification

| Check | macOS | Linux | Windows |
|---|---|---|---|
| `--release` (build type transition, revert, fast path, real optimized binary) | ✅ | ✅ | ✅ |
| `--web` (configure + end-to-end wasm/js/html build) | ✅ | ✅ | skipped (no Emscripten toolchain) |

`--release` confirmed at the compile-flag / binary level on all three:
e.g. Linux Release vs RelWithDebInfo — 2.86 MB vs 47.7 MB, `-O3 -DNDEBUG` vs
`-O2 -g -DNDEBUG`, no `.debug_info` vs present. Pre-fix bug reproduced on Linux
and Windows (Release request silently producing a Debug/RelWithDebInfo binary).

## Note (out of scope, separate issue)

On Windows/MSVC the fresh default build type is `Debug` (CMake's `project()`
seeds the cache before `trussc_app.cmake`'s `if(NOT CMAKE_BUILD_TYPE)` default
can apply), whereas macOS/Linux get `RelWithDebInfo`. This predates these
changes and is harmless here, but means Windows plain builds are unoptimized.
Worth fixing separately by setting `CMAKE_BUILD_TYPE` explicitly in the native
presets' `cacheVariables`.
