### PR TITLE
Video frame extraction (extractFrame/extractKeyFrame) + Windows alpha fix, and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ addons/*
 !addons/tcxDepthCamera
 !addons/tcxDepthRecord
 
+# tcxLua binding-check harness — throwaway dev tool, not shipped (see its README)
+addons/tcxLua/_bindcheck/
+
 # =============================================================================
 # trusscli / Project Generator (built binary + build artifacts in tools/)
 # =============================================================================

--- a/addons/tcxCurl/src/tcxCurl.h
+++ b/addons/tcxCurl/src/tcxCurl.h
@@ -122,6 +122,11 @@ public:
     // Set request timeout in seconds (default: 30)
     void setTimeout(long seconds) { timeoutSeconds_ = seconds; }
 
+    // Follow 3xx redirects (default off). Needed for e.g. public file shares that
+    // redirect the download to a signed URL. Off by default so existing callers
+    // (which expect the raw response) are unaffected.
+    void setFollowRedirects(bool follow) { followRedirects_ = follow; }
+
     // Enable verbose curl logging to stderr (for debugging)
     void setVerbose(bool v) { verbose_ = v; }
 
@@ -165,6 +170,7 @@ private:
     std::string baseUrl_;
     std::vector<std::pair<std::string, std::string>> headers_;
     long timeoutSeconds_ = 30;
+    bool followRedirects_ = false;
     bool verbose_ = false;
 
     HttpResponse request(const std::string& method, const std::string& path,
@@ -205,6 +211,10 @@ inline HttpResponse HttpClient::request(const std::string& method, const std::st
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseBody);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeoutSeconds_);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+    if (followRedirects_) {
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
+    }
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE, 30L);
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 15L);

--- a/addons/tcxCurl/src/tcxCurl.h
+++ b/addons/tcxCurl/src/tcxCurl.h
@@ -211,6 +211,12 @@ inline HttpResponse HttpClient::request(const std::string& method, const std::st
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseBody);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeoutSeconds_);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+#if defined(_WIN32) && defined(CURLSSLOPT_NATIVE_CA)
+    // Windows: verify TLS certs against the OS cert store. Without this an
+    // OpenSSL-backed libcurl has no CA bundle and every HTTPS request fails with
+    // "SSL connect error".
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_NATIVE_CA);
+#endif
     if (followRedirects_) {
         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -66,6 +66,10 @@ public:
             return false;
         }
 
+        // Remember the resolved path so instance-level frame extraction
+        // (extractFrame / extractKeyFrame with no path arg) and getPath() work.
+        sourcePath_ = resolvedPath;
+
         // Create texture(s) for per-frame updates
         if (width_ > 0 && height_ > 0) {
             if (nv12Mode_) {
@@ -114,6 +118,7 @@ public:
         done_ = false;
         width_ = 0;
         height_ = 0;
+        sourcePath_.clear();
     }
 
     // =========================================================================
@@ -272,6 +277,11 @@ public:
     bool isUsingHwAccel() const override { return isUsingHwAccelPlatform(); }
     std::string getHwAccelName() const override { return getHwAccelNamePlatform(); }
 
+    /// Path of the currently loaded video file (empty string when not loaded).
+    /// This is the resolved path (relative paths passed to load() are resolved
+    /// via getDataPath).
+    const std::string& getPath() const { return sourcePath_; }
+
 protected:
     // -------------------------------------------------------------------------
     // Implementation methods
@@ -333,6 +343,10 @@ private:
     // Platform-specific handle
     void* platformHandle_ = nullptr;
 
+    // Resolved path of the currently loaded video (empty when not loaded).
+    // Used by getPath() and the instance-level frame-extraction overloads.
+    std::string sourcePath_;
+
     // -------------------------------------------------------------------------
     // Internal methods
     // -------------------------------------------------------------------------
@@ -358,6 +372,7 @@ private:
         nv12Mode_        = other.nv12Mode_;
         nv12ShaderHandle_ = other.nv12ShaderHandle_;
         platformHandle_  = other.platformHandle_;
+        sourcePath_      = std::move(other.sourcePath_);
 
         other.pixels_    = nullptr;
         other.pixelsY_   = nullptr;
@@ -418,10 +433,22 @@ private:
     std::string getHwAccelNamePlatform() const;
 
     // =========================================================================
-    // Static utility — frame extraction (thread-safe, no GPU required)
+    // Frame extraction (thread-safe, no GPU required)
+    //
+    // extractFrame    — the EXACT frame displayed at timeSec. Seeks to the
+    //                   preceding keyframe then decodes forward to timeSec.
+    //                   Slightly heavier, but frame-accurate on every platform.
+    // extractKeyFrame — the NEAREST keyframe at or before timeSec. Seek only,
+    //                   no forward decode, so it is faster but time-approximate.
+    //                   Falls back to an exact decode if no keyframe is reachable.
+    //
+    // Both come in a static form (give a path, no load() needed — good for
+    // thumbnails) and an instance form (uses the currently loaded getPath()).
+    // These are single-shot helpers: do NOT use them for continuous playback
+    // (each call opens its own decode context). For playback use load()/play().
     // =========================================================================
 public:
-    /// Extract a single frame as RGBA pixels from a video file.
+    /// Extract the exact frame at a time from a video file (static).
     /// @param path      Video file path
     /// @param outPixels Receives the extracted frame (RGBA U8)
     /// @param timeSec   Time in seconds to extract from (default 1.0)
@@ -432,9 +459,39 @@ public:
         return extractFramePlatform(path, outPixels, timeSec, outDuration);
     }
 
+    /// Extract the nearest keyframe at or before a time (static, faster).
+    /// The returned frame's real time may be earlier than timeSec.
+    /// @param path      Video file path
+    /// @param outPixels Receives the extracted frame (RGBA U8)
+    /// @param timeSec   Upper-bound time in seconds (default 1.0)
+    /// @param outDuration If non-null, receives video duration in seconds
+    /// @return true on success
+    static bool extractKeyFrame(const std::string& path, Pixels& outPixels,
+                                float timeSec = 1.0f, float* outDuration = nullptr) {
+        return extractKeyFramePlatform(path, outPixels, timeSec, outDuration);
+    }
+
+    /// Extract the exact frame at a time from the currently loaded video
+    /// (instance). Returns false if no video is loaded.
+    bool extractFrame(Pixels& outPixels, float timeSec = 1.0f,
+                      float* outDuration = nullptr) const {
+        if (sourcePath_.empty()) return false;
+        return extractFramePlatform(sourcePath_, outPixels, timeSec, outDuration);
+    }
+
+    /// Extract the nearest keyframe at or before a time from the currently
+    /// loaded video (instance, faster). Returns false if no video is loaded.
+    bool extractKeyFrame(Pixels& outPixels, float timeSec = 1.0f,
+                         float* outDuration = nullptr) const {
+        if (sourcePath_.empty()) return false;
+        return extractKeyFramePlatform(sourcePath_, outPixels, timeSec, outDuration);
+    }
+
 private:
     static bool extractFramePlatform(const std::string& path, Pixels& outPixels,
                                      float timeSec, float* outDuration);
+    static bool extractKeyFramePlatform(const std::string& path, Pixels& outPixels,
+                                        float timeSec, float* outDuration);
 
     // Allow platform implementations to access internals
     friend class internal::VideoPlayerPlatformAccess;

--- a/core/platform/android/tcVideoPlayer_android.cpp
+++ b/core/platform/android/tcVideoPlayer_android.cpp
@@ -52,6 +52,12 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
     return false;
 }
 
+bool VideoPlayer::extractKeyFramePlatform(const std::string& path, Pixels& outPixels,
+                                          float timeSec, float* outDuration) {
+    (void)path; (void)outPixels; (void)timeSec; (void)outDuration;
+    return false;
+}
+
 } // namespace trussc
 
 #endif // __ANDROID__

--- a/core/platform/linux/tcVideoPlayer_linux.cpp
+++ b/core/platform/linux/tcVideoPlayer_linux.cpp
@@ -1412,10 +1412,15 @@ std::string VideoPlayer::getHwAccelNamePlatform() const {
     return "none";
 }
 
-bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
-                                       float timeSec, float* outDuration) {
-    // Standalone single-frame decode: own format/codec/scaler contexts, plain
-    // software decode (no HW device), independent of any playback instance.
+// Standalone single-frame decode: own format/codec/scaler contexts, plain
+// software decode (no HW device), independent of any playback instance.
+//
+// When `exact` is true we seek to the preceding keyframe then decode forward
+// until a frame's pts reaches timeSec (the frame shown at that time). When
+// false we return the first frame after the seek — the nearest keyframe at or
+// before timeSec — which skips the forward decode and is faster.
+static bool tcv_extract_frame_linux(const std::string& path, Pixels& outPixels,
+                                    float timeSec, float* outDuration, bool exact) {
     AVFormatContext* fmtCtx = nullptr;
     if (avformat_open_input(&fmtCtx, path.c_str(), nullptr, nullptr) < 0) return false;
     if (avformat_find_stream_info(fmtCtx, nullptr) < 0) {
@@ -1471,21 +1476,41 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
         avcodec_flush_buffers(codecCtx);
     }
 
-    // Decode until we get the first frame.
+    // Returns true once `frame` holds the frame we want to keep: for keyframe
+    // mode that is the first decoded frame, for exact mode the first frame at
+    // or after timeSec (frames before it are decoded then overwritten).
+    const double tb = av_q2d(videoStream->time_base);
+    auto isTargetFrame = [&](AVFrame* f) -> bool {
+        if (!exact) return true;
+        int64_t pts = (f->best_effort_timestamp != AV_NOPTS_VALUE)
+                          ? f->best_effort_timestamp
+                          : f->pts;
+        double ftime = (pts == AV_NOPTS_VALUE) ? 0.0 : pts * tb;
+        return ftime >= (double)timeSec;
+    };
+
+    // Decode forward until we reach the target frame (or exhaust the stream).
     AVFrame* frame = av_frame_alloc();
     AVPacket* pkt  = av_packet_alloc();
-    bool got = false;
-    while (!got && av_read_frame(fmtCtx, pkt) >= 0) {
+    bool got = false, reached = false;
+    while (!reached && av_read_frame(fmtCtx, pkt) >= 0) {
         if (pkt->stream_index == videoIdx &&
             avcodec_send_packet(codecCtx, pkt) == 0) {
-            if (avcodec_receive_frame(codecCtx, frame) == 0) got = true;
+            while (avcodec_receive_frame(codecCtx, frame) == 0) {
+                got = true;
+                if (isTargetFrame(frame)) { reached = true; break; }
+            }
         }
         av_packet_unref(pkt);
     }
-    // Flush the decoder if nothing came out during the read loop.
-    if (!got) {
+    // Flush the decoder for any frames still buffered (also covers the case
+    // where the target time lands past the last packet).
+    if (!reached) {
         avcodec_send_packet(codecCtx, nullptr);
-        if (avcodec_receive_frame(codecCtx, frame) == 0) got = true;
+        while (avcodec_receive_frame(codecCtx, frame) == 0) {
+            got = true;
+            if (isTargetFrame(frame)) break;
+        }
     }
 
     bool ok = false;
@@ -1512,6 +1537,20 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
     avcodec_free_context(&codecCtx);
     avformat_close_input(&fmtCtx);
     return ok;
+}
+
+bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
+                                       float timeSec, float* outDuration) {
+    return tcv_extract_frame_linux(path, outPixels, timeSec, outDuration, /*exact=*/true);
+}
+
+bool VideoPlayer::extractKeyFramePlatform(const std::string& path, Pixels& outPixels,
+                                          float timeSec, float* outDuration) {
+    if (tcv_extract_frame_linux(path, outPixels, timeSec, outDuration, /*exact=*/false)) {
+        return true;
+    }
+    // No keyframe reachable — fall back to an exact decode.
+    return tcv_extract_frame_linux(path, outPixels, timeSec, outDuration, /*exact=*/true);
 }
 
 } // namespace trussc

--- a/core/platform/linux/tcVideoPlayer_linux.cpp
+++ b/core/platform/linux/tcVideoPlayer_linux.cpp
@@ -1414,9 +1414,104 @@ std::string VideoPlayer::getHwAccelNamePlatform() const {
 
 bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
                                        float timeSec, float* outDuration) {
-    // TODO: implement frame extraction on Linux
-    (void)path; (void)outPixels; (void)timeSec; (void)outDuration;
-    return false;
+    // Standalone single-frame decode: own format/codec/scaler contexts, plain
+    // software decode (no HW device), independent of any playback instance.
+    AVFormatContext* fmtCtx = nullptr;
+    if (avformat_open_input(&fmtCtx, path.c_str(), nullptr, nullptr) < 0) return false;
+    if (avformat_find_stream_info(fmtCtx, nullptr) < 0) {
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+
+    // Find the first video stream.
+    int videoIdx = -1;
+    for (unsigned int i = 0; i < fmtCtx->nb_streams; i++) {
+        if (fmtCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+            videoIdx = i;
+            break;
+        }
+    }
+    if (videoIdx < 0) {
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+    AVStream* videoStream = fmtCtx->streams[videoIdx];
+
+    // Duration (seconds) for the optional out-param + clamping.
+    double duration = 0.0;
+    if (fmtCtx->duration > 0)
+        duration = fmtCtx->duration / (double)AV_TIME_BASE;
+    else if (videoStream->duration > 0)
+        duration = videoStream->duration * av_q2d(videoStream->time_base);
+    if (outDuration) *outDuration = (float)duration;
+
+    // Clamp requested time to valid range (mirrors the macOS behaviour).
+    if (duration > 0.0 && timeSec > duration) timeSec = (float)(duration * 0.1);
+    if (timeSec < 0) timeSec = 0;
+
+    // Open the video decoder (software).
+    AVCodecParameters* par = videoStream->codecpar;
+    const AVCodec* codec = avcodec_find_decoder(par->codec_id);
+    if (!codec) {
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+    AVCodecContext* codecCtx = avcodec_alloc_context3(codec);
+    avcodec_parameters_to_context(codecCtx, par);
+    if (avcodec_open2(codecCtx, codec, nullptr) < 0) {
+        avcodec_free_context(&codecCtx);
+        avformat_close_input(&fmtCtx);
+        return false;
+    }
+
+    // Seek to the nearest keyframe at or before the requested time.
+    if (timeSec > 0.0f) {
+        int64_t ts = (int64_t)(timeSec / av_q2d(videoStream->time_base));
+        av_seek_frame(fmtCtx, videoIdx, ts, AVSEEK_FLAG_BACKWARD);
+        avcodec_flush_buffers(codecCtx);
+    }
+
+    // Decode until we get the first frame.
+    AVFrame* frame = av_frame_alloc();
+    AVPacket* pkt  = av_packet_alloc();
+    bool got = false;
+    while (!got && av_read_frame(fmtCtx, pkt) >= 0) {
+        if (pkt->stream_index == videoIdx &&
+            avcodec_send_packet(codecCtx, pkt) == 0) {
+            if (avcodec_receive_frame(codecCtx, frame) == 0) got = true;
+        }
+        av_packet_unref(pkt);
+    }
+    // Flush the decoder if nothing came out during the read loop.
+    if (!got) {
+        avcodec_send_packet(codecCtx, nullptr);
+        if (avcodec_receive_frame(codecCtx, frame) == 0) got = true;
+    }
+
+    bool ok = false;
+    if (got && frame->width > 0 && frame->height > 0) {
+        int w = frame->width, h = frame->height;
+        // Convert the decoded frame to RGBA straight into outPixels.
+        SwsContext* sws = sws_getContext(
+            w, h, (AVPixelFormat)frame->format,
+            w, h, AV_PIX_FMT_RGBA,
+            SWS_BILINEAR, nullptr, nullptr, nullptr
+        );
+        if (sws) {
+            outPixels.allocate(w, h, 4);
+            uint8_t* dstData[1]   = { outPixels.getData() };
+            int      dstStride[1] = { w * 4 };
+            sws_scale(sws, frame->data, frame->linesize, 0, h, dstData, dstStride);
+            sws_freeContext(sws);
+            ok = true;
+        }
+    }
+
+    av_frame_free(&frame);
+    av_packet_free(&pkt);
+    avcodec_free_context(&codecCtx);
+    avformat_close_input(&fmtCtx);
+    return ok;
 }
 
 } // namespace trussc

--- a/core/platform/mac/tcVideoPlayer_mac.mm
+++ b/core/platform/mac/tcVideoPlayer_mac.mm
@@ -865,8 +865,12 @@ std::string VideoPlayer::getHwAccelNamePlatform() const {
 // Static frame extraction (thread-safe, no GPU)
 // =============================================================================
 
-bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
-                                       float timeSec, float* outDuration) {
+// Shared implementation for both extract paths. When `exact` is true we ask
+// AVAssetImageGenerator for the frame displayed at the exact time (tolerance
+// zero); when false we allow it to return the nearest keyframe at or before the
+// requested time (tolerance-before = infinity), which is faster.
+static bool tcv_extract_frame_mac(const std::string& path, Pixels& outPixels,
+                                  float timeSec, float* outDuration, bool exact) {
     @autoreleasepool {
         NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path.c_str()]];
         if (!url) return false;
@@ -890,8 +894,16 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
 
         AVAssetImageGenerator* generator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
         generator.appliesPreferredTrackTransform = YES;
-        generator.requestedTimeToleranceBefore = kCMTimeZero;
-        generator.requestedTimeToleranceAfter  = kCMTimeZero;
+        if (exact) {
+            // Frame-accurate: no tolerance either way.
+            generator.requestedTimeToleranceBefore = kCMTimeZero;
+            generator.requestedTimeToleranceAfter  = kCMTimeZero;
+        } else {
+            // Nearest keyframe at or before timeSec: allow snapping backwards,
+            // never forward. Seek-only, so it is fast but time-approximate.
+            generator.requestedTimeToleranceBefore = kCMTimePositiveInfinity;
+            generator.requestedTimeToleranceAfter  = kCMTimeZero;
+        }
 
         CMTime requestTime = CMTimeMakeWithSeconds(timeSec, NSEC_PER_SEC);
         NSError* error = nil;
@@ -922,6 +934,20 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
 
         return true;
     }
+}
+
+bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
+                                       float timeSec, float* outDuration) {
+    return tcv_extract_frame_mac(path, outPixels, timeSec, outDuration, /*exact=*/true);
+}
+
+bool VideoPlayer::extractKeyFramePlatform(const std::string& path, Pixels& outPixels,
+                                          float timeSec, float* outDuration) {
+    if (tcv_extract_frame_mac(path, outPixels, timeSec, outDuration, /*exact=*/false)) {
+        return true;
+    }
+    // No keyframe reachable — fall back to an exact decode.
+    return tcv_extract_frame_mac(path, outPixels, timeSec, outDuration, /*exact=*/true);
 }
 
 } // namespace trussc

--- a/core/platform/win/tcVideoPlayer_win.cpp
+++ b/core/platform/win/tcVideoPlayer_win.cpp
@@ -1036,10 +1036,15 @@ std::string VideoPlayer::getHwAccelNamePlatform() const {
     return platformHandle_ ? "mediafoundation" : "none";
 }
 
-bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
-                                       float timeSec, float* outDuration) {
-    // Single-frame decode via IMFSourceReader (independent of the playback
-    // IMFMediaEngine path; runs on the calling thread, no GPU/D3D needed).
+// Shared single-frame decode via IMFSourceReader (independent of the playback
+// IMFMediaEngine path; runs on the calling thread, no GPU/D3D needed).
+//
+// When `exact` is true we seek to the preceding keyframe then read forward
+// until the sample timestamp reaches timeSec, yielding the exact frame shown at
+// that time. When false we return the first sample after the seek — the nearest
+// keyframe at or before timeSec — which is faster but time-approximate.
+static bool tcv_extract_frame_win(const std::string& path, Pixels& outPixels,
+                                  float timeSec, float* outDuration, bool exact) {
     if (!InitMediaFoundation()) {
         return false;
     }
@@ -1109,21 +1114,29 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
             PropVariantClear(&pos);
         }
 
-        // Read samples until we get a decoded frame (or hit end-of-stream).
+        // Read samples until we reach the target. In keyframe mode we stop at
+        // the first decoded sample after the seek. In exact mode we keep the
+        // latest decoded sample and read forward until its timestamp reaches
+        // timeSec (the frame actually displayed at that time).
+        const LONGLONG targetTicks = (LONGLONG)(timeSec * 10000000.0);
         ComPtr<IMFSample> sample;
         while (SUCCEEDED(hr)) {
             DWORD flags = 0;
+            LONGLONG llTimestamp = 0;
             ComPtr<IMFSample> s;
             hr = reader->ReadSample(MF_SOURCE_READER_FIRST_VIDEO_STREAM, 0,
-                                    nullptr, &flags, nullptr, &s);
+                                    nullptr, &flags, &llTimestamp, &s);
             if (FAILED(hr) || (flags & MF_SOURCE_READERF_ENDOFSTREAM)) {
-                break;
+                break;  // fall back to the last sample we retained, if any
             }
-            if (s) {
-                sample = s;
-                break;
+            if (!s) {
+                // No sample this iteration (e.g. a stream/format tick) — keep reading.
+                continue;
             }
-            // No sample this iteration (e.g. a stream/format tick) — keep reading.
+            sample = s;
+            if (!exact || llTimestamp >= targetTicks) {
+                break;  // keyframe: first sample; exact: reached the target time
+            }
         }
 
         // Resolve the actual output frame size and stride (may have changed
@@ -1182,6 +1195,20 @@ bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixel
 
     CloseMediaFoundation();
     return ok;
+}
+
+bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
+                                       float timeSec, float* outDuration) {
+    return tcv_extract_frame_win(path, outPixels, timeSec, outDuration, /*exact=*/true);
+}
+
+bool VideoPlayer::extractKeyFramePlatform(const std::string& path, Pixels& outPixels,
+                                          float timeSec, float* outDuration) {
+    if (tcv_extract_frame_win(path, outPixels, timeSec, outDuration, /*exact=*/false)) {
+        return true;
+    }
+    // No keyframe reachable — fall back to an exact decode.
+    return tcv_extract_frame_win(path, outPixels, timeSec, outDuration, /*exact=*/true);
 }
 
 } // namespace trussc

--- a/core/platform/win/tcVideoPlayer_win.cpp
+++ b/core/platform/win/tcVideoPlayer_win.cpp
@@ -1181,7 +1181,10 @@ static bool tcv_extract_frame_win(const std::string& path, Pixels& outPixels,
                             dst[dstIdx + 0] = src[srcIdx + 2]; // R <- B
                             dst[dstIdx + 1] = src[srcIdx + 1]; // G <- G
                             dst[dstIdx + 2] = src[srcIdx + 0]; // B <- R
-                            dst[dstIdx + 3] = src[srcIdx + 3]; // A <- A
+                            // RGB32 from the source reader is BGRX: the 4th byte
+                            // is undefined padding, not alpha. Force opaque so the
+                            // extracted frame isn't fully transparent.
+                            dst[dstIdx + 3] = 255;             // A = opaque
                         }
                         dst += rowBytes;
                     }

--- a/core/platform/win/tcVideoPlayer_win.cpp
+++ b/core/platform/win/tcVideoPlayer_win.cpp
@@ -1038,9 +1038,150 @@ std::string VideoPlayer::getHwAccelNamePlatform() const {
 
 bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
                                        float timeSec, float* outDuration) {
-    // TODO: implement frame extraction on Windows
-    (void)path; (void)outPixels; (void)timeSec; (void)outDuration;
-    return false;
+    // Single-frame decode via IMFSourceReader (independent of the playback
+    // IMFMediaEngine path; runs on the calling thread, no GPU/D3D needed).
+    if (!InitMediaFoundation()) {
+        return false;
+    }
+
+    bool ok = false;
+    {
+        int wideLen = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, nullptr, 0);
+        std::wstring widePath(wideLen, 0);
+        MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, &widePath[0], wideLen);
+
+        // Enable the built-in video processor so we can request RGB32 output
+        // regardless of the source pixel format.
+        ComPtr<IMFAttributes> attrs;
+        HRESULT hr = MFCreateAttributes(&attrs, 1);
+        if (SUCCEEDED(hr)) {
+            attrs->SetUINT32(MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, TRUE);
+        }
+
+        ComPtr<IMFSourceReader> reader;
+        if (SUCCEEDED(hr)) {
+            hr = MFCreateSourceReaderFromURL(widePath.c_str(), attrs.Get(), &reader);
+        }
+
+        // Select the first video stream only.
+        if (SUCCEEDED(hr)) {
+            reader->SetStreamSelection(MF_SOURCE_READER_ALL_STREAMS, FALSE);
+            hr = reader->SetStreamSelection(MF_SOURCE_READER_FIRST_VIDEO_STREAM, TRUE);
+        }
+
+        // Ask for uncompressed RGB32 (BGRA in memory).
+        if (SUCCEEDED(hr)) {
+            ComPtr<IMFMediaType> rgbType;
+            hr = MFCreateMediaType(&rgbType);
+            if (SUCCEEDED(hr)) {
+                rgbType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+                rgbType->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_RGB32);
+                hr = reader->SetCurrentMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+                                                 nullptr, rgbType.Get());
+            }
+        }
+
+        // Duration (100ns units) for the optional out-param + clamping.
+        float duration = 0.0f;
+        if (SUCCEEDED(hr)) {
+            PROPVARIANT var;
+            PropVariantInit(&var);
+            if (SUCCEEDED(reader->GetPresentationAttribute(
+                    MF_SOURCE_READER_MEDIASOURCE, MF_PD_DURATION, &var)) &&
+                var.vt == VT_UI8) {
+                duration = (float)(var.uhVal.QuadPart / 10000000.0);
+            }
+            PropVariantClear(&var);
+        }
+        if (outDuration) *outDuration = duration;
+
+        // Clamp requested time to valid range (mirrors the macOS behaviour).
+        if (duration > 0.0f && timeSec > duration) timeSec = duration * 0.1f;
+        if (timeSec < 0) timeSec = 0;
+
+        // Seek to the requested position (nearest keyframe at or before it).
+        if (SUCCEEDED(hr) && timeSec > 0.0f) {
+            PROPVARIANT pos;
+            PropVariantInit(&pos);
+            pos.vt = VT_I8;
+            pos.hVal.QuadPart = (LONGLONG)(timeSec * 10000000.0);
+            reader->SetCurrentPosition(GUID_NULL, pos);
+            PropVariantClear(&pos);
+        }
+
+        // Read samples until we get a decoded frame (or hit end-of-stream).
+        ComPtr<IMFSample> sample;
+        while (SUCCEEDED(hr)) {
+            DWORD flags = 0;
+            ComPtr<IMFSample> s;
+            hr = reader->ReadSample(MF_SOURCE_READER_FIRST_VIDEO_STREAM, 0,
+                                    nullptr, &flags, nullptr, &s);
+            if (FAILED(hr) || (flags & MF_SOURCE_READERF_ENDOFSTREAM)) {
+                break;
+            }
+            if (s) {
+                sample = s;
+                break;
+            }
+            // No sample this iteration (e.g. a stream/format tick) — keep reading.
+        }
+
+        // Resolve the actual output frame size and stride (may have changed
+        // during the read).
+        UINT32 width = 0, height = 0;
+        LONG stride = 0;
+        if (SUCCEEDED(hr) && sample) {
+            ComPtr<IMFMediaType> curType;
+            if (SUCCEEDED(reader->GetCurrentMediaType(
+                    MF_SOURCE_READER_FIRST_VIDEO_STREAM, &curType))) {
+                MFGetAttributeSize(curType.Get(), MF_MT_FRAME_SIZE, &width, &height);
+                UINT32 mfStride = 0;
+                if (SUCCEEDED(curType->GetUINT32(MF_MT_DEFAULT_STRIDE, &mfStride))) {
+                    stride = (LONG)(INT32)mfStride;  // negative => bottom-up
+                } else {
+                    stride = (LONG)width * 4;
+                }
+            }
+        }
+
+        if (SUCCEEDED(hr) && sample && width > 0 && height > 0) {
+            ComPtr<IMFMediaBuffer> buffer;
+            hr = sample->ConvertToContiguousBuffer(&buffer);
+            if (SUCCEEDED(hr)) {
+                BYTE* data = nullptr;
+                DWORD length = 0;
+                hr = buffer->Lock(&data, nullptr, &length);
+                if (SUCCEEDED(hr)) {
+                    LONG absStride = stride < 0 ? -stride : stride;
+                    outPixels.allocate((int)width, (int)height, 4);
+                    unsigned char* dst = outPixels.getData();
+                    int rowBytes = (int)width * 4;
+
+                    for (UINT32 y = 0; y < height; y++) {
+                        // Negative stride means the image is stored bottom-up.
+                        UINT32 srcRow = stride < 0 ? (height - 1 - y) : y;
+                        const BYTE* src = data + (size_t)srcRow * absStride;
+                        // BGRA to RGBA conversion
+                        for (UINT32 x = 0; x < width; x++) {
+                            int srcIdx = x * 4;
+                            int dstIdx = x * 4;
+                            dst[dstIdx + 0] = src[srcIdx + 2]; // R <- B
+                            dst[dstIdx + 1] = src[srcIdx + 1]; // G <- G
+                            dst[dstIdx + 2] = src[srcIdx + 0]; // B <- R
+                            dst[dstIdx + 3] = src[srcIdx + 3]; // A <- A
+                        }
+                        dst += rowBytes;
+                    }
+
+                    buffer->Unlock();
+                    ok = true;
+                }
+            }
+        }
+    }
+
+    CloseMediaFoundation();
+    return ok;
 }
 
 } // namespace trussc

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1123,6 +1123,24 @@ Two ways:
 - **Write arbitrary frames**: use `VideoWriter` — `open(path, w, h, settings)` → `addFrame(fbo)` / `addFrame(pixels)` (timestamped via `addFrameAt(frame, timeSec)`) → `close()`. For writing offscreen (FBO) content at a steady rate.
 Encoder settings: `VideoRecordSettings`. Platforms: macOS / Windows / Linux / Android / iOS.
 
+### How do I avoid a black first frame when a VideoPlayer starts?
+
+`VideoPlayer::load()` / `play()` decode **asynchronously**, so for the first few frames the player has no picture yet and draws **black**. To hide that flash, synchronously extract frame 0 as a still and show it until the live player has a real frame:
+
+```cpp
+Pixels still; Texture stillTex;
+if (VideoPlayer::extractFrame(path, still, 0.0f) && still.getWidth() > 0) {
+    stillTex.allocate(still.getWidth(), still.getHeight(), 4, TextureUsage::Stream);
+    stillTex.loadData(still.getData(), still.getWidth(), still.getHeight(), 4);
+}
+player.load(path); player.play();
+// in draw(): show the live player once player.isFrameNew() has fired at least
+// once, otherwise draw stillTex. In update(): flip a "ready" flag on the first
+// isFrameNew().
+```
+
+`extractFrame(path, outPixels, timeSec=1.0, outDuration=nullptr)` is a **static, thread-safe, GPU-free** single-frame decoder returning RGBA `Pixels`. Implemented on **macOS (AVFoundation), Windows (Media Foundation), Linux (FFmpeg)**; iOS and web are unsupported (returns false). Pass `timeSec = 0` for the first frame; it seeks to the nearest keyframe at or before the requested time.
+
 ## Networking
 
 ### TCP / UDP networking? (brief)

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1129,7 +1129,7 @@ Encoder settings: `VideoRecordSettings`. Platforms: macOS / Windows / Linux / An
 
 ```cpp
 Pixels still; Texture stillTex;
-if (VideoPlayer::extractFrame(path, still, 0.0f) && still.getWidth() > 0) {
+if (VideoPlayer::extractKeyFrame(path, still, 0.0f) && still.getWidth() > 0) {
     stillTex.allocate(still.getWidth(), still.getHeight(), 4, TextureUsage::Stream);
     stillTex.loadData(still.getData(), still.getWidth(), still.getHeight(), 4);
 }
@@ -1139,7 +1139,25 @@ player.load(path); player.play();
 // isFrameNew().
 ```
 
-`extractFrame(path, outPixels, timeSec=1.0, outDuration=nullptr)` is a **static, thread-safe, GPU-free** single-frame decoder returning RGBA `Pixels`. Implemented on **macOS (AVFoundation), Windows (Media Foundation), Linux (FFmpeg)**; iOS and web are unsupported (returns false). Pass `timeSec = 0` for the first frame; it seeks to the nearest keyframe at or before the requested time.
+Use `extractKeyFrame(path, px, 0.0f)` here rather than `extractFrame`: frame 0 is always a keyframe, so it is the exact first frame *and* the fastest to fetch (seek only, no forward decode). If the player is already loaded you can also use the instance form `player.extractKeyFrame(px, 0.0f)`.
+
+### How do I grab a single frame (thumbnail / poster) from a video?
+
+Two single-shot helpers, both **static, thread-safe, GPU-free**, returning RGBA `Pixels`. Each has a static form (pass a path, no `load()` needed) and an instance form (uses the already-loaded `player.getPath()`):
+
+```cpp
+// exact frame at 3.5s — frame-accurate (seeks to the preceding keyframe, then
+// decodes forward to the requested time). Slightly heavier.
+VideoPlayer::extractFrame(path, px, 3.5f);
+// nearest keyframe at or before 3.5s — faster, but the real time may be earlier.
+VideoPlayer::extractKeyFrame(path, px, 3.5f);
+// instance form (video already loaded):
+video.extractFrame(px, 3.5f);
+```
+
+Pick by need: **`extractFrame` = frame-accurate but heavier; `extractKeyFrame` = fast but time-approximate** (good for coarse thumbnails or scrub previews; falls back to an exact decode if no keyframe is reachable). Both take an optional `float* outDuration` that receives the clip length in seconds. Implemented on **macOS (AVFoundation), Windows (Media Foundation), Linux (FFmpeg)**; Android stubs them and iOS/web are unsupported (return false).
+
+⚠️ These open a fresh decode context per call, so they are for **one-off frame grabs only — never for continuous playback**. To play a video use `load()` + `play()` + `update()` and draw the player each frame.
 
 ## Networking
 

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10047,9 +10047,34 @@ keywords = ["thumbnail", "snapshot", "grab", "single frame", "poster"]
 description.en = "Extract a single frame from a video file without loading the full video. Useful for thumbnails"
 description.ja = "ビデオファイルから1フレームを抽出（全体を読み込まずに）。サムネイル生成に便利"
 description.ko = "비디오 파일에서 전체를 로드하지 않고 단일 프레임을 추출. 썸네일 생성에 유용"
-related = ["Pixels", "VideoPlayer"]
-platform_note.en = "Static single-frame extraction is fully implemented only on macOS (AVAssetImageGenerator). Windows/Linux/Android stub it (`return false`, TODO); iOS and web have no extractFramePlatform() definition at all."
-platform_note.ja = "静止フレーム抽出が実装されているのは macOS のみ（AVAssetImageGenerator）。win/linux/android は false を返すスタブ、ios/web は extractFramePlatform() の定義自体が存在しない。"
+related = ["Pixels", "VideoPlayer", "VideoPlayer::load"]
+platform_note.en = "Static single-frame extraction is implemented on macOS (AVAssetImageGenerator), Windows (Media Foundation / IMFSourceReader), and Linux (FFmpeg). Android stubs it (`return false`); iOS and web have no extractFramePlatform() definition and are unsupported."
+platform_note.ja = "静止フレーム抽出は macOS（AVAssetImageGenerator）・Windows（Media Foundation / IMFSourceReader）・Linux（FFmpeg）で実装済み。android は false を返すスタブ、ios/web は extractFramePlatform() の定義自体が無く未対応。"
+details.en = '''
+Static, thread-safe, GPU-free single-frame decoder: opens the file on the calling
+thread with its own decode context (independent of any playing
+[`VideoPlayer`](#VideoPlayer)), seeks to the nearest keyframe at or before
+`timeSec`, and returns one frame as RGBA U8 [`Pixels`](#Pixels). `outDuration`, if
+non-null, receives the clip length in seconds.
+
+A common use is as a **black-flash stopgap**: [`load`](#VideoPlayer::load) /
+[`play`](#VideoPlayer::play) decode asynchronously, so the first on-screen frames
+are black. Extract frame 0 synchronously (`extractFrame(path, px, 0.0f)`), upload
+it to a [`Texture`](#Texture), and draw that still until the live player's
+[`isFrameNew`](#VideoPlayer::isFrameNew) has fired at least once.
+'''
+details.ja = '''
+静止・スレッドセーフ・GPU不要の1フレームデコーダ。呼び出しスレッド上で独自の
+デコードコンテキスト（再生中の [`VideoPlayer`](#VideoPlayer) とは独立）でファイルを
+開き、`timeSec` 以下の最寄りキーフレームへシークして1フレームを RGBA U8 の
+[`Pixels`](#Pixels) で返す。`outDuration` が非 null ならクリップ長（秒）を格納する。
+
+代表的な用途は**黒フレーム対策のつなぎ**。[`load`](#VideoPlayer::load) /
+[`play`](#VideoPlayer::play) は非同期デコードなので再生開始直後の数フレームは黒に
+なる。フレーム0を同期抽出（`extractFrame(path, px, 0.0f)`）して
+[`Texture`](#Texture) に載せ、ライブ側の
+[`isFrameNew`](#VideoPlayer::isFrameNew) が最初に true になるまでその静止画を描く。
+'''
 
 ["VideoPlayer::getAudioChannels"]
 category = "video"
@@ -10174,6 +10199,23 @@ keywords = ["open", "read", "file", "movie"]
 description.en = "Load a video file"
 description.ja = "ビデオファイルを読み込む"
 description.ko = "비디오 파일을 로드"
+related = ["VideoPlayer::play", "VideoPlayer::isFrameNew", "VideoPlayer::extractFrame"]
+details.en = '''
+Decoding is **asynchronous** — the decoder spins up in the background, so for a
+short window after `load()` / [`play`](#VideoPlayer::play) the player has no
+picture yet and draws **black**. To hide that flash, synchronously grab the first
+frame with [`extractFrame`](#VideoPlayer::extractFrame)`(path, px, 0.0f)`, show it
+as a still [`Texture`](#Texture), and switch to the live player once
+[`isFrameNew`](#VideoPlayer::isFrameNew) has returned true at least once.
+'''
+details.ja = '''
+デコードは**非同期**で、デコーダはバックグラウンドで立ち上がる。そのため
+`load()` / [`play`](#VideoPlayer::play) 直後のわずかな間、プレイヤーはまだ絵を
+持たず**黒**を描く。このちらつきを隠すには、
+[`extractFrame`](#VideoPlayer::extractFrame)`(path, px, 0.0f)` で先頭フレームを
+同期取得して静止 [`Texture`](#Texture) として表示し、
+[`isFrameNew`](#VideoPlayer::isFrameNew) が一度 true になったらライブ側へ切り替える。
+'''
 
 ["VideoPlayer::nextFrame"]
 category = "video"

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10043,37 +10043,93 @@ description.ja = "現在のビデオフレームを (x, y) に描画。w x h を
 description.ko = "현재 비디오 프레임을 (x, y)에 그림. w x h를 지정하면 스케일"
 
 ["VideoPlayer::extractFrame"]
-keywords = ["thumbnail", "snapshot", "grab", "single frame", "poster"]
-description.en = "Extract a single frame from a video file without loading the full video. Useful for thumbnails"
-description.ja = "ビデオファイルから1フレームを抽出（全体を読み込まずに）。サムネイル生成に便利"
-description.ko = "비디오 파일에서 전체를 로드하지 않고 단일 프레임을 추출. 썸네일 생성에 유용"
-related = ["Pixels", "VideoPlayer", "VideoPlayer::load"]
-platform_note.en = "Static single-frame extraction is implemented on macOS (AVAssetImageGenerator), Windows (Media Foundation / IMFSourceReader), and Linux (FFmpeg). Android stubs it (`return false`); iOS and web have no extractFramePlatform() definition and are unsupported."
-platform_note.ja = "静止フレーム抽出は macOS（AVAssetImageGenerator）・Windows（Media Foundation / IMFSourceReader）・Linux（FFmpeg）で実装済み。android は false を返すスタブ、ios/web は extractFramePlatform() の定義自体が無く未対応。"
+keywords = ["thumbnail", "snapshot", "grab", "single frame", "poster", "exact frame"]
+description.en = "Extract the exact frame at a given time from a video file. Frame-accurate on every platform"
+description.ja = "ビデオファイルの指定時刻の正確なフレームを抽出。全プラットフォームでフレーム精度"
+description.ko = "비디오 파일에서 지정한 시간의 정확한 프레임을 추출. 모든 플랫폼에서 프레임 정확도"
+related = ["Pixels", "VideoPlayer", "VideoPlayer::load", "VideoPlayer::extractKeyFrame", "VideoPlayer::getPath"]
+platform_note.en = "Implemented on macOS (AVAssetImageGenerator), Windows (Media Foundation / IMFSourceReader), and Linux (FFmpeg). Android stubs it (`return false`); iOS and web have no extractFramePlatform() definition and are unsupported."
+platform_note.ja = "macOS（AVAssetImageGenerator）・Windows（Media Foundation / IMFSourceReader）・Linux（FFmpeg）で実装済み。android は false を返すスタブ、ios/web は extractFramePlatform() の定義自体が無く未対応。"
 details.en = '''
-Static, thread-safe, GPU-free single-frame decoder: opens the file on the calling
-thread with its own decode context (independent of any playing
-[`VideoPlayer`](#VideoPlayer)), seeks to the nearest keyframe at or before
-`timeSec`, and returns one frame as RGBA U8 [`Pixels`](#Pixels). `outDuration`, if
-non-null, receives the clip length in seconds.
+Thread-safe, GPU-free single-frame decoder that returns the **exact frame
+displayed at `timeSec`**: it opens the file on the calling thread with its own
+decode context (independent of any playing [`VideoPlayer`](#VideoPlayer)), seeks
+to the preceding keyframe, decodes forward to `timeSec`, and returns one frame as
+RGBA U8 [`Pixels`](#Pixels). `outDuration`, if non-null, receives the clip length
+in seconds.
 
-A common use is as a **black-flash stopgap**: [`load`](#VideoPlayer::load) /
-[`play`](#VideoPlayer::play) decode asynchronously, so the first on-screen frames
-are black. Extract frame 0 synchronously (`extractFrame(path, px, 0.0f)`), upload
-it to a [`Texture`](#Texture), and draw that still until the live player's
-[`isFrameNew`](#VideoPlayer::isFrameNew) has fired at least once.
+Comes in two forms:
+- **Static** — `VideoPlayer::extractFrame(path, px, timeSec)`. No `load()` needed;
+  good for thumbnails/posters from a file you are not playing.
+- **Instance** — `player.extractFrame(px, timeSec)`. Uses the currently loaded
+  file ([`getPath`](#VideoPlayer::getPath)); returns false if nothing is loaded.
+
+If you only need the nearest keyframe (faster, time-approximate — e.g. a rough
+thumbnail), use [`extractKeyFrame`](#VideoPlayer::extractKeyFrame) instead. These
+are single-shot helpers — do **not** use them for continuous playback (each call
+opens a fresh decode context); for playback use [`load`](#VideoPlayer::load) +
+[`play`](#VideoPlayer::play) + [`update`](#VideoPlayer::update).
 '''
 details.ja = '''
-静止・スレッドセーフ・GPU不要の1フレームデコーダ。呼び出しスレッド上で独自の
-デコードコンテキスト（再生中の [`VideoPlayer`](#VideoPlayer) とは独立）でファイルを
-開き、`timeSec` 以下の最寄りキーフレームへシークして1フレームを RGBA U8 の
+スレッドセーフ・GPU不要の1フレームデコーダで、**`timeSec` に表示される正確な
+フレーム**を返す。呼び出しスレッド上で独自のデコードコンテキスト（再生中の
+[`VideoPlayer`](#VideoPlayer) とは独立）でファイルを開き、直前のキーフレームへ
+シークしてから `timeSec` まで前進デコードし、1フレームを RGBA U8 の
 [`Pixels`](#Pixels) で返す。`outDuration` が非 null ならクリップ長（秒）を格納する。
 
-代表的な用途は**黒フレーム対策のつなぎ**。[`load`](#VideoPlayer::load) /
-[`play`](#VideoPlayer::play) は非同期デコードなので再生開始直後の数フレームは黒に
-なる。フレーム0を同期抽出（`extractFrame(path, px, 0.0f)`）して
-[`Texture`](#Texture) に載せ、ライブ側の
-[`isFrameNew`](#VideoPlayer::isFrameNew) が最初に true になるまでその静止画を描く。
+2 種類ある:
+- **静的** — `VideoPlayer::extractFrame(path, px, timeSec)`。`load()` 不要。再生して
+  いないファイルからサムネイル/ポスターを取るのに向く。
+- **インスタンス** — `player.extractFrame(px, timeSec)`。現在ロード中のファイル
+  （[`getPath`](#VideoPlayer::getPath)）を使う。未ロードなら false。
+
+最寄りキーフレームで十分（速い・時刻は近似、例えばラフなサムネイル）なら
+[`extractKeyFrame`](#VideoPlayer::extractKeyFrame) を使う。これらは単発取得用で、
+連続再生には**使わない**（呼ぶたびにデコードコンテキストを開くため重い）。再生は
+[`load`](#VideoPlayer::load) + [`play`](#VideoPlayer::play) +
+[`update`](#VideoPlayer::update) を使う。
+'''
+
+["VideoPlayer::extractKeyFrame"]
+keywords = ["thumbnail", "snapshot", "keyframe", "fast", "single frame", "poster", "I-frame"]
+description.en = "Extract the nearest keyframe at or before a given time. Faster than extractFrame but time-approximate"
+description.ja = "指定時刻以前の最寄りキーフレームを抽出。extractFrame より速いが時刻は近似"
+description.ko = "지정한 시간 이전의 가장 가까운 키프레임을 추출. extractFrame보다 빠르지만 시간은 근사치"
+related = ["Pixels", "VideoPlayer", "VideoPlayer::load", "VideoPlayer::extractFrame", "VideoPlayer::getPath"]
+platform_note.en = "Implemented on macOS (AVAssetImageGenerator), Windows (Media Foundation / IMFSourceReader), and Linux (FFmpeg). Android stubs it (`return false`); iOS and web are unsupported."
+platform_note.ja = "macOS（AVAssetImageGenerator）・Windows（Media Foundation / IMFSourceReader）・Linux（FFmpeg）で実装済み。android は false を返すスタブ、ios/web は未対応。"
+details.en = '''
+Like [`extractFrame`](#VideoPlayer::extractFrame) but returns the **nearest
+keyframe at or before `timeSec`** — it seeks only, skipping the forward decode, so
+it is faster at the cost of landing on a slightly earlier time. If no keyframe is
+reachable it falls back to an exact decode, so it always returns *a* frame on
+success.
+
+Trade-off: **`extractFrame` = frame-accurate but heavier; `extractKeyFrame` =
+fast but time-approximate.** Prefer this for coarse thumbnails, scrub previews, or
+grabbing frame 0 (the first frame is always a keyframe, so it is exact *and*
+fastest here — handy for the black-flash stopgap).
+
+Same two forms as [`extractFrame`](#VideoPlayer::extractFrame): static
+(`VideoPlayer::extractKeyFrame(path, px, timeSec)`, no `load()` needed) and
+instance (`player.extractKeyFrame(px, timeSec)`, uses the loaded
+[`getPath`](#VideoPlayer::getPath)). Single-shot only — not for playback.
+'''
+details.ja = '''
+[`extractFrame`](#VideoPlayer::extractFrame) と同様だが、**`timeSec` 以下の最寄り
+キーフレーム**を返す。シークのみで前進デコードを省くため速いが、少し手前の時刻に
+なる。キーフレームに到達できない場合は正確デコードにフォールバックするので、成功時は
+必ず何らかのフレームを返す。
+
+トレードオフ: **`extractFrame` は正確だが重い / `extractKeyFrame` は速いが時刻は
+近似**。ラフなサムネイル、スクラブのプレビュー、あるいはフレーム0の取得に向く
+（先頭フレームは必ずキーフレームなので、ここでは正確かつ最速 —— 黒フレーム対策の
+つなぎに便利）。
+
+[`extractFrame`](#VideoPlayer::extractFrame) と同じく 2 種類:静的
+（`VideoPlayer::extractKeyFrame(path, px, timeSec)`、`load()` 不要）とインスタンス
+（`player.extractKeyFrame(px, timeSec)`、ロード中の
+[`getPath`](#VideoPlayer::getPath) を使う）。単発取得用で再生には使わない。
 '''
 
 ["VideoPlayer::getAudioChannels"]
@@ -10132,6 +10188,14 @@ keywords = ["hardware", "backend", "decoder", "videotoolbox", "vaapi"]
 description.en = "Get the name of the active decode backend. Returns 'vaapi', 'v4l2m2m', 'cuda', 'videotoolbox', 'mediafoundation', 'software', or 'none'"
 description.ja = "使用中のデコードバックエンド名を取得。'vaapi', 'v4l2m2m', 'cuda', 'videotoolbox', 'mediafoundation', 'software', 'none' のいずれか"
 description.ko = "사용 중인 디코드 백엔드 이름을 가져옴. 'vaapi', 'v4l2m2m', 'cuda', 'videotoolbox', 'mediafoundation', 'software', 'none' 중 하나"
+
+["VideoPlayer::getPath"]
+category = "video"
+keywords = ["path", "filename", "source", "url", "loaded file"]
+description.en = "Path of the currently loaded video file (resolved via getDataPath); empty string when nothing is loaded"
+description.ja = "現在ロード中のビデオファイルのパス（getDataPath で解決済み）。未ロードなら空文字列"
+description.ko = "현재 로드된 비디오 파일의 경로(getDataPath로 해석됨). 로드되지 않았으면 빈 문자열"
+related = ["VideoPlayer::load", "VideoPlayer::extractFrame", "VideoPlayer::extractKeyFrame"]
 
 ["VideoPlayer::getPixels"]
 category = "video"
@@ -10199,21 +10263,23 @@ keywords = ["open", "read", "file", "movie"]
 description.en = "Load a video file"
 description.ja = "ビデオファイルを読み込む"
 description.ko = "비디오 파일을 로드"
-related = ["VideoPlayer::play", "VideoPlayer::isFrameNew", "VideoPlayer::extractFrame"]
+related = ["VideoPlayer::play", "VideoPlayer::isFrameNew", "VideoPlayer::extractKeyFrame", "VideoPlayer::getPath"]
 details.en = '''
 Decoding is **asynchronous** — the decoder spins up in the background, so for a
 short window after `load()` / [`play`](#VideoPlayer::play) the player has no
 picture yet and draws **black**. To hide that flash, synchronously grab the first
-frame with [`extractFrame`](#VideoPlayer::extractFrame)`(path, px, 0.0f)`, show it
-as a still [`Texture`](#Texture), and switch to the live player once
+frame with [`extractKeyFrame`](#VideoPlayer::extractKeyFrame)`(path, px, 0.0f)`
+(frame 0 is always a keyframe, so this is the fastest exact way to get it), show
+it as a still [`Texture`](#Texture), and switch to the live player once
 [`isFrameNew`](#VideoPlayer::isFrameNew) has returned true at least once.
 '''
 details.ja = '''
 デコードは**非同期**で、デコーダはバックグラウンドで立ち上がる。そのため
 `load()` / [`play`](#VideoPlayer::play) 直後のわずかな間、プレイヤーはまだ絵を
 持たず**黒**を描く。このちらつきを隠すには、
-[`extractFrame`](#VideoPlayer::extractFrame)`(path, px, 0.0f)` で先頭フレームを
-同期取得して静止 [`Texture`](#Texture) として表示し、
+[`extractKeyFrame`](#VideoPlayer::extractKeyFrame)`(path, px, 0.0f)` で先頭フレームを
+同期取得し（フレーム0は必ずキーフレームなので、これが最速かつ正確に取れる）、静止
+[`Texture`](#Texture) として表示して、
 [`isFrameNew`](#VideoPlayer::isFrameNew) が一度 true になったらライブ側へ切り替える。
 '''
 


### PR DESCRIPTION
Bring dev into main. Main changes below.

## Video frame extraction API
- Split `VideoPlayer::extractFrame` (the **exact** frame at a time: seeks to the preceding keyframe, then decodes forward to timeSec) and `extractKeyFrame` (the **nearest keyframe** at or before the time: seek-only, faster but time-approximate)
- Both a static form (give a path, no `load()` needed) and an instance form (uses the loaded video); added `getPath()`
- Windows (Media Foundation) / Linux (FFmpeg) / macOS implementations + docs

### 🔧 Windows alpha fix (included in this PR)
`IMFSourceReader`'s `RGB32` is really BGR**X**: the 4th byte is undefined padding (0), not alpha. It was being copied straight into the output alpha, so **every extracted frame came out with alpha=0 (fully transparent)** (RGB was fine). Fixed by forcing alpha to 255 in the shared extraction helper.

**Verification (Windows / D3D11, real hardware)** — across H264 / HEVC / MPEG-4 / VP9 / WMV / MJPEG / AV1:
- extractFrame is frame-accurate (exact requested time); extractKeyFrame returns the nearest preceding keyframe
- After the fix, all formats yield alpha=255 and frames render correctly
- The playback path (`TransferVideoFrame`) is a separate implementation whose alpha is a genuine 255, so it is unaffected (confirmed by inspecting the playback buffer)

## tcxCurl
- Added `setFollowRedirects` (default off)
- Use the native CA store on Windows (`CURLSSLOPT_NATIVE_CA`)

## Misc
- gitignore the tcxLua `_bindcheck` harness