### PR TITLE
Code review fixes: stale docs, deprecated API in examples, Deliver::Main listener lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspired by openFrameworks, implemented simply with modern C++.
 - **Lightweight**: Minimal dependencies, built on sokol
 - **Header-only**: Most features are header-only
 - **C++20**: Leverages modern C++ features
-- **Cross-platform**: macOS 14+ (Metal), Windows (D3D11), Web (WebGPU). Linux/Raspberry Pi planned.
+- **Cross-platform**: macOS 14+ (Metal), Windows (D3D11), Linux (OpenGL), Raspberry Pi (GLES3), Web (WebGPU), Android (GLES3)
 - **oF-like API**: Familiar design for openFrameworks users
 
 ## Quick Start

--- a/core/include/tc/events/tcEvent.h
+++ b/core/include/tc/events/tcEvent.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <vector>
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <type_traits>
@@ -94,6 +95,13 @@ namespace priority {
 //     (onReceive); input events that use `consumed` already fire on the main
 //     thread, where Main is a no-op anyway.
 //   - Requires T to be copy-constructible (enforced by static_assert).
+//   - Listener lifetime is honored across the marshal boundary: a call queued
+//     for next frame re-checks the listener's liveness token when it runs, so
+//     it is dropped if the EventListener was destroyed (or removeListener /
+//     clear() ran) while it sat in the queue. The RAII guarantee — "after the
+//     listener dies, the callback never runs" — holds for Deliver::Main.
+//     (Raw runOnMainThread(fn) has no such token; there the captured object's
+//     lifetime is the caller's responsibility.)
 //
 // Scoped enum on purpose: it does NOT convert to int, so listen(fn, Deliver)
 // and the existing listen(fn, int priority) overloads never collide.
@@ -176,6 +184,12 @@ private:
         int priority;
         Deliver deliver;
         Callback callback;
+        // Liveness token, shared by every COW snapshot of this entry. A
+        // marshalled Deliver::Main call holds a weak_ptr and re-checks the
+        // VALUE at drain time: removeListener/clear() flip it to false, which
+        // also covers queued calls whose snapshot is still held by an
+        // in-flight notify() on another thread (weak expiry alone would not).
+        std::shared_ptr<std::atomic<bool>> alive;
     };
 
     using EntryList = std::vector<Entry>;
@@ -190,7 +204,8 @@ private:
             ConstEntryListPtr cur = std::atomic_load(&entries_);
             auto next = cur ? std::make_shared<EntryList>(*cur)
                             : std::make_shared<EntryList>();
-            next->push_back({id, priority, deliver, std::move(callback)});
+            next->push_back({id, priority, deliver, std::move(callback),
+                             std::make_shared<std::atomic<bool>>(true)});
             std::stable_sort(next->begin(), next->end(),
                 [](const Entry& a, const Entry& b) {
                     return a.priority < b.priority;
@@ -225,7 +240,12 @@ public:
             if (entry.deliver == Deliver::Main && !isMainThread()) {
                 if constexpr (std::is_copy_constructible_v<T>) {
                     T copy = arg;
-                    runOnMainThread([cb = entry.callback, copy]() mutable {
+                    runOnMainThread([cb = entry.callback, copy,
+                                     w = std::weak_ptr<std::atomic<bool>>(entry.alive)]() mutable {
+                        // Listener died while this call sat in the queue —
+                        // drop it (keeps the EventListener RAII guarantee).
+                        auto alive = w.lock();
+                        if (!alive || !alive->load()) return;
                         cb(copy);
                     });
                     continue;
@@ -256,6 +276,11 @@ public:
     // Remove all listeners
     void clear() {
         TC_LOCK_GUARD(mutex_);
+        ConstEntryListPtr cur = std::atomic_load(&entries_);
+        if (cur) {
+            // Invalidate queued Deliver::Main calls too
+            for (const auto& e : *cur) if (e.alive) e.alive->store(false);
+        }
         std::atomic_store(&entries_, ConstEntryListPtr{});
     }
 
@@ -264,12 +289,16 @@ private:
         TC_LOCK_GUARD(mutex_);
         ConstEntryListPtr cur = std::atomic_load(&entries_);
         if (!cur) return;
-        auto next = std::make_shared<EntryList>(*cur);
-        next->erase(
-            std::remove_if(next->begin(), next->end(),
-                [id](const Entry& e) { return e.id == id; }),
-            next->end()
-        );
+        auto next = std::make_shared<EntryList>();
+        next->reserve(cur->size());
+        for (const auto& e : *cur) {
+            if (e.id == id) {
+                // Invalidate queued Deliver::Main calls too
+                if (e.alive) e.alive->store(false);
+            } else {
+                next->push_back(e);
+            }
+        }
         std::atomic_store(&entries_, ConstEntryListPtr(next));
     }
 
@@ -354,6 +383,8 @@ private:
         int priority;
         Deliver deliver;
         Callback callback;
+        // Liveness token — see Event<T>::Entry::alive
+        std::shared_ptr<std::atomic<bool>> alive;
     };
 
     using EntryList = std::vector<Entry>;
@@ -368,7 +399,8 @@ private:
             ConstEntryListPtr cur = std::atomic_load(&entries_);
             auto next = cur ? std::make_shared<EntryList>(*cur)
                             : std::make_shared<EntryList>();
-            next->push_back({id, priority, deliver, std::move(callback)});
+            next->push_back({id, priority, deliver, std::move(callback),
+                             std::make_shared<std::atomic<bool>>(true)});
             std::stable_sort(next->begin(), next->end(),
                 [](const Entry& a, const Entry& b) {
                     return a.priority < b.priority;
@@ -397,7 +429,13 @@ public:
             // Deliver::Main from a worker thread: run on the main thread next
             // frame (no payload to copy for Event<void>).
             if (entry.deliver == Deliver::Main && !isMainThread()) {
-                runOnMainThread(entry.callback);
+                runOnMainThread([cb = entry.callback,
+                                 w = std::weak_ptr<std::atomic<bool>>(entry.alive)]() {
+                    // Listener died while this call sat in the queue — drop it
+                    auto alive = w.lock();
+                    if (!alive || !alive->load()) return;
+                    cb();
+                });
                 continue;
             }
             {
@@ -413,6 +451,11 @@ public:
 
     void clear() {
         TC_LOCK_GUARD(mutex_);
+        ConstEntryListPtr cur = std::atomic_load(&entries_);
+        if (cur) {
+            // Invalidate queued Deliver::Main calls too
+            for (const auto& e : *cur) if (e.alive) e.alive->store(false);
+        }
         std::atomic_store(&entries_, ConstEntryListPtr{});
     }
 
@@ -421,12 +464,16 @@ private:
         TC_LOCK_GUARD(mutex_);
         ConstEntryListPtr cur = std::atomic_load(&entries_);
         if (!cur) return;
-        auto next = std::make_shared<EntryList>(*cur);
-        next->erase(
-            std::remove_if(next->begin(), next->end(),
-                [id](const Entry& e) { return e.id == id; }),
-            next->end()
-        );
+        auto next = std::make_shared<EntryList>();
+        next->reserve(cur->size());
+        for (const auto& e : *cur) {
+            if (e.id == id) {
+                // Invalidate queued Deliver::Main calls too
+                if (e.alive) e.alive->store(false);
+            } else {
+                next->push_back(e);
+            }
+        }
         std::atomic_store(&entries_, ConstEntryListPtr(next));
     }
 

--- a/core/include/tc/graphics/tcRenderContext.h
+++ b/core/include/tc/graphics/tcRenderContext.h
@@ -9,12 +9,12 @@
 //
 // Usage:
 //   // Global functions (same as before)
-//   setColor(255, 0, 0);
+//   setColor(1.0, 0.0, 0.0);
 //   drawRect(10, 10, 100, 100);
 //
 //   // Explicit context (for future use)
 //   auto& ctx = getDefaultContext();
-//   ctx.setColor(255, 0, 0);
+//   ctx.setColor(1.0, 0.0, 0.0);
 //   ctx.drawRect(10, 10, 100, 100);
 //
 // =============================================================================

--- a/core/include/tc/network/tcTcpClient.h
+++ b/core/include/tc/network/tcTcpClient.h
@@ -74,6 +74,18 @@ class TC_PLATFORMS("macos,windows,linux,android,ios") TcpClient {
 public:
     // -------------------------------------------------------------------------
     // Events
+    //
+    // THREADING: with threading enabled (default), these events fire on the
+    // internal receive/connect threads, not the main thread. A listener that
+    // touches the Node tree, GPU resources, or unguarded app state must opt
+    // into main-thread delivery:
+    //
+    //   listener = client.onReceive.listen(fn, Deliver::Main);
+    //
+    // Deliver::Main copies the payload and runs the listener at the start of
+    // the next frame (see tcEvent.h). Plain listen(fn) runs inline on the
+    // firing thread. With setUseThread(false) everything runs on the main
+    // thread and this does not apply.
     // -------------------------------------------------------------------------
     Event<TcpConnectEventArgs> onConnect;       // On connection complete
     Event<TcpReceiveEventArgs> onReceive;       // On data receive

--- a/core/include/tc/network/tcTcpServer.h
+++ b/core/include/tc/network/tcTcpServer.h
@@ -91,6 +91,17 @@ class TC_PLATFORMS("macos,windows,linux,android") TcpServer {
 public:
     // -------------------------------------------------------------------------
     // Events
+    //
+    // THREADING: TcpServer always runs internal accept/receive threads, so
+    // these events fire on those threads, not the main thread. A listener that
+    // touches the Node tree, GPU resources, or unguarded app state must opt
+    // into main-thread delivery:
+    //
+    //   listener = server.onReceive.listen(fn, Deliver::Main);
+    //
+    // Deliver::Main copies the payload and runs the listener at the start of
+    // the next frame (see tcEvent.h). Plain listen(fn) runs inline on the
+    // firing thread — fastest, but you handle the synchronization.
     // -------------------------------------------------------------------------
     Event<TcpClientConnectEventArgs> onClientConnect;       // On client connect
     Event<TcpServerReceiveEventArgs> onReceive;             // On data receive

--- a/core/include/tc/network/tcUdpSocket.h
+++ b/core/include/tc/network/tcUdpSocket.h
@@ -51,6 +51,21 @@ struct UdpErrorEventArgs {
 class TC_PLATFORMS("macos,windows,linux,android,ios") UdpSocket {
 public:
     // Events
+    //
+    // THREADING: when the receive thread is active (bind() default), onReceive
+    // fires ON THE RECEIVE THREAD, not the main thread. onError fires on
+    // whichever thread the failing call ran on (receive thread for receive
+    // errors, the caller's thread for send/bind/connect errors). A listener
+    // that touches the Node tree, GPU resources, or unguarded app state must
+    // opt into main-thread delivery:
+    //
+    //   listener = socket.onReceive.listen(fn, Deliver::Main);
+    //
+    // Deliver::Main copies the payload and runs the listener at the start of
+    // the next frame (see tcEvent.h). Plain listen(fn) runs inline on the
+    // receive thread — fastest, but you handle the synchronization.
+    // With setUseThread(false) everything runs on the main thread and this
+    // does not apply.
     Event<UdpReceiveEventArgs> onReceive;   // On data receive
     Event<UdpErrorEventArgs> onError;       // On error
 

--- a/core/tests/threadSafety/src/main.cpp
+++ b/core/tests/threadSafety/src/main.cpp
@@ -122,6 +122,75 @@ int main() {
         check("Event Deliver::Main: every listener ran on main", allOnMain.load());
     }
 
+    // --- 3b. Deliver::Main honors listener lifetime across the queue ---
+    // A marshalled call sits in the main-thread queue for up to a frame. If the
+    // EventListener dies in that window, the queued call must be dropped —
+    // otherwise it runs a callback whose captures (typically `this`) dangle.
+    {
+        // Listener destroyed between notify() and drain
+        {
+            Event<int> ev;
+            atomic<int> ran{0};
+            {
+                auto L = ev.listen([&](int&) { ran.fetch_add(1); }, Deliver::Main);
+                thread t([&] { int v = 1; ev.notify(v); });   // queues the call
+                t.join();
+            }   // L destroyed here, queued call still pending
+            internal::drainMainThreadQueue();
+            check("Deliver::Main: queued call dropped after listener death", ran.load() == 0);
+        }
+
+        // clear() between notify() and drain
+        {
+            Event<int> ev;
+            atomic<int> ran{0};
+            auto L = ev.listen([&](int&) { ran.fetch_add(1); }, Deliver::Main);
+            thread t([&] { int v = 1; ev.notify(v); });
+            t.join();
+            ev.clear();
+            internal::drainMainThreadQueue();
+            check("Deliver::Main: queued call dropped after clear()", ran.load() == 0);
+        }
+
+        // Event itself destroyed between notify() and drain
+        {
+            atomic<int> ran{0};
+            EventListener L;
+            {
+                Event<int> ev;
+                L = ev.listen([&](int&) { ran.fetch_add(1); }, Deliver::Main);
+                thread t([&] { int v = 1; ev.notify(v); });
+                t.join();
+            }   // ev destroyed, queued call still pending
+            internal::drainMainThreadQueue();
+            check("Deliver::Main: queued call dropped after Event death", ran.load() == 0);
+        }
+
+        // Event<void>: listener destroyed between notify() and drain
+        {
+            Event<void> ev;
+            atomic<int> ran{0};
+            {
+                auto L = ev.listen([&] { ran.fetch_add(1); }, Deliver::Main);
+                thread t([&] { ev.notify(); });
+                t.join();
+            }
+            internal::drainMainThreadQueue();
+            check("Deliver::Main (void): queued call dropped after listener death", ran.load() == 0);
+        }
+
+        // Positive control: listener still alive at drain → call runs
+        {
+            Event<int> ev;
+            atomic<int> ran{0};
+            auto L = ev.listen([&](int&) { ran.fetch_add(1); }, Deliver::Main);
+            thread t([&] { int v = 1; ev.notify(v); });
+            t.join();
+            internal::drainMainThreadQueue();
+            check("Deliver::Main: queued call runs while listener alive", ran.load() == 1);
+        }
+    }
+
     // --- 4. Headless runtime stress: worker marshals tree edits, no crash ---
     {
         g_stop.store(false);

--- a/examples/graphics/clippingExample/src/tcApp.cpp
+++ b/examples/graphics/clippingExample/src/tcApp.cpp
@@ -33,7 +33,7 @@ void tcApp::setup() {
         circle->vy = 1.0f + i * 0.4f;
         circle->boundsWidth = innerBox_->getWidth();
         circle->boundsHeight = innerBox_->getHeight();
-        circle->color = colorFromHSB(i * 0.15f, 0.7f, 0.9f);
+        circle->color = Color::fromHSB(i * 0.15f, 0.7f, 0.9f);
         innerBox_->addChild(circle);
         circles_.push_back(circle);
     }

--- a/examples/graphics/strokeMeshExample/src/tcApp.cpp
+++ b/examples/graphics/strokeMeshExample/src/tcApp.cpp
@@ -33,7 +33,7 @@ void tcApp::setup() {
 
             // Color variation (change hue with HSB)
             float hue = (cap * 3 + join) * 0.07f;
-            stroke.setColor(colorFromHSB(hue, 0.78f, 1.0f));
+            stroke.setColor(Color::fromHSB(hue, 0.78f, 1.0f));
 
             stroke.update();
             strokes.push_back(stroke);
@@ -59,7 +59,7 @@ void tcApp::setup() {
         stroke.setShape(star);
         stroke.setWidth(strokeWidth);
         stroke.setJoinType((StrokeMesh::JoinType)cap);
-        stroke.setColor(colorFromHSB(0.55f + cap * 0.05f, 0.78f, 1.0f));
+        stroke.setColor(Color::fromHSB(0.55f + cap * 0.05f, 0.78f, 1.0f));
         stroke.update();
 
         closedStrokes.push_back(stroke);

--- a/examples/input_output/screenshotExample/src/tcApp.cpp
+++ b/examples/input_output/screenshotExample/src/tcApp.cpp
@@ -33,7 +33,7 @@ void tcApp::draw() {
 
         // Change hue
         float hue = float(i) / numCircles;
-        Color c = colorFromHSB(hue, 0.8f, 1.0f);
+        Color c = Color::fromHSB(hue, 0.8f, 1.0f);
         setColor(c);
 
         float circleRadius = 30.0f + sin(time * 2.0f + i) * 10.0f;

--- a/examples/network/tcpExample/src/tcApp.cpp
+++ b/examples/network/tcpExample/src/tcApp.cpp
@@ -19,18 +19,21 @@ void tcApp::setup() {
 
     addLog("Press S for Server, C for Client");
 
+    // Network events fire on internal threads; Deliver::Main marshals each
+    // listener onto the main thread, so app state can be touched without locks.
+
     // Server event setup
     clientConnectListener = server.onClientConnect.listen([this](TcpClientConnectEventArgs& e) {
         ostringstream oss;
         oss << "[Server] Client " << e.clientId << " connected from " << e.host << ":" << e.port;
         addLog(oss.str());
-    });
+    }, Deliver::Main);
 
     clientDisconnectListener = server.onClientDisconnect.listen([this](TcpClientDisconnectEventArgs& e) {
         ostringstream oss;
         oss << "[Server] Client " << e.clientId << " disconnected: " << e.reason;
         addLog(oss.str());
-    });
+    }, Deliver::Main);
 
     serverReceiveListener = server.onReceive.listen([this](TcpServerReceiveEventArgs& e) {
         string msg(e.data.begin(), e.data.end());
@@ -41,13 +44,13 @@ void tcApp::setup() {
         // Echo back
         string reply = "Echo: " + msg;
         server.send(e.clientId, reply);
-    });
+    }, Deliver::Main);
 
     serverErrorListener = server.onError.listen([this](TcpServerErrorEventArgs& e) {
         ostringstream oss;
         oss << "[Server] Error: " << e.message;
         addLog(oss.str());
-    });
+    }, Deliver::Main);
 
     // Client event setup
     clientConnectedListener = client.onConnect.listen([this](TcpConnectEventArgs& e) {
@@ -58,20 +61,20 @@ void tcApp::setup() {
             oss << "[Client] Connection failed: " << e.message;
         }
         addLog(oss.str());
-    });
+    }, Deliver::Main);
 
     clientReceiveListener = client.onReceive.listen([this](TcpReceiveEventArgs& e) {
         string msg(e.data.begin(), e.data.end());
         addLog("[Client] Received: " + msg);
-    });
+    }, Deliver::Main);
 
     clientDisconnectListener2 = client.onDisconnect.listen([this](TcpDisconnectEventArgs& e) {
         addLog("[Client] Disconnected: " + e.reason);
-    });
+    }, Deliver::Main);
 
     clientErrorListener = client.onError.listen([this](TcpErrorEventArgs& e) {
         addLog("[Client] Error: " + e.message);
-    });
+    }, Deliver::Main);
 }
 
 void tcApp::update() {
@@ -118,7 +121,6 @@ void tcApp::draw() {
     y += 25;
 
     setColor(0.86f);
-    lock_guard<mutex> lock(logMutex);
     for (const auto& msg : logMessages) {
         drawBitmapString(msg, 50, y);
         y += 18;
@@ -176,11 +178,8 @@ void tcApp::keyPressed(int key) {
             addLog("[Server] Stopped");
         }
     } else if (key == 'X') {
-        {
-            lock_guard<mutex> lock(logMutex);
-            logMessages.clear();
-            messageCount = 0;
-        }
+        logMessages.clear();
+        messageCount = 0;
         addLog("Log cleared");
     }
 }
@@ -193,7 +192,6 @@ void tcApp::cleanup() {
 void tcApp::addLog(const string& msg) {
     logNotice("tcApp") << msg;
 
-    lock_guard<mutex> lock(logMutex);
     logMessages.push_back(msg);
     if (logMessages.size() > 20) {
         logMessages.erase(logMessages.begin());

--- a/examples/network/tcpExample/src/tcApp.h
+++ b/examples/network/tcpExample/src/tcApp.h
@@ -32,7 +32,6 @@ private:
 
     // Log messages
     std::vector<std::string> logMessages;
-    std::mutex logMutex;
 
     // State
     int messageCount = 0;

--- a/examples/network/udpExample/src/tcApp.cpp
+++ b/examples/network/udpExample/src/tcApp.cpp
@@ -14,17 +14,18 @@ void tcApp::setup() {
     logNotice("tcApp") << "Press C to clear messages";
     logNotice("tcApp") << "==========================";
 
-    // Listen for receive events
+    // Listen for receive events.
+    // onReceive fires on the receive thread; Deliver::Main marshals the
+    // listener onto the main thread, so app state can be touched without locks.
     receiveListener = receiver.onReceive.listen([this](UdpReceiveEventArgs& e) {
         string msg(e.data.begin(), e.data.end());
         logNotice("UdpReceiver") << "Received from " << e.remoteHost << ":" << e.remotePort << " -> " << msg;
 
-        lock_guard<mutex> lock(messagesMutex);
         receivedMessages.push_back(e.remoteHost + ":" + to_string(e.remotePort) + " -> " + msg);
         if (receivedMessages.size() > 20) {
             receivedMessages.erase(receivedMessages.begin());
         }
-    });
+    }, Deliver::Main);
 
     // Listen for error events
     errorListener = receiver.onError.listen([](UdpErrorEventArgs& e) {
@@ -69,7 +70,6 @@ void tcApp::draw() {
     y += 25;
 
     setColor(0.86f);
-    lock_guard<mutex> lock(messagesMutex);
     for (const auto& msg : receivedMessages) {
         drawBitmapString(msg, 50, y);
         y += 18;
@@ -88,7 +88,6 @@ void tcApp::keyPressed(int key) {
             logNotice("tcApp") << "Sent: " << msg;
         }
     } else if (key == 'C') {
-        lock_guard<mutex> lock(messagesMutex);
         receivedMessages.clear();
         sendCount = 0;
         logNotice("tcApp") << "Messages cleared";

--- a/examples/network/udpExample/src/tcApp.h
+++ b/examples/network/udpExample/src/tcApp.h
@@ -20,7 +20,6 @@ private:
     EventListener errorListener;
 
     std::vector<std::string> receivedMessages;
-    std::mutex messagesMutex;
 
     int sendCount = 0;
 };

--- a/examples/utils/timerExample/src/tcApp.cpp
+++ b/examples/utils/timerExample/src/tcApp.cpp
@@ -14,7 +14,7 @@ TimerBall::TimerBall(float x, float y, float radius)
 void TimerBall::setup() {
     // Change color randomly every 0.5 seconds
     callEvery(0.5, [this]() {
-        color_ = colorFromHSB(random(TAU), 0.8f, 1.0f);
+        color_ = Color::fromHSB(random(1.0f), 0.8f, 1.0f);
         colorChangeCount_++;
     });
 }


### PR DESCRIPTION
Fixes a batch of issues found in an internal code review.

**Docs / examples cleanup**
- README still said "Linux/Raspberry Pi planned" — updated the platform list to what actually ships (Linux/OpenGL, Raspberry Pi/GLES3, Web/WebGPU, Android/GLES3)
- tcRenderContext.h usage comment used `setColor(255, 0, 0)`; colors are 0–1
- 4 examples used the deprecated `colorFromHSB()` → `Color::fromHSB()`. timerExample also passed `random(TAU)` as hue (hue is 0–1)

**Network event threading contract**
- UdpSocket / TcpClient / TcpServer events fire on internal worker threads, but no header said so. The contract is now documented at the event declarations, pointing to `listen(fn, Deliver::Main)` as the safe default
- udpExample / tcpExample now demonstrate that pattern (all listeners marshalled to main, manual mutexes removed)

**Fix: Deliver::Main listener lifetime**
- A marshalled `Deliver::Main` call sits in the main-thread queue for up to one frame as a copied `std::function`, outside the entry list — so destroying the `EventListener` couldn't cancel it and the callback could run with dangling captures
- Each entry now carries a liveness token (`shared_ptr<atomic<bool>>`); queued calls re-check it at drain time. `removeListener`/`clear()` flip the value (covers entries kept alive by in-flight `notify()` snapshots), Event destruction is covered by weak expiry. No API change, Inline hot path untouched
- +5 checks in `core/tests/threadSafety` (14/14 pass)

**Verified:** threadSafety suite (macOS), udpExample / tcpExample rebuilt and exercised live (external datagrams, TCP echo round-trip), timerExample render checked