### PR TITLE
feat: derive version from git tags (kill hardcoded 0.0.1)

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+describe: $Format:%(describe:tags,match=v[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -27,3 +27,7 @@
 *.so binary
 *.a binary
 *.lib binary
+
+# Version stamping for source archives (GitHub "Download ZIP" = git archive):
+# git archive substitutes the $Format:...$ placeholder with the tag name
+.git_archival.txt export-subst

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,10 +1,10 @@
-# TrussC v0.0.1
+# TrussC
 # A cross-platform creative coding framework
 
 cmake_minimum_required(VERSION 3.20)
 
 # Start with C/CXX only — OBJC/OBJCXX enabled after project() if on macOS
-project(TrussC VERSION 0.0.1 LANGUAGES C CXX)
+project(TrussC LANGUAGES C CXX)
 # Toolchain variables (ANDROID, APPLE) are available after project()
 if(APPLE AND NOT ANDROID)
     enable_language(OBJC OBJCXX)
@@ -17,6 +17,29 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # TC_ROOT (root directory containing core and addons)
 get_filename_component(TC_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
 set(TC_ROOT "${TC_ROOT}" CACHE PATH "TrussC root directory" FORCE)
+
+# =============================================================================
+# Version — git tags are the single source of truth
+# =============================================================================
+# Fallback chain: git describe → .git_archival.txt (GitHub "Download ZIP",
+# substituted by git archive via export-subst) → "unknown"
+execute_process(
+    COMMAND git describe --tags --always --dirty --match "v[0-9]*"
+    WORKING_DIRECTORY ${TC_ROOT}
+    OUTPUT_VARIABLE TC_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+if(NOT TC_VERSION AND EXISTS "${TC_ROOT}/.git_archival.txt")
+    file(READ "${TC_ROOT}/.git_archival.txt" _tc_archival)
+    if(NOT _tc_archival MATCHES "Format:")   # still contains Format: = unsubstituted checkout
+        string(REGEX MATCH "describe: ([^\n]+)" _ "${_tc_archival}")
+        set(TC_VERSION "${CMAKE_MATCH_1}")
+    endif()
+endif()
+if(NOT TC_VERSION)
+    set(TC_VERSION "unknown")
+endif()
+message(STATUS "TrussC version: ${TC_VERSION}")
 
 # =============================================================================
 # Platform detection
@@ -124,6 +147,10 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TC_ALL_SOURCES})
 add_library(TrussC STATIC ${TC_ALL_SOURCES})
 
 add_library(tc::TrussC ALIAS TrussC)
+
+# Bake the git-derived version into tc::getVersion() (tcVersion.h).
+# PUBLIC so user apps and addons see the same value.
+target_compile_definitions(TrussC PUBLIC TC_VERSION_STRING="${TC_VERSION}")
 
 # iOS: sound sources include ObjC headers (AVFoundation) via miniaudio,
 # so they must be compiled as Objective-C++

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -2,7 +2,6 @@
 
 // =============================================================================
 // TrussC - Thin, Modern, and Native Creative Coding Framework
-// Version 0.0.1
 // =============================================================================
 
 // Windows: Hide console window (in Release builds)
@@ -104,6 +103,9 @@
 
 // TrussC console input (accept commands from stdin)
 #include "tc/utils/tcConsole.h"
+
+// TrussC version (git-tag derived, see tcVersion.h)
+#include "tc/utils/tcVersion.h"
 
 // TrussC MCP (Model Context Protocol) Server
 #include "tc/utils/tcMCP.h"
@@ -222,10 +224,7 @@ namespace trussc { namespace internal {
 // Reopen namespace
 namespace trussc {
 
-// Version information
-constexpr int VERSION_MAJOR = 0;
-constexpr int VERSION_MINOR = 0;
-constexpr int VERSION_PATCH = 1;
+// Version: git-tag derived — tc::getVersion() in tc/utils/tcVersion.h
 
 // Math constants defined in tcMath.h: TAU, HALF_TAU, QUARTER_TAU, PI
 

--- a/core/include/tc/utils/tcMCP.h
+++ b/core/include/tc/utils/tcMCP.h
@@ -25,6 +25,7 @@ using json = nlohmann::json;
 
 #include "tcLog.h"
 #include "tcThreadChannel.h"
+#include "tcVersion.h"
 
 #ifndef __EMSCRIPTEN__
 #include "../../impl/httplib.h"
@@ -234,7 +235,7 @@ private:
             {"protocolVersion", "2024-11-05"},
             {"server", {
                 {"name", "TrussC App"},
-                {"version", "0.0.1"}
+                {"version", getVersion()}
             }},
             {"capabilities", {
                 {"tools", {}},

--- a/core/include/tc/utils/tcVersion.h
+++ b/core/include/tc/utils/tcVersion.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// =============================================================================
+// tcVersion.h - TrussC version reporting
+// =============================================================================
+//
+// The version's single source of truth is the git tag: the build bakes
+// `git describe` output into TC_VERSION_STRING (see core/CMakeLists.txt).
+// Source archives without .git get it from .git_archival.txt (export-subst).
+// No version number lives in source code.
+
+#ifndef TC_VERSION_STRING
+#define TC_VERSION_STRING "unknown"   // direct include without the CMake build
+#endif
+
+namespace trussc {
+
+// TrussC version as reported by `git describe`, e.g. "v0.6.2" on a tagged
+// release or "v0.6.2-14-gabc123" for a build 14 commits past it.
+inline const char* getVersion() { return TC_VERSION_STRING; }
+
+} // namespace trussc

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1739,6 +1739,7 @@ std::size_t compressBound(std::size_t nbytes, Codec codec)  // Worst-case compre
 bool decompress(const void * src, std::size_t nbytes, std::vector<std::uint8_t> & out, std::size_t decompressedSize, Codec codec) [+1]  // Decompress a byte buffer; decompressedSize is the known original byte count. The vector overload resizes out and returns true on success (false / cleared out on mismatch or failure); the raw (dst pointer) overload returns the number of bytes written, or -1 on failure.
 Logger & getLogger()  // Access the global logger instance
 std::thread::id getMainThreadId()  // Get the main thread ID. Records the current thread's ID on the first call, so it must first be called from the main thread.
+const char * getVersion()  // TrussC version string from git describe (e.g. "v0.6.2" or "v0.6.2-14-gabc123")
 int hexToInt(const std::string & hexStr)  // Parse a hex string into a signed int
 unsigned int hexToUInt(const std::string & hexStr)  // Parse a hex string into an unsigned int
 void intersectRect(float x1, float y1, float w1, float h1, float x2, float y2, float w2, float h2, float & ox, float & oy, float & ow, float & oh)  // Compute intersection of two rectangles
@@ -2025,9 +2026,6 @@ float tanh(float x) [std]  // Hyperbolic tangent
 TAU  // Ratio of circumference to radius; the radian measure of one full turn. ≈ 6.28318.
 Top  // Direction shorthand for Direction::Top
 float trunc(float x) [std]  // Truncate toward zero (drop the fractional part)
-VERSION_MAJOR  // TrussC major version number
-VERSION_MINOR  // TrussC minor version number
-VERSION_PATCH  // TrussC patch version number
 VSYNC  // Frame-rate sentinel: sync to the monitor refresh rate
 ```
 
@@ -3773,7 +3771,8 @@ void VideoGrabber::update()  // Poll for a new frame and upload it to the textur
 ```cpp
 void VideoPlayer::close()  // Close the video and release resources
 void VideoPlayer::draw(float x, float y) const [+1]  // Draw the current video frame at (x, y), optionally scaled to w x h
-bool VideoPlayer::extractFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr)  // Extract a single frame from a video file without loading the full video. Useful for thumbnails
+bool VideoPlayer::extractFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+1]  // Extract the exact frame at a given time from a video file. Frame-accurate on every platform
+bool VideoPlayer::extractKeyFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+1]  // Extract the nearest keyframe at or before a given time. Faster than extractFrame but time-approximate
 int VideoPlayer::getAudioChannels() const [macos,windows,linux,ios]  // Number of audio channels (0 if no audio)
 uint32_t VideoPlayer::getAudioCodec() const [macos,windows,linux,ios]  // FourCC of the audio codec in the loaded video (0 if none)
 std::vector<uint8_t> VideoPlayer::getAudioData() const [macos,windows,linux,ios]  // Raw decoded audio data for the loaded video
@@ -3782,6 +3781,7 @@ int VideoPlayer::getCurrentFrame() const  // Get current frame number
 float VideoPlayer::getDuration() const  // Get total duration in seconds
 float VideoPlayer::getGammaCorrection() const  // Get current gamma correction value
 std::string VideoPlayer::getHwAccelName() const  // Get the name of the active decode backend. Returns 'vaapi', 'v4l2m2m', 'cuda', 'videotoolbox', 'mediafoundation', 'software', or 'none'
+const std::string & VideoPlayer::getPath() const  // Path of the currently loaded video file (resolved via getDataPath); empty string when nothing is loaded
 unsigned char * VideoPlayer::getPixels() [+1]  // Pointer to the current RGBA pixel buffer (mutable)
 unsigned char * VideoPlayer::getPixelsUV()  // Pointer to the interleaved UV (chroma) plane when decoding NV12; null otherwise
 unsigned char * VideoPlayer::getPixelsY()  // Pointer to the Y (luma) plane when decoding NV12/YUV; null otherwise

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -9377,24 +9377,6 @@ description.en = "Stop the receive thread"
 description.ja = "受信スレッドを停止"
 description.ko = "수신 스레드를 정지"
 
-["VERSION_MAJOR"]
-keywords = ["semver", "release"]
-description.en = "TrussC major version number"
-description.ja = "TrussC のメジャーバージョン番号"
-description.ko = "TrussC 메이저 버전 번호"
-
-["VERSION_MINOR"]
-keywords = ["semver", "release"]
-description.en = "TrussC minor version number"
-description.ja = "TrussC のマイナーバージョン番号"
-description.ko = "TrussC 마이너 버전 번호"
-
-["VERSION_PATCH"]
-keywords = ["semver", "release"]
-description.en = "TrussC patch version number"
-description.ja = "TrussC のパッチバージョン番号"
-description.ko = "TrussC 패치 버전 번호"
-
 ["VSYNC"]
 keywords = ["frame rate", "fps", "refresh", "sync"]
 description.en = "Frame-rate sentinel: sync to the monitor refresh rate"
@@ -12880,6 +12862,14 @@ keywords = ["tick", "logic", "number", "total"]
 description.en = "Get the number of update() calls since the app started"
 description.ja = "アプリ開始からの update() 呼び出し回数を取得"
 description.ko = "앱 시작 이후 update() 호출 횟수를 얻음"
+
+["getVersion"]
+category = "utility"
+keywords = ["semver", "release", "git", "tag", "describe"]
+of = ["ofGetVersionInfo"]
+description.en = "TrussC version string from git describe (e.g. \"v0.6.2\" or \"v0.6.2-14-gabc123\")"
+description.ja = "git describe 由来の TrussC バージョン文字列（例: \"v0.6.2\"、\"v0.6.2-14-gabc123\"）"
+description.ko = "git describe 기반 TrussC 버전 문자열 (예: \"v0.6.2\", \"v0.6.2-14-gabc123\")"
 
 ["getWeekday"]
 category = "time_current"


### PR DESCRIPTION
The source still claimed version 0.0.1 while the repo is at v0.6.2 — nothing tied the hardcoded spots to git tags. After this PR the single source of truth is the git tag; releasing = pushing a tag, no source edits.

**How it works (3 tiers)**

1. **git clone**: core CMake bakes `git describe --tags --always --dirty --match "v[0-9]*"` into a `PUBLIC TC_VERSION_STRING` compile definition (same pattern trusscli already uses for itself). `tc::getVersion()` (new `tc/utils/tcVersion.h`) returns it, e.g. `v0.6.2` on a tag, `v0.6.2-14-gabc123` past it — bug reports pin the exact commit.
2. **GitHub "Download ZIP"** (= `git archive`): new `.git_archival.txt` with an `export-subst` attribute gets the `$Format:%(describe:tags,...)$` placeholder substituted with the real tag at archive time (setuptools-scm technique). CMake parses it when `.git` is absent.
3. **Neither**: falls back to `"unknown"` — honest, never a wrong number.

**Changes**

- `core/CMakeLists.txt`: version detection + `TC_VERSION_STRING` define (PUBLIC → propagates to every app/addon incl. web and hot-reload guest); `project()` VERSION arg dropped
- `core/include/tc/utils/tcVersion.h` (new): `tc::getVersion()`, dependency-free, `"unknown"` fallback for direct includes without CMake
- `TrussC.h`: removed `constexpr VERSION_MAJOR/MINOR/PATCH` (said 0.0.1 forever; grep across core/examples/apps/all addons/TrussSketch found zero consumers)
- `tcMCP.h`: MCP `serverInfo.version` now reports the real build version instead of "0.0.1"
- `docs/reference/api-reference.toml`: `VERSION_*` entries replaced with `getVersion` (En/Ja/Ko); FOR_AI_ASSISTANT.md regenerated

**Verified**

- Native: MCP `initialize` returns `"version": "v0.6.2-178-g39c26421-dirty"` (live app)
- Zip path: `git archive HEAD` → unzipped tree without `.git` configures with `TrussC version: v0.6.2-180-g5cd98ece`
- No git + no archival file → `unknown`
- `node docs/reference/check.js --strict` green locally (0 orphans, 100% documented)

**Note for releases**: tag before release (`git tag v0.x.y && git push --tags`) — an untagged zip ships as `v0.6.2-N-g…`, which is accurate but not pretty. Lightweight tags are fine (everything uses `--tags`).