### PR TITLE
fix: add the app's src/ as an include root for the normal build

### DIFF
--- a/core/cmake/trussc_app.cmake
+++ b/core/cmake/trussc_app.cmake
@@ -469,6 +469,11 @@ message(\"  [HotReload] Generated \${DEF_FILE} with \${SYM_COUNT} symbols\")
     # Link TrussC
     target_link_libraries(${PROJECT_NAME} PRIVATE tc::TrussC)
 
+    # The app's own src/ is an include root, so projects organized into
+    # subfolders can include across them as "subdir/File.h". The hot-reload
+    # guest target already gets this; keep the normal build consistent.
+    target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
     # Opt-in compiler warnings on the USER's own sources (`trusscli build
     # --warnings` passes -DTRUSSC_WARNINGS=ON). TrussC / sokol / stb headers are
     # SYSTEM includes (see core/CMakeLists.txt), so only the app's code is


### PR DESCRIPTION
The hot-reload guest target already lists `src/` in its include dirs, so projects organized into subfolders could include across them as `"subdir/File.h"` under hot reload — but the same include failed in a normal build (quote includes only resolve relative to the including file). This adds the same include root to the app target so both builds behave identically.

**Verified both ways** (macOS): a probe header in `src/a/` including `"b/Other.h"` fails to compile without this change (`fatal error: file not found`) and builds with it; stock examples build unchanged.

Note: this change surfaced as an uncommitted local edit (likely from another working session, Nextcloud-synced); reviewed, repro'd the underlying inconsistency, and adopted it.