### PR TITLE
feat: drawBitmapString(Vec3) billboards through the current camera context

### DIFF
--- a/core/include/tc/graphics/tcRenderContext.cpp
+++ b/core/include/tc/graphics/tcRenderContext.cpp
@@ -167,6 +167,128 @@ void internal::RenderContext::drawRectSquircle(Vec3 pos, Vec2 size, float radius
 }
 
 // ---------------------------------------------------------------------------
+// Bitmap string billboard (project a world position through the current camera
+// context and draw the glyphs screen-aligned on top of the scene).
+//
+// Shared by all Vec3 drawBitmapString overloads. Always active when a camera
+// context exists — EasyCam scopes AND the ambient default screen alike. The
+// default screen is a perspective projection whose z=0 plane maps pixel-
+// identically to 2D coordinates ("3D coexisting with 2D"), so projecting is
+// always semantically correct: at z=0 it is the identity mapping (2D compat
+// holds mathematically), at z!=0 the label finally lands on the 3D point.
+// Returns false only when no camera context exists (e.g. headless before any
+// camera setup), so the callers fall back to plain 2D drawing. Returns true
+// when handled — including the behind-camera case, where the correct result is
+// to draw nothing.
+// ---------------------------------------------------------------------------
+bool internal::RenderContext::drawBitmapStringBillboard(const std::string& text, Vec3 pos,
+                                                        Direction h, Direction v,
+                                                        bool screenFixed, float extraScale) {
+    // Absence-of-context handling only (not a semantic gate): with no camera
+    // context yet (headless / before the first camera setup) or a degenerate
+    // viewport there is nothing to project through.
+    std::shared_ptr<const CameraContext> ctx = internal::currentCameraContext;
+    if (!ctx || ctx->viewW <= 0.0f || ctx->viewH <= 0.0f) return false;
+
+    if (text.empty()) return true;                 // handled: nothing to draw
+    ensureFontAtlasForText(text);
+    if (!internal::fontAtlasInitialized) return true;
+
+    // 1) Current model matrix (pushMatrix/translate) -> world space (full 3D).
+    Mat4 model = getMatrix();
+    Vec4 worldH = model * Vec4(pos.x, pos.y, pos.z, 1.0f);
+    float invW = (std::abs(worldH.w) > 1e-6f) ? (1.0f / worldH.w) : 1.0f;
+    Vec3 world(worldH.x * invW, worldH.y * invW, worldH.z * invW);
+
+    // 2) Project through the active camera. z < 0 => behind camera => no draw.
+    Vec3 screen = ctx->worldToScreen(world);
+    if (screen.z < 0.0f) return true;              // handled: behind camera
+
+    // 3) Glyph pixel scale.
+    float pixelScale = extraScale;
+    if (!screenFixed) {
+        // Perspective falloff: measure pixels-per-world-unit at the label's
+        // depth by projecting a 1-unit offset along the camera's right axis.
+        // ctx->view is world->view (row-major), so its row 0 is the camera
+        // right vector expressed in world space.
+        Vec3 right(ctx->view.m[0], ctx->view.m[1], ctx->view.m[2]);
+        Vec3 screen2 = ctx->worldToScreen(world + right);
+        float pxPerWorld = std::abs(screen2.x - screen.x);
+        if (screen2.z < 0.0f) pxPerWorld = 0.0f;   // offset point behind camera
+        pixelScale = pxPerWorld * extraScale;
+    }
+
+    Vec2 offset = calcBitmapAlignOffset(text, h, v);
+
+    // 4) Draw in screen space (ortho). The 2D fill pipeline neither writes nor
+    //    tests depth (compare defaults to ALWAYS), so the label sits ON TOP of
+    //    the 3D scene regardless of what is in front of it.
+    sgl_matrix_mode_projection();
+    sgl_push_matrix();
+    sgl_load_identity();
+    sgl_ortho(0.0f, internal::currentViewW, internal::currentViewH, 0.0f, -10000.0f, 10000.0f);
+
+    sgl_matrix_mode_modelview();
+    sgl_push_matrix();
+    sgl_load_identity();
+    sgl_translate(screen.x, screen.y, 0.0f);
+    sgl_scale(pixelScale, pixelScale, 1.0f);
+    sgl_translate(offset.x, offset.y, 0.0f);
+
+    internal::loadPipeline(internal::activeFill2D());
+    sgl_enable_texture();
+    sgl_texture(internal::fontView, internal::fontSampler);
+
+    sgl_begin_quads();
+    sgl_c4f(currentR_, currentG_, currentB_, currentA_);
+
+    const float charH = bitmapfont::CHAR_TEX_HEIGHT;
+    const float tabW  = bitmapfont::CHAR_TEX_WIDTH * 8.0f;
+    float cursorX = 0;
+    float cursorY = 0;
+
+    const char* p  = text.data();
+    const char* pe = p + text.size();
+    while (p < pe) {
+        unsigned char b0 = (unsigned char)*p;
+        if (b0 == '\n') { ++p; cursorX = 0; cursorY += style_.bitmapLineHeight; continue; }
+        if (b0 == '\t') { ++p; cursorX += tabW; continue; }
+        if (b0 < 32)    { ++p; continue; }
+        uint32_t cp = bitmapfont::utf8Decode(p, pe);
+        if (cp == 0) break;
+
+        float u, vt, u2, v2;
+        bitmapfont::getCodepointTexCoord(cp, internal::fontAtlasRows, u, vt, u2, v2);
+        float gw = (float)bitmapfont::codepointPixelWidth(cp);
+
+        sgl_v2f_t2f(cursorX, cursorY, u, vt);
+        sgl_v2f_t2f(cursorX + gw, cursorY, u2, vt);
+        sgl_v2f_t2f(cursorX + gw, cursorY + charH, u2, v2);
+        sgl_v2f_t2f(cursorX, cursorY + charH, u, v2);
+
+        cursorX += gw;
+    }
+
+    sgl_end();
+    sgl_disable_texture();
+
+    // Restore matrices.
+    sgl_pop_matrix();                 // modelview
+    sgl_matrix_mode_projection();
+    sgl_pop_matrix();
+    sgl_matrix_mode_modelview();
+
+    // CRITICAL: we may be inside a 3D pass (EasyCam or the default perspective
+    // screen). restoreCurrentPipeline() would load a 2D pipeline (no depth
+    // write/test) and corrupt subsequent 3D geometry, so restore the depth-
+    // testing 3D pipeline explicitly — it is also what the perspective screen
+    // loads at frame start, so the ambient state is preserved.
+    internal::loadPipeline(internal::active3D());
+
+    return true;
+}
+
+// ---------------------------------------------------------------------------
 // Bitmap string drawing (base version)
 // ---------------------------------------------------------------------------
 void internal::RenderContext::drawBitmapString(const std::string& text, float x, float y, bool screenFixed) {

--- a/core/include/tc/graphics/tcRenderContext.h
+++ b/core/include/tc/graphics/tcRenderContext.h
@@ -832,13 +832,30 @@ public:
 
     void drawBitmapString(const std::string& text, float x, float y, bool screenFixed = true);
 
+    // Vec3 overload. The position is transformed by the current model matrix to
+    // world space and projected through the current camera context — an EasyCam
+    // scope or the ambient default screen alike; the glyphs are then drawn as a
+    // screen-aligned BILLBOARD on top of the scene (no depth test). On the
+    // default screen the z=0 plane maps pixel-identically to 2D coordinates, so
+    // Vec3(x, y, 0) draws exactly where (x, y) does, while z != 0 projects to
+    // the true 3D point. A point behind the camera draws nothing.
+    //   screenFixed=true  (default): constant pixel size regardless of distance.
+    //   screenFixed=false: the glyph cell is measured in world units at the
+    //                      label's depth, so it foreshortens with perspective
+    //                      (shrinks with distance).
     void drawBitmapString(const std::string& text, Vec3 pos, bool screenFixed = true) {
+        if (drawBitmapStringBillboard(text, pos, textAlignH_, textAlignV_, screenFixed, 1.0f)) return;
         drawBitmapString(text, pos.x, pos.y, screenFixed);
     }
 
     void drawBitmapString(const std::string& text, float x, float y, float scale);
 
+    // Vec3 + scale overload. Billboards through the current camera context with
+    // a perspective-scaled glyph cell (like screenFixed=false) multiplied by
+    // `scale`, so the label shrinks with distance. At z=0 on the default screen
+    // the perspective factor is 1, matching the 2D (x, y, scale) overload's size.
     void drawBitmapString(const std::string& text, Vec3 pos, float scale) {
+        if (drawBitmapStringBillboard(text, pos, textAlignH_, textAlignV_, /*screenFixed=*/false, scale)) return;
         drawBitmapString(text, pos.x, pos.y, scale);
     }
 
@@ -862,10 +879,28 @@ public:
     void drawBitmapString(const std::string& text, float x, float y,
                           Direction h, Direction v, bool screenFixed = true);
 
+    // Vec3 + alignment overload. Same billboard rule as the Vec3 overloads
+    // above (see their docs), but with explicit horizontal/vertical alignment
+    // of the label around the projected point.
     void drawBitmapString(const std::string& text, Vec3 pos,
                           Direction h, Direction v, bool screenFixed = true) {
+        if (drawBitmapStringBillboard(text, pos, h, v, screenFixed, 1.0f)) return;
         drawBitmapString(text, pos.x, pos.y, h, v, screenFixed);
     }
+
+    // Billboard a WORLD position through the current camera context (EasyCam
+    // scope or the ambient default screen). Returns true when it handled the
+    // draw — including the behind-camera case where it correctly draws nothing
+    // — and false only when no camera context exists (headless / before any
+    // camera setup) so the Vec3 overloads fall back to plain 2D.
+    // `pos` is transformed by the current model matrix (pushMatrix/translate
+    // apply) then projected. screenFixed=true keeps a constant pixel size;
+    // screenFixed=false measures the glyph cell in world units at the label's
+    // depth so it foreshortens with distance. `extraScale` multiplies the final
+    // glyph size in both modes. Implementation in tcRenderContext.cpp.
+    bool drawBitmapStringBillboard(const std::string& text, Vec3 pos,
+                                   Direction h, Direction v,
+                                   bool screenFixed, float extraScale);
 
     // -----------------------------------------------------------------------
     // Bitmap string metrics


### PR DESCRIPTION
## What

The Vec3 overloads of `drawBitmapString` used to silently drop `z` and draw in 2D screen space — a footgun for anyone labeling 3D objects. They now project through the **current camera context, in every context**: an explicit camera scope (EasyCam) and the ambient default screen alike. No flags, no special cases.

## Why this is safe for 2D

TrussC's default screen is itself a perspective projection whose z=0 plane is pixel-identical to 2D ("3D coexists with 2D"). Projecting `Vec3(x, y, 0)` through it is the identity mapping — verified **byte-for-byte** (PIL ImageChops.difference == 0 over the text region at retina resolution) against the `(x, y)` overload. Existing 2D code is unaffected; the `(x, y)` overloads are untouched.

## Behavior

- Position is transformed by the current model matrix, projected via `worldToScreen`, and glyphs draw screen-aligned at that point.
- `screenFixed=true` (default): constant pixel size regardless of distance.
- `screenFixed=false` (and the `(Vec3, float scale)` overload): size falls off with perspective (world-unit scale at the label's depth), mirroring the 2D meaning.
- Points behind the camera draw nothing.
- Labels draw on top (no depth test); the 3D pipeline (depth write) is restored immediately after.
- On the default screen, `z != 0` now labels the 3D position it names (previously the z was dropped).

## Verified

EasyCam test app over MCP across 4 camera angles: fixed-size labels hold pixel size across depths, perspective labels foreshorten, labels track their boxes through 90°/180° orbits, behind-camera culling proven both ways (label culled facing away, appears facing +z), depth pipeline intact after the text draw (occlusion probe box), 2D HUD via the (x,y) overload unaffected. Default-screen z≠0 labeling and the byte-identical z=0 comparison verified separately.

## Deferred

Reference prose (api-definition / docs) update for the new Vec3 behavior — follow-up doc pass.