### PR TITLE
feat: fixed-duration recording + MCP start_recording/stop_recording tools

### DIFF
--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -127,18 +127,18 @@ inline void registerInspectionTools() {
 
     // --- Recording tools (native encoder, no ffmpeg) ---
 
-    tool("start_recording", "Start recording the window to a video file (the screenshot's video counterpart)")
-        .arg<std::string>("path", "Output file path (relative paths resolve to the data dir)")
+    tool("start_recording", "Start recording the window to a video file (the screenshot's video counterpart). Omit path for a timestamped file in the data dir; give duration for a fixed-length clip that auto-stops and finalizes itself.")
+        .arg<std::string>("path", "Output file path (relative paths resolve to the data dir). Omit for recording-<timestamp>.mp4/.mov in the data dir.", false)
+        .arg<float>("duration", "Fixed length in seconds; the file auto-stops & finalizes at that length. Omit or 0 = unlimited (stop_recording to end).", false)
         .arg<float>("fps", "Target frame rate (default 60; ProMotion frames are decimated to it)", false)
         .arg<std::string>("codec", "h264 (default) | hevc | prores422 | prores4444 (.mov, macOS)", false)
         .bind([](const json& args) -> json {
-            std::string path = args.value("path", std::string());
-            if (path.empty()) {
-                return json{{"status", "error"}, {"message", "path is required"}};
-            }
             trussc::VideoRecordSettings settings;
             if (args.contains("fps") && args.at("fps").is_number()) {
                 settings.fps = args.at("fps").get<float>();
+            }
+            if (args.contains("duration") && args.at("duration").is_number()) {
+                settings.duration = args.at("duration").get<float>();
             }
             std::string codec = args.value("codec", std::string());
             if      (codec == "hevc")       settings.codec = trussc::VideoCodec::HEVC;
@@ -147,22 +147,41 @@ inline void registerInspectionTools() {
             else if (!codec.empty() && codec != "h264") {
                 return json{{"status", "error"}, {"message", "unknown codec: " + codec}};
             }
+            // Default output: recording-<timestamp> in the data dir. ProRes is a
+            // .mov container; everything else is .mp4. startRecording() resolves
+            // the relative path via getDataPath(); recordingPath() returns it.
+            std::string path = args.value("path", std::string());
+            if (path.empty()) {
+                bool isProRes = settings.codec == trussc::VideoCodec::ProRes422 ||
+                                settings.codec == trussc::VideoCodec::ProRes4444;
+                path = "recording-" + trussc::getTimestampString("%Y-%m-%d-%H-%M-%S")
+                     + (isProRes ? ".mov" : ".mp4");
+            }
             bool ok = trussc::startRecording(path, settings);
-            return json{{"status", ok ? "ok" : "error"},
-                        {"path", trussc::recordingPath()},
-                        {"fps", settings.fps},
-                        {"codec", trussc::videoCodecName(settings.codec)}};
+            json r{{"status", ok ? "ok" : "error"},
+                   {"path", trussc::recordingPath()},
+                   {"fps", settings.fps},
+                   {"codec", trussc::videoCodecName(settings.codec)}};
+            if (settings.duration > 0.0f) r["duration"] = settings.duration;
+            return r;
         });
 
-    tool("stop_recording", "Stop the current recording and finalize the file")
+    tool("stop_recording", "Stop the current recording and finalize the file. Wins over a pending fixed duration (finalizes immediately at the current length); a no-op if nothing is recording.")
         .bind(std::function<json()>([]() -> json {
             if (!trussc::isRecording()) {
-                return json{{"status", "error"}, {"message", "not recording"}};
+                // Harmless no-op (e.g. a fixed-duration recording already
+                // auto-stopped, or nothing was started). Not an error.
+                return json{{"status", "ok"}, {"recording", false},
+                            {"message", "not recording"}};
             }
             std::string path = trussc::recordingPath();
             int frames = trussc::recordingFrameCount();
+            float fps  = trussc::internal::globalScreenRecorder().writer().getFps();
             trussc::stopRecording();
-            return json{{"status", "ok"}, {"path", path}, {"frames", frames}};
+            json r{{"status", "ok"}, {"recording", false},
+                   {"path", path}, {"frames", frames}};
+            if (fps > 0.0f) r["length"] = frames / fps;   // measured output length (s)
+            return r;
         }));
 
     // --- Node tree tools ---

--- a/core/include/tc/video/tcVideoRecorder.h
+++ b/core/include/tc/video/tcVideoRecorder.h
@@ -16,6 +16,11 @@
 //                       every frame at wall-clock speed until stop().
 //                       start(path) / start(fbo, path) -> stop()
 //                     Size is taken automatically; built on a VideoWriter.
+//                     A fixed length may be requested (settings.duration, or the
+//                       start(path, seconds) overload): recording then auto-stops
+//                       and finalizes the file at exactly that length — no frame
+//                       whose PTS reaches `duration` is written. Default is 0 =
+//                       unlimited (record until stop()).
 //
 //   startRecording()/stopRecording() - global convenience over a singleton
 //                     ScreenRecorder ("just record the whole window").
@@ -85,6 +90,9 @@ struct VideoRecordSettings {
                                 // VideoWriter: the exact output frame rate.
     int bitrate = 0;            // bits/sec for H.264/HEVC; 0 = auto. Ignored by ProRes.
     int keyframeInterval = 0;   // frames between keyframes; 0 = encoder default.
+    float duration = 0.0f;      // ScreenRecorder: auto-stop & finalize after this
+                                // many seconds of output; 0 = unlimited (call
+                                // stop() manually). Ignored by VideoWriter.
 };
 
 // ---------------------------------------------------------------------------
@@ -292,6 +300,20 @@ public:
                            fbo.getWidth(), fbo.getHeight(), path, settings);
     }
 
+    // Fixed-duration convenience: record for `durationSec` seconds, then auto-stop
+    // and finalize the file at exactly that length. Same as filling
+    // settings.duration. (durationSec <= 0 records until stop(), like the default.)
+    bool start(const std::string& path, float durationSec) {
+        VideoRecordSettings s;
+        s.duration = durationSec;
+        return start(path, s);
+    }
+    bool start(const Fbo& fbo, const std::string& path, float durationSec) {
+        VideoRecordSettings s;
+        s.duration = durationSec;
+        return start(fbo, path, s);
+    }
+
     // Stop capturing and finalize the file. Safe to call multiple times.
     void stop() {
         afterFrameListener_ = EventListener{};   // no new captures get queued
@@ -328,6 +350,7 @@ private:
         if (!writer_.open(path, w, h, settings)) return false;
         source_ = src;
         fbo_ = fbo;
+        duration_ = settings.duration;
         startElapsed_ = getElapsedTimef();
         nextCaptureTime_ = -1.0f;
         lastFrameTime_ = -1.0f;
@@ -339,6 +362,25 @@ private:
     void onAfterFrame() {
         if (!writer_.isOpen()) return;
         float now = getElapsedTimef();
+
+        // Fixed-duration cutoff. `t` is the wall-clock PTS this frame would carry;
+        // once it reaches the requested length we finalize and append nothing more,
+        // so the output length == duration (to within one frame slot). The cut is
+        // PTS-based, so any async capture already in flight — its PTS was sampled
+        // below when it was issued, always < duration — can't push the file past
+        // the cutoff; stop() just drains those before closing the writer.
+        //
+        // stop() clears afterFrameListener_ from inside this callback (self-removal
+        // mid-dispatch). That is safe here: Event::notify() iterates an RCU
+        // snapshot of the listener list held alive for the whole loop, so removing
+        // ourselves only swaps in a new list for the NEXT fire; the in-progress
+        // dispatch is unaffected, and removeListener() takes a recursive_mutex that
+        // notify() does not hold (no deadlock). No deferral needed.
+        if (duration_ > 0.0f && (double)(now - startElapsed_) >= (double)duration_) {
+            stop();
+            return;
+        }
+
         float interval = 1.0f / writer_.getFps();
 
         // Decimate the (often higher-rate) frame stream to the target fps by
@@ -396,6 +438,7 @@ private:
     Source source_ = Source::None;
     const Fbo* fbo_ = nullptr;
     float startElapsed_ = 0.0f;
+    float duration_ = 0.0f;           // fixed-length cutoff in seconds (0 = unlimited)
     float nextCaptureTime_ = -1.0f;   // scheduled time of the next frame to capture
     float lastFrameTime_ = -1.0f;     // previous afterFrame time (for source dt)
     EventListener afterFrameListener_;
@@ -419,6 +462,14 @@ namespace internal {
 TC_PLATFORMS("macos,windows,linux,android,ios") inline bool startRecording(const std::string& path,
                            const VideoRecordSettings& settings = {}) {
     return internal::globalScreenRecorder().start(path, settings);
+}
+
+// Fixed-duration convenience: record the whole window for `durationSec` seconds,
+// then auto-stop and finalize at exactly that length. (durationSec <= 0 behaves
+// like the unlimited overload above — record until stopRecording().)
+TC_PLATFORMS("macos,windows,linux,android,ios") inline bool startRecording(const std::string& path,
+                           float durationSec) {
+    return internal::globalScreenRecorder().start(path, durationSec);
 }
 
 inline void stopRecording() { internal::globalScreenRecorder().stop(); }

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10509,6 +10509,11 @@ description.en = "Output codec (default H264)"
 description.ja = "出力コーデック（デフォルト H264）"
 description.ko = "출력 코덱(기본값 H264)"
 
+["VideoRecordSettings::duration"]
+description.en = "Recording length in seconds; 0 = unlimited (stop manually). When set, recording auto-stops and the file is finalized at exactly this length; a manual stop before the cutoff still wins"
+description.ja = "録画の長さ（秒）。0 = 無制限（手動で stop）。指定するとその長さで自動停止しファイルが確定する。時間内の手動 stop は常に優先される"
+description.ko = "녹화 길이(초). 0 = 무제한(수동으로 stop). 지정하면 해당 길이에서 자동 정지되고 파일이 확정된다. 시간 내 수동 stop이 항상 우선"
+
 ["VideoRecordSettings::fps"]
 description.en = "Capture/output frame rate. For ScreenRecorder this is the capture ceiling; for VideoWriter it is the exact output rate (default 60)"
 description.ja = "キャプチャ/出力フレームレート。ScreenRecorder ではキャプチャの上限、VideoWriter では正確な出力レート（デフォルト 60）"


### PR DESCRIPTION
## What

Recording can now be given a length in seconds; it auto-stops and finalizes the file at exactly that length. Default remains unlimited (record until `stop()`), unchanged.

```cpp
startRecording("out.mp4", 3.0f);            // exactly 3.0s, auto-finalized
settings.duration = 10.0f;                   // same via VideoRecordSettings
recorder.start(fbo, "clean.mp4", 5.0f);      // Fbo variant
```

## Semantics

- `duration = 0` (default): unlimited — identical to today.
- `duration > 0`: PTS-based cut — no frame whose timestamp would reach the duration is written, so output length == requested duration to within one frame slot (async captures in flight at the cutoff can't overrun; their PTS is sampled at issue time).
- **Manual stop always wins**: `stopRecording()` at t≈2s with duration=10 finalizes a valid ~2s file immediately. A stop after auto-stop is a harmless no-op.
- Auto-stop calls `stop()` directly from the afterFrame listener — safe with the RCU event dispatch (in-progress notify iterates its snapshot; removal applies from the next fire).

## MCP standard tools

`start_recording` (optional `path` — defaults to a timestamped file in the data dir — plus optional `duration`, `fps`, `codec`) and `stop_recording` (returns path, frames, length) are now registered alongside `get_screenshot`/`save_screenshot` when `TRUSSC_MCP=1`, so agents can capture video of app behavior, not just still frames.

## Verified (ffprobe-measured)

| Case | Measured |
|---|---|
| Fixed 3.0s | 3.002s |
| Unlimited, manual stop at ~4s | 4.025s |
| duration=10, MCP stop at ~2s | 2.045s (stop wins) |
| duration=2 auto-stop | 2.010s |
| stop after auto-stop | clean no-op |

No crash across auto-stop boundaries; default path regression-checked.