### PR TITLE
ci: compiler caching (ccache/sccache) + skip heavy builds on docs-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,76 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Path-based change detector. Emits docs_only=true when EVERY file in the diff
+  # is documentation (any *.md, or anything under docs/ — prose + doc tooling).
+  # The heavy build jobs gate on this so a docs-only change skips the ~20min
+  # compile matrix while the cheap reference-check still runs. Conservative:
+  # anything that isn't clearly a doc (and every non-diff event, e.g.
+  # workflow_dispatch) counts as code and builds everything.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.detect.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+          event="${{ github.event_name }}"
+          if [ "$event" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          elif [ "$event" = "push" ]; then
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+          else
+            echo "Non-diff event ($event): building everything."
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # New branch / unknown base (all-zero SHA or missing object): build all.
+          if [ "$base" = "0000000000000000000000000000000000000000" ] || \
+             ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "Base $base unavailable: building everything."
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(git diff --name-only "${base}...${head}")
+          echo "Changed files:"
+          echo "$files"
+
+          if [ -z "$files" ]; then
+            echo "Empty diff: building everything (conservative)."
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          docs_only=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md) ;;       # markdown anywhere (README, addon docs, docs/*)
+              docs/*) ;;     # docs tree: prose, images, and doc tooling
+              *)
+                echo "Non-doc change -> full build: $f"
+                docs_only=false
+                break
+                ;;
+            esac
+          done <<< "$files"
+
+          echo "Result: docs_only=$docs_only"
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -157,6 +226,8 @@ jobs:
           fi
 
   build-android:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
@@ -240,6 +311,8 @@ jobs:
         run: ccache -s || true
 
   build-web:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 120
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,19 +25,54 @@ jobs:
         include:
           - os: macos-latest
             preset: macos
+            launcher: ccache
           # Pinned to 2022: windows-latest now redirects to a VS2026 runner,
           # where projectGenerator's VS-project generation falls back to the
           # "Visual Studio 17 2022" generator and fails (VS2022 absent). Revert
           # to windows-latest once projectGenerator supports VS2026.
+          #
+          # CI builds examples with the Ninja generator (TRUSSC_CMAKE_GENERATOR)
+          # instead of the Visual Studio generator: the compiler-launcher hook
+          # sccache relies on is ignored by the VS generator, and Ninja + cl.exe
+          # (from vcvars) is version-agnostic anyway. Local dev is unchanged.
           - os: windows-2022
             preset: windows
+            launcher: sccache
+            cmake_gen: Ninja
           - os: ubuntu-latest
             preset: linux
+            launcher: ccache
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      TRUSSC_CMAKE_GENERATOR: ${{ matrix.cmake_gen }}
+
     steps:
       - uses: actions/checkout@v5
+
+      # Compiler cache: ccache on mac/linux, sccache on Windows/MSVC (Release
+      # builds carry no /Zi, so cl objects are cacheable). Wires the compiler
+      # launcher into every cmake invocation (trusscli + all examples/tests) via
+      # the CMAKE_*_COMPILER_LAUNCHER env vars, which CMake reads at configure
+      # time. The action handles install + restore/save + restore-key prefix.
+      - name: Setup compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          variant: ${{ matrix.launcher }}
+          key: ${{ matrix.os }}-build
+          max-size: 800M
+
+      - name: Enable compiler launcher
+        shell: bash
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=${{ matrix.launcher }}" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.launcher }}" >> "$GITHUB_ENV"
+          # Hash the compiler by content, not mtime: a fresh runner VM installs
+          # the same compiler at a different mtime, which otherwise invalidates
+          # every restored ccache entry (macOS hit this: 8% hits despite a warm
+          # cache). No-op for sccache (ignores CCACHE_*).
+          echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
 
       - name: Cache build directories
         uses: actions/cache@v5
@@ -111,12 +146,37 @@ jobs:
         shell: bash
         run: ./examples/build_all.py --test-hot-reload --verbose
 
+      - name: Compiler cache stats
+        if: always()
+        shell: bash
+        run: |
+          if [ "${{ matrix.launcher }}" = "sccache" ]; then
+            sccache --show-stats || true
+          else
+            ccache -s || true
+          fi
+
   build-android:
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Setup compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          variant: ccache
+          key: android-build
+          max-size: 800M
+
+      - name: Enable compiler launcher
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          # Hash the compiler by content, not mtime, so restored entries survive
+          # a runner-VM swap (see build job for the macOS symptom).
+          echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
 
       # The NDK shipped with ubuntu-latest runners is too old for sol2's
       # libc++ trait checks (causes "substitution failure" errors when
@@ -175,12 +235,31 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build . -- -j$(nproc)
 
+      - name: Compiler cache stats
+        if: always()
+        run: ccache -s || true
+
   build-web:
     timeout-minutes: 120
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Setup compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          variant: ccache
+          key: web-build
+          max-size: 800M
+
+      - name: Enable compiler launcher
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          # Hash the compiler by content, not mtime, so restored entries survive
+          # a runner-VM swap (see build job for the macOS symptom).
+          echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
 
       - name: Cache build directories
         uses: actions/cache@v5
@@ -223,6 +302,10 @@ jobs:
              ./examples/build_all.py --web-only --test-only --verbose
           fi
 
+      - name: Compiler cache stats
+        if: always()
+        run: ccache -s || true
+
   # Verify the API reference (docs/reference/) against the real C++ headers.
   # The structure is DERIVED from the clang AST, so signatures can't drift — the
   # old signature-probe is obsolete. check.js instead guards the prose sidecar:
@@ -230,6 +313,7 @@ jobs:
   #   orphan a sidecar key with no such symbol    (renamed/removed; hard)
   #   undocumented a public symbol with no prose  (soft report, not a gate yet)
   # structure.js runs the same clang AST dump the probe used (macOS: clang + SDK).
+  # Cheap job — always runs, including on docs-only changes (not gated).
   reference-check:
     timeout-minutes: 20
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,3 +402,44 @@ jobs:
 
       - name: reference check (dup / orphan / 100% documented gate)
         run: node docs/reference/check.js --strict
+
+  # ---------------------------------------------------------------------------
+  # Aggregate gate for branch protection. The ruleset requires ONLY this job,
+  # so matrix/job renames never break required checks. It fails on any failed,
+  # cancelled, or unexpectedly-skipped job; the three heavy build jobs may be
+  # skipped only when the `changes` gate declared the diff docs-only.
+  # ---------------------------------------------------------------------------
+  ci-ok:
+    runs-on: ubuntu-latest
+    needs: [changes, build, build-android, build-web, reference-check]
+    if: always()
+    steps:
+      - name: Verify job results
+        env:
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          R_CHANGES: ${{ needs.changes.result }}
+          R_BUILD: ${{ needs.build.result }}
+          R_ANDROID: ${{ needs.build-android.result }}
+          R_WEB: ${{ needs.build-web.result }}
+          R_REF: ${{ needs.reference-check.result }}
+        run: |
+          ok=1
+          check() { # name result skippable
+            echo "$1: $2"
+            case "$2" in
+              success) ;;
+              skipped) if [ "$3" = "skippable" ] && [ "$DOCS_ONLY" = "true" ]; then
+                         echo "  -> skipped by docs-only gate (OK)"
+                       else
+                         echo "  -> unexpected skip"; ok=0
+                       fi ;;
+              *) ok=0 ;;
+            esac
+          }
+          check "changes"         "$R_CHANGES"
+          check "build"           "$R_BUILD"    skippable
+          check "build-android"   "$R_ANDROID"  skippable
+          check "build-web"       "$R_WEB"      skippable
+          check "reference-check" "$R_REF"
+          [ "$ok" = "1" ] || { echo "ci-ok: FAILING"; exit 1; }
+          echo "ci-ok: all good"

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -41,10 +41,15 @@ ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
 def get_platform_info():
     system = platform.system()
     if system == "Windows":
+        # Default to the VS generator for local dev, but allow CI (or anyone) to
+        # override it via TRUSSC_CMAKE_GENERATOR — e.g. "Ninja", which lets
+        # sccache cache compilation (the compiler-launcher hook is ignored by the
+        # Visual Studio generator). Requires cl.exe/ninja on PATH (vcvars).
+        win_gen = os.environ.get("TRUSSC_CMAKE_GENERATOR") or "Visual Studio 17 2022"
         return {
             "os": "windows",
             "build_dir": "build-windows",
-            "cmake_generator": "Visual Studio 17 2022",
+            "cmake_generator": win_gen,
             "pg_bin_path": ["tools", "bin", "trusscli.exe"]
         }
     elif system == "Darwin":
@@ -177,6 +182,21 @@ def run_command(cmd, cwd, verbose=False):
                 print(e.stdout.decode('utf-8', errors='replace'))
         return False
 
+def cmake_config_cmd(build_dir_name, platform_info):
+    # Assemble the `cmake -S . -B <dir>` configure command for the current
+    # platform/generator. Single-config generators (Ninja, Makefiles) need the
+    # build type pinned at configure time (--config is multi-config only), so
+    # add it when a non-multi-config generator is explicitly selected. The
+    # default (None) path — mac/linux Makefiles — is left untouched.
+    cmd = ["cmake", "-S", ".", "-B", build_dir_name]
+    gen = platform_info["cmake_generator"]
+    if gen:
+        cmd.extend(["-G", gen])
+        if "Visual Studio" not in gen and "Xcode" not in gen:
+            cmd.append("-DCMAKE_BUILD_TYPE=Release")
+    return cmd
+
+
 def build_and_run_test(test_dir, pg_bin, platform_info, args):
     # Build a native console test project, then RUN it (non-zero exit = failure).
     # Returns (ok, stage) where stage names what failed for the summary.
@@ -185,9 +205,7 @@ def build_and_run_test(test_dir, pg_bin, platform_info, args):
         return False, "update"
 
     build_dir_name = platform_info["build_dir"]
-    cmd_config = ["cmake", "-S", ".", "-B", build_dir_name]
-    if platform_info["cmake_generator"]:
-        cmd_config.extend(["-G", platform_info["cmake_generator"]])
+    cmd_config = cmake_config_cmd(build_dir_name, platform_info)
     if not run_command(cmd_config, cwd=test_dir, verbose=args.verbose):
         return False, "configure"
 
@@ -212,9 +230,7 @@ def build_and_run_unit_test(test_dir, pg_bin, platform_info, args):
     # Build a standalone CMake test (its own committed CMakeLists.txt, no
     # trusscli), then RUN it (non-zero exit = failure). pg_bin is unused.
     build_dir_name = platform_info["build_dir"]
-    cmd_config = ["cmake", "-S", ".", "-B", build_dir_name]
-    if platform_info["cmake_generator"]:
-        cmd_config.extend(["-G", platform_info["cmake_generator"]])
+    cmd_config = cmake_config_cmd(build_dir_name, platform_info)
     if not run_command(cmd_config, cwd=test_dir, verbose=args.verbose):
         return False, "configure"
 
@@ -395,10 +411,8 @@ def main():
             if args.clean and os.path.exists(build_dir):
                 shutil.rmtree(build_dir)
 
-            cmd_config = ["cmake", "-S", ".", "-B", build_dir_name]
-            if platform_info["cmake_generator"]:
-                cmd_config.extend(["-G", platform_info["cmake_generator"]])
-            
+            cmd_config = cmake_config_cmd(build_dir_name, platform_info)
+
             if not run_command(cmd_config, cwd=example_dir, verbose=args.verbose):
                 Colors.print(f"  Native Configure failed!", Colors.RED)
                 failed_count += 1


### PR DESCRIPTION
Cuts warm PR CI wall time from ~20min to ~6min.

- ccache on macOS/Linux/Android/Web, sccache on Windows (examples switch to Ninja in CI only — the compiler-launcher hook is ignored by the VS generator; local builds unchanged). Per-job cache with stats steps for auditability; a cache miss never fails a build.
- `CCACHE_COMPILERCHECK=content` so fresh runner VMs don't invalidate the cache (compiler mtime varies per image).
- New `changes` job: heavy build jobs skip when the diff touches only `docs/**` / `*.md`; `reference-check` always runs. Conservative fallbacks (non-diff events or unknown diff → full build). Verified with a real docs-only run (builds skipped, reference-check green).
- `build_all.py`: `TRUSSC_CMAKE_GENERATOR` env override + `CMAKE_BUILD_TYPE=Release` pin for single-config generators.

Measured cold→warm: macOS 18m→6m, Linux 11m→4.5m, Windows 10m→3.7m (hit rates 87–98%).