### PR TITLE
doc: recording tools + drawBitmapString billboard behavior

### DIFF
--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -49,6 +49,15 @@ TrussC uses **HTTP transport** for MCP. All JSON-RPC messages are sent as HTTP P
 | `get_node_tree` | `id`, `depth` (both optional) | Dump the node tree (or a subtree) as JSON: per node `{type, name, id, members, mods, children}`. Members are the `TC_REFLECT`ed values — rotation as euler degrees, colors as `[r,g,b,a]` floats 0-1, Vec3 as `[x,y,z]`, enums as their label string. `mods` lists each attached Mod as `{type, members}`. `depth` limits recursion (~270 bytes/node — on large scenes, explore with `depth` + drill into subtrees by `id`; cut-off nodes carry a `childCount`) |
 | `get_selected_node` | (none) | The currently selected node (same shape, no children), or `null` |
 
+### Recording Tools (always available in MCP mode)
+
+The video counterpart of `save_screenshot` — capture the window to a video file with the native encoder (no ffmpeg). Always registered when MCP is enabled, but unlike the inspection tools these *write* (start/stop a recording), so they are listed separately.
+
+| Tool | Arguments | Description |
+|------|-----------|-------------|
+| `start_recording` | `path`, `duration`, `fps`, `codec` (all optional) | Start recording the window. Omit `path` for a timestamped `recording-<timestamp>.mp4` (`.mov` for ProRes) in the data dir; relative paths resolve under the data dir. `duration` (seconds) makes a fixed-length clip that **auto-stops and finalizes itself** at exactly that length (omit or `0` = unlimited). `fps` is the target frame rate (default 60; ProMotion frames are decimated to it). `codec` is `h264` (default) / `hevc` / `prores422` / `prores4444`. Returns `{status, path (resolved), fps, codec}` plus `duration` when a fixed length was set |
+| `stop_recording` | (none) | Stop the current recording and finalize the file. A manual stop **always wins** over a pending fixed `duration` — it finalizes immediately at the current length. Returns `{status, recording:false, path, frames, length}` (`length` = measured output seconds). Idle is not an error: returns `{status:"ok", recording:false, message:"not recording"}` |
+
 ### Debugger Tools (opt-in via `mcp::registerDebuggerTools()`)
 | Tool | Arguments | Description |
 |------|-----------|-------------|
@@ -164,11 +173,23 @@ curl -X POST http://localhost:8080/mcp \
 curl -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"tools/call","id":3,"params":{"name":"mouse_click","arguments":{"x":100,"y":200}}}'
+
+# Record a fixed 3-second clip (auto-stops & finalizes itself); omit "duration"
+# for an unlimited recording you end with stop_recording. Omit "path" for a
+# timestamped file in the data dir; the response carries the resolved path.
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","id":4,"params":{"name":"start_recording","arguments":{"path":"/tmp/clip.mp4","duration":3}}}'
+
+# Stop early (a manual stop always wins — valid shorter file); no-op if idle
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","id":5,"params":{"name":"stop_recording","arguments":{}}}'
 ```
 
 ### Taking Screenshots from Shell
 
-**IMPORTANT for AI agents**: Do NOT use macOS `screencapture` or similar OS commands. TrussC apps may render with Metal/OpenGL and the OS cannot capture the screen correctly. Always use the MCP `save_screenshot` tool.
+**IMPORTANT for AI agents**: Do NOT use macOS `screencapture`, OS screen recorders (QuickTime, `ffmpeg`-avfoundation, OBS, etc.), or similar OS commands. TrussC apps may render with Metal/OpenGL and the OS cannot capture the screen correctly. Always use the MCP tools — `save_screenshot` for a still, `start_recording` / `stop_recording` for video.
 
 ```bash
 # Start app, wait, take screenshot, then kill
@@ -212,6 +233,7 @@ Configure your MCP client with the HTTP URL:
 | Category | Tools | Enabled by |
 |----------|-------|------------|
 | Inspection (read-only) | `get_screenshot`, `save_screenshot`, `get_node_tree`, `get_selected_node` | Automatic when MCP is enabled |
+| Recording (window capture to video) | `start_recording`, `stop_recording` | Automatic when MCP is enabled |
 | Debugger (input injection / scene mutation) | `mouse_click`, `mouse_press`, `mouse_release`, `key_press`, `mouse_move`, `mouse_scroll`, `key_release`, `select_node`, `set_node_members` | `mcp::registerDebuggerTools()` |
 | ImGui (widget interaction) | `imgui_get_widgets`, `imgui_click`, `imgui_input`, `imgui_checkbox` | Requires tcxImGui addon + `mcp::registerDebuggerTools()` |
 | Custom | `mcp::tool(...)` | Your code |

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1123,6 +1123,14 @@ Two ways:
 - **Write arbitrary frames**: use `VideoWriter` — `open(path, w, h, settings)` → `addFrame(fbo)` / `addFrame(pixels)` (timestamped via `addFrameAt(frame, timeSec)`) → `close()`. For writing offscreen (FBO) content at a steady rate.
 Encoder settings: `VideoRecordSettings`. Platforms: macOS / Windows / Linux / Android / iOS.
 
+### How do I record a fixed-length clip that stops itself?
+
+Pass the length in seconds: `startRecording("out.mp4", 3.0f)` records exactly 3 seconds, then **auto-stops and finalizes the file itself** (PTS-based cut, output length == the requested length within one frame). Same as setting `VideoRecordSettings.duration` (0 = unlimited = the default). A manual `stopRecording()` **always wins**: call it early and you get a valid shorter file; call it after the auto-stop already fired and it's a harmless no-op. So you never need a timer thread to end a recording.
+
+### Can an AI agent start/stop recording over MCP?
+
+Yes — every TrussC app in MCP mode (`TRUSSC_MCP=1`) exposes `start_recording` and `stop_recording` as standard tools (the video counterpart of `save_screenshot`, always available). `start_recording` takes optional `path` (omit → timestamped file in the data dir), `duration` (fixed-length auto-stop), `fps`, and `codec`, and returns the resolved path; `stop_recording` returns `{path, frames, length}` and is a no-op (not an error) when nothing is recording. See docs/AI_AUTOMATION.md.
+
 ### How do I avoid a black first frame when a VideoPlayer starts?
 
 `VideoPlayer::load()` / `play()` decode **asynchronously**, so for the first few frames the player has no picture yet and draws **black**. To hide that flash, synchronously extract frame 0 as a still and show it until the live player has a real frame:
@@ -1197,6 +1205,14 @@ TrussC is "2D-looking but actually 3D space" by default (same philosophy as oF).
 ### Centering bitmap text? (default is left / baseline)
 
 Text alignment defaults to **left / baseline**, shared by `Font` and `drawBitmapString`. So to center, you don't need to compute an offset by hand — call **`setTextAlign(Direction::Center, Direction::Center)`** before drawing (it applies to bitmap text too).
+
+### How do I draw a text label above a 3D object (billboard)?
+
+Just call `drawBitmapString("name", worldPos)` with a `Vec3` — there is **no need to project with `worldToScreen()` by hand anymore**. The `Vec3` overloads take the position through the current model matrix and the **current camera context** (an `EasyCam`/camera scope, or the ambient default screen) and draw the glyphs as a screen-aligned billboard **on top** of the scene (no depth test), so the label always faces you and stays readable. A point **behind the camera draws nothing**. Two size modes:
+- `screenFixed = true` (default): constant pixel size regardless of distance — good for HUD-style tags.
+- `screenFixed = false`, or the `drawBitmapString(text, pos, scale)` overload: the glyph cell is measured in world units at the label's depth, so it **foreshortens with perspective** (shrinks with distance).
+
+This also works on the **default screen** (no camera scope): `z = 0` is pixel-identical to plain 2D `drawBitmapString(text, x, y)`, while `z != 0` labels the true 3D point. `setTextAlign` positions the label around the projected point.
 
 ### Why doesn't fill work on a stroke? (fill/noFill apply to beginShape only)
 

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -11603,9 +11603,9 @@ related = ["drawCurve", "Path::bezierTo", "setCurveResolution", "setCurveToleran
 category = "graphics_shapes"
 keywords = ["text", "label", "print", "ofdrawbitmapstring"]
 of = ["ofDrawBitmapString"]
-description.en = "Draw text"
-description.ja = "テキストを描画"
-description.ko = "비트맵 텍스트 그리기"
+description.en = "Draw text. The Vec3 overloads project through the current camera context — a screen-aligned 3D label; z=0 on the default screen matches plain 2D; behind-camera draws nothing; screenFixed picks fixed-pixel vs perspective size"
+description.ja = "テキストを描画。Vec3 オーバーロードは現在のカメラコンテキストで投影し、画面に正対する3Dラベルになる（デフォルト画面の z=0 は通常の2Dと一致、カメラ後方は非描画、screenFixed で固定ピクセル/遠近サイズを選択）"
+description.ko = "비트맵 텍스트 그리기. Vec3 오버로드는 현재 카메라 컨텍스트로 투영해 화면에 정렬된 3D 라벨을 그린다(기본 화면의 z=0은 일반 2D와 동일, 카메라 뒤쪽은 그리지 않음, screenFixed로 고정 픽셀/원근 크기 선택)"
 related = ["drawBitmapStringHighlight", "Font::drawString", "setTextAlign"]
 
 ["drawBitmapStringHighlight"]
@@ -14442,9 +14442,9 @@ related = ["VideoPlayer::setGammaCorrection"]
 ["startRecording"]
 category = "window_system"
 keywords = ["record", "video", "capture", "movie", "mp4"]
-description.en = "Start recording the window to a video file (native encoder, no ffmpeg)"
-description.ja = "ウィンドウを動画ファイルに録画開始（ネイティブエンコーダ、ffmpeg不要）"
-description.ko = "윈도우를 동영상 파일로 녹화 시작 (네이티브 인코더, ffmpeg 불필요)"
+description.en = "Start recording the window to a video file (native encoder, no ffmpeg). Pass a seconds argument (or VideoRecordSettings.duration) for a fixed-length clip that auto-stops and finalizes itself; 0 = unlimited"
+description.ja = "ウィンドウを動画ファイルに録画開始（ネイティブエンコーダ、ffmpeg不要）。秒数引数（または VideoRecordSettings.duration）を渡すと、その長さで自動停止・確定する固定長クリップになる（0 = 無制限）"
+description.ko = "윈도우를 동영상 파일로 녹화 시작 (네이티브 인코더, ffmpeg 불필요). 초 인자(또는 VideoRecordSettings.duration)를 넘기면 그 길이에서 자동 정지·마무리되는 고정 길이 클립이 된다(0 = 무제한)"
 related = ["VideoRecordSettings", "stopRecording", "isRecording", "saveScreenshot"]
 platform_note.en = "Global convenience over the singleton ScreenRecorder; non-functional on web for the same reason (VideoWriter stub returns false)."
 platform_note.ja = "シングルトン ScreenRecorder への薄いラッパ。同じ理由で web では機能しない（VideoWriter スタブが false）。"


### PR DESCRIPTION
Documentation follow-up for #163 and #164:

- **AI_AUTOMATION.md**: new Recording Tools section (`start_recording` / `stop_recording` — params, defaults, response shape), curl example, and the "don't use OS capture tools" note now covers video recording.
- **FOR_AI_ASSISTANT.md**: three new Q&A chunks (fixed-length recording, MCP recording tools, 3D text label / billboard) — feeds the trussc-docs MCP corpus.
- **reference prose**: `drawBitmapString` rewritten for the camera-context billboard behavior; `startRecording` mentions the fixed-duration form. `check.js --strict` green.

Docs-only change — expected to exercise the new `changes` gate: build jobs skip, `reference-check` + `ci-ok` verify.