### PR TITLE
VideoPlayer auto-poster + iOS fixes, extractFrame improvements, v0.6.5 API tightening

### DIFF
--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -2041,13 +2041,9 @@ namespace internal {
 
         setup();
 
-        // For macOS bundles, set default data path
-        // Executable: bin/xxx.app/Contents/MacOS/xxx
-        // data: bin/data/
-        // ../../../ = bin/, so ../../../data/ is the correct path
-        #ifdef __APPLE__
-        setDataPathRoot("../../../data/");
-        #endif
+        // The Apple data path root is chosen lazily on first getDataPath() use
+        // (resolveDataPathRootOnce in tcUtils.h) — probing here is too early to
+        // see a valid executable path on iOS.
 
         // Start console input thread (enabled by default)
         // To disable, call console::stop() in setup()

--- a/core/include/tc/gpu/tcFbo.h
+++ b/core/include/tc/gpu/tcFbo.h
@@ -31,6 +31,12 @@ public:
     Fbo(const Fbo&) = delete;
     Fbo& operator=(const Fbo&) = delete;
 
+    // Lifetime token for observers that hold a raw pointer to this Fbo
+    // (e.g. ScreenRecorder auto-stops when the recorded Fbo is destroyed).
+    // Per-object: it deliberately does NOT transfer on move, so an observer
+    // watching a moved-from Fbo expires when that shell is destroyed.
+    std::shared_ptr<void> lifetimeToken() const { return aliveToken_; }
+
     // Move-enabled
     Fbo(Fbo&& other) noexcept {
         moveFrom(std::move(other));
@@ -676,8 +682,10 @@ private:
     }
 
 private:
+    std::shared_ptr<void> aliveToken_ = std::make_shared<char>();
 
     void moveFrom(Fbo&& other) {
+        // aliveToken_ intentionally not moved (see lifetimeToken())
         width_ = other.width_;
         height_ = other.height_;
         sampleCount_ = other.sampleCount_;

--- a/core/include/tc/utils/tcFileDialog.h
+++ b/core/include/tc/utils/tcFileDialog.h
@@ -42,8 +42,7 @@ struct FileDialogResult {
 // title: Bold header text
 // message: Body text
 // -----------------------------------------------------------------------------
-TC_SYNC_DIALOG_UNAVAILABLE
-TC_PLATFORMS("macos,windows,linux,android,web") void alertDialog(const std::string& title, const std::string& message);
+TC_PLATFORMS("macos,windows,linux,android,web") TC_SYNC_DIALOG_UNAVAILABLE void alertDialog(const std::string& title, const std::string& message);
 
 void alertDialogAsync(const std::string& title,
                       const std::string& message,
@@ -53,8 +52,7 @@ void alertDialogAsync(const std::string& title,
 // Confirm dialog (Yes/No)
 // Returns true if user clicked Yes
 // -----------------------------------------------------------------------------
-TC_SYNC_DIALOG_UNAVAILABLE
-TC_PLATFORMS("macos,windows,linux,android,web") bool confirmDialog(const std::string& title, const std::string& message);
+TC_PLATFORMS("macos,windows,linux,android,web") TC_SYNC_DIALOG_UNAVAILABLE bool confirmDialog(const std::string& title, const std::string& message);
 
 void confirmDialogAsync(const std::string& title,
                         const std::string& message,
@@ -64,8 +62,7 @@ void confirmDialogAsync(const std::string& title,
 // File open dialog
 // folderSelection: true for folder selection mode
 // -----------------------------------------------------------------------------
-TC_SYNC_DIALOG_UNAVAILABLE
-TC_PLATFORMS("macos,windows,linux,android") FileDialogResult loadDialog(const std::string& title = "",
+TC_PLATFORMS("macos,windows,linux,android") TC_SYNC_DIALOG_UNAVAILABLE FileDialogResult loadDialog(const std::string& title = "",
                             const std::string& message = "",
                             const std::string& defaultPath = "",
                             bool folderSelection = false);
@@ -80,8 +77,7 @@ void loadDialogAsync(const std::string& title,
 // File save dialog
 // defaultName: Initial filename
 // -----------------------------------------------------------------------------
-TC_SYNC_DIALOG_UNAVAILABLE
-TC_PLATFORMS("macos,windows,linux,android") FileDialogResult saveDialog(const std::string& title = "",
+TC_PLATFORMS("macos,windows,linux,android") TC_SYNC_DIALOG_UNAVAILABLE FileDialogResult saveDialog(const std::string& title = "",
                             const std::string& message = "",
                             const std::string& defaultPath = "",
                             const std::string& defaultName = "");

--- a/core/include/tc/utils/tcUtils.h
+++ b/core/include/tc/utils/tcUtils.h
@@ -61,32 +61,34 @@ inline void setDataPathRoot(const std::string& path) {
     internal::dataPathRootUserSet = true;  // explicit choice wins over the probe
 }
 
+namespace internal {
 // One-shot: pick the Apple bundle layout by probing which data/ exists next to
 // the executable. Skipped if the user set the root explicitly. No-op elsewhere.
 inline void resolveDataPathRootOnce() {
 #ifdef __APPLE__
-    if (internal::dataPathRootProbed || internal::dataPathRootUserSet) return;
+    if (dataPathRootProbed || dataPathRootUserSet) return;
     std::string exe = getExecutableDir();
     // Don't latch until the executable path is actually available — early on
     // iOS it can be empty/"/", which would resolve the checks against the CWD.
     if (exe.empty() || exe == "/") return;
-    internal::dataPathRootProbed = true;
+    dataPathRootProbed = true;
     std::error_code ec;
     // Check the flat-bundle layout FIRST (unambiguous on iOS: data/ sits right
     // next to the executable). macOS dev has no Contents/MacOS/data, so it
     // correctly falls through to the ../../../data (bin/data) layout.
     if (std::filesystem::exists(exe + "data", ec)) {
-        internal::dataPathRoot = "data/";           // iOS flat bundle / distributed
+        dataPathRoot = "data/";           // iOS flat bundle / distributed
     } else if (std::filesystem::exists(exe + "../../../data", ec)) {
-        internal::dataPathRoot = "../../../data/";  // macOS dev / bin layout
+        dataPathRoot = "../../../data/";  // macOS dev / bin layout
     }
     // else: keep the compile-time default
 #endif
 }
+} // namespace internal
 
 // Get the data path root
 inline std::string getDataPathRoot() {
-    resolveDataPathRootOnce();
+    internal::resolveDataPathRootOnce();
     return internal::dataPathRoot;
 }
 
@@ -94,7 +96,7 @@ inline std::string getDataPathRoot() {
 // - If filename is absolute, return as-is
 // - Otherwise, resolved relative to executable directory + dataPathRoot
 inline std::string getDataPath(const std::string& filename) {
-    resolveDataPathRootOnce();
+    internal::resolveDataPathRootOnce();
 
     // If filename is absolute, return as-is (like oF)
     // Uses std::filesystem for cross-platform support (Unix: /path, Windows: C:\path)

--- a/core/include/tc/utils/tcUtils.h
+++ b/core/include/tc/utils/tcUtils.h
@@ -30,14 +30,21 @@ namespace internal {
 // ---------------------------------------------------------------------------
 
 namespace internal {
-    // Default is "data/" relative to executable directory
-    // On macOS, executable is in xxx.app/Contents/MacOS/, so "../../../data/" points to bin/data/
+    // Compile-time default. On Apple the true root differs by bundle layout
+    // and is chosen at runtime (see resolveDataPathRootOnce): macOS keeps data
+    // in bin/data/ reached via ../../../ from Contents/MacOS/, while iOS uses a
+    // FLAT bundle with data/ right next to the executable. Existence, not a
+    // preprocessor macro, is the source of truth (TARGET_OS_* proved unreliable
+    // in the iOS build, and the runtime probe also runs too early in _setup_cb
+    // to see a valid executable path — so it happens lazily on first use).
     #ifdef __APPLE__
     inline std::string dataPathRoot = "../../../data/";
     #else
     inline std::string dataPathRoot = "data/";
     #endif
     inline bool dataPathRootIsAbsolute = false;
+    inline bool dataPathRootUserSet = false;  // user called setDataPathRoot()
+    inline bool dataPathRootProbed = false;   // lazy Apple probe done
 }
 
 // Set the data path root
@@ -51,10 +58,35 @@ inline void setDataPathRoot(const std::string& path) {
     }
     // Record whether path is absolute
     internal::dataPathRootIsAbsolute = (!path.empty() && path[0] == '/');
+    internal::dataPathRootUserSet = true;  // explicit choice wins over the probe
+}
+
+// One-shot: pick the Apple bundle layout by probing which data/ exists next to
+// the executable. Skipped if the user set the root explicitly. No-op elsewhere.
+inline void resolveDataPathRootOnce() {
+#ifdef __APPLE__
+    if (internal::dataPathRootProbed || internal::dataPathRootUserSet) return;
+    std::string exe = getExecutableDir();
+    // Don't latch until the executable path is actually available — early on
+    // iOS it can be empty/"/", which would resolve the checks against the CWD.
+    if (exe.empty() || exe == "/") return;
+    internal::dataPathRootProbed = true;
+    std::error_code ec;
+    // Check the flat-bundle layout FIRST (unambiguous on iOS: data/ sits right
+    // next to the executable). macOS dev has no Contents/MacOS/data, so it
+    // correctly falls through to the ../../../data (bin/data) layout.
+    if (std::filesystem::exists(exe + "data", ec)) {
+        internal::dataPathRoot = "data/";           // iOS flat bundle / distributed
+    } else if (std::filesystem::exists(exe + "../../../data", ec)) {
+        internal::dataPathRoot = "../../../data/";  // macOS dev / bin layout
+    }
+    // else: keep the compile-time default
+#endif
 }
 
 // Get the data path root
 inline std::string getDataPathRoot() {
+    resolveDataPathRootOnce();
     return internal::dataPathRoot;
 }
 
@@ -62,6 +94,8 @@ inline std::string getDataPathRoot() {
 // - If filename is absolute, return as-is
 // - Otherwise, resolved relative to executable directory + dataPathRoot
 inline std::string getDataPath(const std::string& filename) {
+    resolveDataPathRootOnce();
+
     // If filename is absolute, return as-is (like oF)
     // Uses std::filesystem for cross-platform support (Unix: /path, Windows: C:\path)
     if (!filename.empty() && std::filesystem::path(filename).is_absolute()) {

--- a/core/include/tc/video/tcVideoGrabber.h
+++ b/core/include/tc/video/tcVideoGrabber.h
@@ -15,6 +15,7 @@
 #include <deque>
 #include <memory>
 #include <cstdint>
+#include <cstring>
 
 namespace trussc {
 
@@ -41,9 +42,7 @@ struct VideoDeviceInfo {
 // arrives from the driver - it stays correct even if the app's main loop
 // stalls. It is NOT wall-clock time; use it for interval math only.
 struct GrabberFrame {
-    std::vector<unsigned char> pixels;  // RGBA8
-    int width = 0;
-    int height = 0;
+    Pixels pixels;             // RGBA8 (carries its own width/height/channels)
     uint64_t timestampUs = 0;  // steady_clock, microseconds since epoch of that clock
 };
 
@@ -63,10 +62,9 @@ struct GrabberFrameQueue {
         size_t cap = maxFrames.load(std::memory_order_relaxed);
         if (cap == 0 || !rgba || w <= 0 || h <= 0) return;
         GrabberFrame f;
-        f.width = w;
-        f.height = h;
         f.timestampUs = tUs;
-        f.pixels.assign(rgba, rgba + (size_t)w * h * 4);
+        f.pixels.allocate(w, h, 4);
+        std::memcpy(f.pixels.getData(), rgba, (size_t)w * h * 4);
         std::lock_guard<std::mutex> lock(mtx);
         while (frames.size() >= cap) frames.pop_front();
         frames.push_back(std::move(f));

--- a/core/include/tc/video/tcVideoGrabber.h
+++ b/core/include/tc/video/tcVideoGrabber.h
@@ -273,7 +273,7 @@ public:
     // Drain all frames captured since the last call (appended to out, oldest
     // first). Returns the number of frames appended. Frames are moved out of
     // the internal queue, so each frame is delivered exactly once.
-    TC_PLATFORMS("macos,windows,linux") size_t getBufferFrames(std::vector<GrabberFrame>& out) {
+    TC_PLATFORMS("macos,windows,linux") size_t getQueuedFrames(std::vector<GrabberFrame>& out) {
         std::lock_guard<std::mutex> lock(frameQueue_->mtx);
         size_t n = frameQueue_->frames.size();
         for (auto& f : frameQueue_->frames) out.push_back(std::move(f));
@@ -334,7 +334,7 @@ private:
     mutable std::mutex mutex_;
     std::atomic<bool> pixelsDirty_{false};
 
-    // Timestamped frame FIFO (see getBufferFrames). unique_ptr keeps the
+    // Timestamped frame FIFO (see getQueuedFrames). unique_ptr keeps the
     // address stable across moves - the capture callback holds a raw pointer.
     std::unique_ptr<internal::GrabberFrameQueue> frameQueue_ =
         std::make_unique<internal::GrabberFrameQueue>();

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -487,7 +487,57 @@ public:
         return extractKeyFramePlatform(sourcePath_, outPixels, timeSec, outDuration);
     }
 
+    // -------------------------------------------------------------------------
+    // Image convenience overloads. Same extraction, but the result lands in a
+    // ready-to-draw Image (allocate + texture upload included). GPU upload =>
+    // MAIN THREAD ONLY; use the Pixels overloads for background work.
+    // -------------------------------------------------------------------------
+
+    /// Extract the exact frame at a time into a ready-to-draw Image (static).
+    static bool extractFrame(const std::string& path, Image& outImage,
+                             float timeSec = 1.0f, float* outDuration = nullptr) {
+        Pixels px;
+        if (!extractFramePlatform(path, px, timeSec, outDuration)) return false;
+        pixelsToImage(px, outImage);
+        return true;
+    }
+
+    /// Extract the nearest keyframe at or before a time into a ready-to-draw
+    /// Image (static, faster).
+    static bool extractKeyFrame(const std::string& path, Image& outImage,
+                                float timeSec = 1.0f, float* outDuration = nullptr) {
+        Pixels px;
+        if (!extractKeyFramePlatform(path, px, timeSec, outDuration)) return false;
+        pixelsToImage(px, outImage);
+        return true;
+    }
+
+    /// Extract the exact frame from the currently loaded video into a
+    /// ready-to-draw Image (instance). Returns false if no video is loaded.
+    bool extractFrame(Image& outImage, float timeSec = 1.0f,
+                      float* outDuration = nullptr) const {
+        if (sourcePath_.empty()) return false;
+        return extractFrame(sourcePath_, outImage, timeSec, outDuration);
+    }
+
+    /// Extract the nearest keyframe from the currently loaded video into a
+    /// ready-to-draw Image (instance, faster). Returns false if no video is loaded.
+    bool extractKeyFrame(Image& outImage, float timeSec = 1.0f,
+                         float* outDuration = nullptr) const {
+        if (sourcePath_.empty()) return false;
+        return extractKeyFrame(sourcePath_, outImage, timeSec, outDuration);
+    }
+
 private:
+    // Move extracted pixels into a drawable Image (allocate + upload).
+    static void pixelsToImage(const Pixels& px, Image& img) {
+        img.allocate(px.getWidth(), px.getHeight(), 4);
+        std::memcpy(img.getPixelsData(), px.getData(),
+                    (size_t)px.getWidth() * px.getHeight() * 4);
+        img.setDirty();
+        img.update();
+    }
+
     static bool extractFramePlatform(const std::string& path, Pixels& outPixels,
                                      float timeSec, float* outDuration);
     static bool extractKeyFramePlatform(const std::string& path, Pixels& outPixels,

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -58,8 +58,10 @@ public:
             close();
         }
 
-        // Resolve relative paths via getDataPath
-        std::string resolvedPath = getDataPath(path);
+        // Resolve relative paths via getDataPath; URLs pass through untouched
+        // (the web backend streams straight from them)
+        bool isUrl = path.rfind("http://", 0) == 0 || path.rfind("https://", 0) == 0;
+        std::string resolvedPath = isUrl ? path : getDataPath(path);
 
         // Platform-specific load
         if (!loadPlatform(resolvedPath)) {
@@ -86,12 +88,20 @@ public:
                 }
             } else {
                 texture_.allocate(width_, height_, 4, TextureUsage::Stream);
-                clearTexture();
             }
         }
 
         initialized_ = true;
         firstFrameReceived_ = false;
+        posterActive_ = false;
+
+        // Auto poster: synchronously put frame 0 on the texture so drawing
+        // never shows black between load() and the first decoded frame.
+        // Frame 0 is always a keyframe, so this is exact AND fast.
+        // Stream textures accept ONE loadData per frame, so the poster and
+        // the black-clear are alternatives, never both.
+        bool postered = autoPoster_ && loadPosterFrame(0.0f);
+        if (!postered) clearTexture();
         return true;
     }
 
@@ -115,6 +125,9 @@ public:
         paused_ = false;
         frameNew_ = false;
         firstFrameReceived_ = false;
+        posterActive_ = false;
+        lastShownTime_ = -1.0f;
+        pendingSeekSec_ = -1.0f;
         done_ = false;
         width_ = 0;
         height_ = 0;
@@ -150,11 +163,50 @@ public:
             }
         }
 
+        // A live frame replaces the poster; free the temporary poster
+        // texture in NV12 mode (the shader path takes over). Track what
+        // moment the picture on the texture belongs to (poster decisions).
+        if (frameNew_) {
+            lastShownTime_ = getCurrentTime();
+            pendingSeekSec_ = -1.0f;  // live playback reflects the position now
+            if (posterActive_) {
+                posterActive_ = false;
+                if (nv12Mode_) texture_.clear();
+            }
+        }
+
         // Check if playback finished
         if (playing_ && !paused_ && isFinishedPlatform()) {
             markDone();
         }
     }
+
+    // =========================================================================
+    // Playback (auto poster on play)
+    // =========================================================================
+
+    void play() override {
+        // Invariant: the texture always shows the frame AT the playback
+        // position. If the position moved while stopped/paused (seek) or the
+        // texture is still empty, bridge with the exact frame synchronously
+        // so playback never starts on black or on a stale picture.
+        if (autoPoster_ && initialized_) {
+            float t = (pendingSeekSec_ >= 0.0f) ? pendingSeekSec_ : getCurrentTime();
+            if (!firstFrameReceived_ || fabsf(t - lastShownTime_) > 0.05f) {
+                loadPosterFrame(t);
+            }
+        }
+        VideoPlayerBase::play();
+    }
+
+    // Auto poster (default ON): on load()/play(), synchronously extract the
+    // frame at the current position and show it until live frames arrive, so
+    // the player never draws its cleared (black) texture. Turn off if the
+    // one-time synchronous decode at load/play is undesirable. No effect on
+    // platforms without frame extraction (Android/web - web bridges via the
+    // <video> element instead).
+    void setAutoPoster(bool on) { autoPoster_ = on; }
+    bool getAutoPoster() const { return autoPoster_; }
 
     // =========================================================================
     // Draw (NV12 path uses shader; RGBA path uses default HasTexture::draw)
@@ -166,7 +218,9 @@ public:
 
     void draw(float x, float y, float w, float h) const override {
 #if defined(__linux__) && !defined(__ANDROID__)
-        if (nv12Mode_ && nv12ShaderHandle_) {
+        // While the poster is up, draw it even in NV12 mode (the poster is an
+        // RGBA texture; the Y/UV planes still hold priming data).
+        if (nv12Mode_ && nv12ShaderHandle_ && !posterActive_) {
             drawNV12Platform(x, y, w, h);
             return;
         }
@@ -293,7 +347,13 @@ protected:
 
     void stopImpl() override {
         stopPlatform();
-        clearTexture();
+        // stop() rewinds to the beginning, so put frame 0 on the texture:
+        // the picture always matches the playback position, and a following
+        // play() starts from an already-correct image (no black, no stale
+        // frame). Platforms without extraction keep the last frame until the
+        // element/decoder surfaces frame 0 itself.
+        pendingSeekSec_ = -1.0f;
+        if (autoPoster_) loadPosterFrame(0.0f);
     }
 
     void setPausedImpl(bool paused) override {
@@ -302,6 +362,10 @@ protected:
 
     void setPositionImpl(float pct) override {
         setPositionPlatform(pct);
+        // Seeks are async on most backends, so getCurrentTime() right after a
+        // seek still returns the OLD position. Remember the target: the
+        // poster logic in play() uses it until a live frame supersedes it.
+        pendingSeekSec_ = pct * getDurationPlatform();
     }
 
     void setVolumeImpl(float vol) override {
@@ -332,6 +396,10 @@ private:
     Texture textureY_;
     Texture textureUV_;
     bool  nv12Mode_       = false;
+    bool  autoPoster_     = true;   // extract-and-show a poster on load/play
+    bool  posterActive_   = false;  // poster currently on texture_ (until live)
+    float lastShownTime_  = -1.0f;  // time (sec) of the picture on the texture
+    float pendingSeekSec_ = -1.0f;  // seek target awaiting playback (-1 = none)
     void* nv12ShaderHandle_ = nullptr;  // NV12VideoShader* on Linux/CUDA
 
     // Gamma correction (1.0 = none)
@@ -370,6 +438,10 @@ private:
         textureY_  = std::move(other.textureY_);
         textureUV_ = std::move(other.textureUV_);
         nv12Mode_        = other.nv12Mode_;
+        autoPoster_      = other.autoPoster_;
+        posterActive_    = other.posterActive_;
+        lastShownTime_   = other.lastShownTime_;
+        pendingSeekSec_  = other.pendingSeekSec_;
         nv12ShaderHandle_ = other.nv12ShaderHandle_;
         platformHandle_  = other.platformHandle_;
         sourcePath_      = std::move(other.sourcePath_);
@@ -386,6 +458,34 @@ private:
     }
 
     // Clear texture to black (prevents old frame from showing)
+    // Extract the frame at timeSec and put it on texture_ as a poster.
+    // timeSec <= 0 uses the keyframe path (frame 0 is a keyframe: exact+fast).
+    // Marks the player ready (isReady) - drawing now shows a real picture.
+    // Returns false when extraction is unavailable/failed (caller clears).
+    bool loadPosterFrame(float timeSec) {
+        if (sourcePath_.empty() || width_ <= 0 || height_ <= 0) return false;
+        Pixels px;
+        bool ok = (timeSec <= 0.001f)
+                      ? extractKeyFramePlatform(sourcePath_, px, 0.0f, nullptr)
+                      : extractFramePlatform(sourcePath_, px, timeSec, nullptr);
+        if (!ok || px.getWidth() != width_ || px.getHeight() != height_) return false;
+        if (!texture_.isAllocated()) {
+            texture_.allocate(width_, height_, 4, TextureUsage::Stream);
+        }
+        {
+            // keep the CPU mirror in sync so getPixels() matches what is shown
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (pixels_) {
+                std::memcpy(pixels_, px.getData(), (size_t)width_ * height_ * 4);
+            }
+        }
+        texture_.loadData(px.getData(), width_, height_, 4);
+        posterActive_ = true;
+        lastShownTime_ = timeSec;    // the picture now belongs to this moment
+        firstFrameReceived_ = true;  // isReady: a real picture is on the texture
+        return true;
+    }
+
     void clearTexture() {
         if (width_ > 0 && height_ > 0 && pixels_) {
             std::lock_guard<std::mutex> lock(mutex_);

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -451,11 +451,11 @@ public:
     /// Extract the exact frame at a time from a video file (static).
     /// @param path      Video file path
     /// @param outPixels Receives the extracted frame (RGBA U8)
-    /// @param timeSec   Time in seconds to extract from (default 1.0)
+    /// @param timeSec   Time in seconds to extract from
     /// @param outDuration If non-null, receives video duration in seconds
     /// @return true on success
     static bool extractFrame(const std::string& path, Pixels& outPixels,
-                             float timeSec = 1.0f, float* outDuration = nullptr) {
+                             float timeSec, float* outDuration = nullptr) {
         return extractFramePlatform(path, outPixels, timeSec, outDuration);
     }
 
@@ -463,17 +463,17 @@ public:
     /// The returned frame's real time may be earlier than timeSec.
     /// @param path      Video file path
     /// @param outPixels Receives the extracted frame (RGBA U8)
-    /// @param timeSec   Upper-bound time in seconds (default 1.0)
+    /// @param timeSec   Upper-bound time in seconds
     /// @param outDuration If non-null, receives video duration in seconds
     /// @return true on success
     static bool extractKeyFrame(const std::string& path, Pixels& outPixels,
-                                float timeSec = 1.0f, float* outDuration = nullptr) {
+                                float timeSec, float* outDuration = nullptr) {
         return extractKeyFramePlatform(path, outPixels, timeSec, outDuration);
     }
 
     /// Extract the exact frame at a time from the currently loaded video
     /// (instance). Returns false if no video is loaded.
-    bool extractFrame(Pixels& outPixels, float timeSec = 1.0f,
+    bool extractFrame(Pixels& outPixels, float timeSec,
                       float* outDuration = nullptr) const {
         if (sourcePath_.empty()) return false;
         return extractFramePlatform(sourcePath_, outPixels, timeSec, outDuration);
@@ -481,7 +481,7 @@ public:
 
     /// Extract the nearest keyframe at or before a time from the currently
     /// loaded video (instance, faster). Returns false if no video is loaded.
-    bool extractKeyFrame(Pixels& outPixels, float timeSec = 1.0f,
+    bool extractKeyFrame(Pixels& outPixels, float timeSec,
                          float* outDuration = nullptr) const {
         if (sourcePath_.empty()) return false;
         return extractKeyFramePlatform(sourcePath_, outPixels, timeSec, outDuration);
@@ -495,7 +495,7 @@ public:
 
     /// Extract the exact frame at a time into a ready-to-draw Image (static).
     static bool extractFrame(const std::string& path, Image& outImage,
-                             float timeSec = 1.0f, float* outDuration = nullptr) {
+                             float timeSec, float* outDuration = nullptr) {
         Pixels px;
         if (!extractFramePlatform(path, px, timeSec, outDuration)) return false;
         pixelsToImage(px, outImage);
@@ -505,7 +505,7 @@ public:
     /// Extract the nearest keyframe at or before a time into a ready-to-draw
     /// Image (static, faster).
     static bool extractKeyFrame(const std::string& path, Image& outImage,
-                                float timeSec = 1.0f, float* outDuration = nullptr) {
+                                float timeSec, float* outDuration = nullptr) {
         Pixels px;
         if (!extractKeyFramePlatform(path, px, timeSec, outDuration)) return false;
         pixelsToImage(px, outImage);
@@ -514,7 +514,7 @@ public:
 
     /// Extract the exact frame from the currently loaded video into a
     /// ready-to-draw Image (instance). Returns false if no video is loaded.
-    bool extractFrame(Image& outImage, float timeSec = 1.0f,
+    bool extractFrame(Image& outImage, float timeSec,
                       float* outDuration = nullptr) const {
         if (sourcePath_.empty()) return false;
         return extractFrame(sourcePath_, outImage, timeSec, outDuration);
@@ -522,7 +522,7 @@ public:
 
     /// Extract the nearest keyframe from the currently loaded video into a
     /// ready-to-draw Image (instance, faster). Returns false if no video is loaded.
-    bool extractKeyFrame(Image& outImage, float timeSec = 1.0f,
+    bool extractKeyFrame(Image& outImage, float timeSec,
                          float* outDuration = nullptr) const {
         if (sourcePath_.empty()) return false;
         return extractKeyFrame(sourcePath_, outImage, timeSec, outDuration);

--- a/core/include/tc/video/tcVideoPlayer.h
+++ b/core/include/tc/video/tcVideoPlayer.h
@@ -126,6 +126,9 @@ public:
         frameNew_ = false;
         firstFrameReceived_ = false;
         posterActive_ = false;
+        posterUploadPending_ = false;
+        posterPx_.clear();
+        texUploadFrame_ = ~0ull;
         lastShownTime_ = -1.0f;
         pendingSeekSec_ = -1.0f;
         done_ = false;
@@ -158,6 +161,7 @@ public:
             } else {
                 if (pixels_ && width_ > 0 && height_ > 0) {
                     texture_.loadData(pixels_, width_, height_, 4);
+                    texUploadFrame_ = sapp_frame_count();
                     markFrameNew();
                 }
             }
@@ -178,6 +182,24 @@ public:
         // Check if playback finished
         if (playing_ && !paused_ && isFinishedPlatform()) {
             markDone();
+        }
+
+        // Deferred poster upload: the poster from stop()/seek+play() could not
+        // use this texture's once-per-frame upload slot when it was requested
+        // (a live frame had it). A live frame arriving now supersedes it;
+        // otherwise the slot is free on this fresh frame - upload for real so
+        // the picture on screen matches the playback position.
+        if (posterUploadPending_) {
+            if (frameNew_) {
+                posterUploadPending_ = false;
+                posterPx_.clear();
+            } else if (posterPx_.isAllocated() && texture_.isAllocated()
+                       && texUploadFrame_ != sapp_frame_count()) {
+                texture_.loadData(posterPx_.getData(), width_, height_, 4);
+                texUploadFrame_ = sapp_frame_count();
+                posterUploadPending_ = false;
+                posterPx_.clear();
+            }
         }
     }
 
@@ -398,6 +420,9 @@ private:
     bool  nv12Mode_       = false;
     bool  autoPoster_     = true;   // extract-and-show a poster on load/play
     bool  posterActive_   = false;  // poster currently on texture_ (until live)
+    Pixels posterPx_;               // poster awaiting upload (deferred one frame)
+    bool  posterUploadPending_ = false;  // upload posterPx_ on the next update()
+    uint64_t texUploadFrame_ = ~0ull;    // sapp frame of the last texture_ upload
     float lastShownTime_  = -1.0f;  // time (sec) of the picture on the texture
     float pendingSeekSec_ = -1.0f;  // seek target awaiting playback (-1 = none)
     void* nv12ShaderHandle_ = nullptr;  // NV12VideoShader* on Linux/CUDA
@@ -440,6 +465,9 @@ private:
         nv12Mode_        = other.nv12Mode_;
         autoPoster_      = other.autoPoster_;
         posterActive_    = other.posterActive_;
+        posterPx_        = std::move(other.posterPx_);
+        posterUploadPending_ = other.posterUploadPending_;
+        texUploadFrame_  = other.texUploadFrame_;
         lastShownTime_   = other.lastShownTime_;
         pendingSeekSec_  = other.pendingSeekSec_;
         nv12ShaderHandle_ = other.nv12ShaderHandle_;
@@ -449,6 +477,8 @@ private:
         other.pixels_    = nullptr;
         other.pixelsY_   = nullptr;
         other.pixelsUV_  = nullptr;
+        other.posterUploadPending_ = false;
+        other.texUploadFrame_      = ~0ull;
         other.nv12Mode_        = false;
         other.nv12ShaderHandle_ = nullptr;
         other.initialized_     = false;
@@ -469,7 +499,8 @@ private:
                       ? extractKeyFramePlatform(sourcePath_, px, 0.0f, nullptr)
                       : extractFramePlatform(sourcePath_, px, timeSec, nullptr);
         if (!ok || px.getWidth() != width_ || px.getHeight() != height_) return false;
-        if (!texture_.isAllocated()) {
+        bool freshTexture = !texture_.isAllocated();
+        if (freshTexture) {
             texture_.allocate(width_, height_, 4, TextureUsage::Stream);
         }
         {
@@ -479,7 +510,20 @@ private:
                 std::memcpy(pixels_, px.getData(), (size_t)width_ * height_ * 4);
             }
         }
-        texture_.loadData(px.getData(), width_, height_, 4);
+        // texture_ accepts ONE loadData per app frame (sokol). During playback
+        // the live frame usually took this frame's slot already, so uploading
+        // now would be silently dropped and the screen would keep the stale
+        // frame. Defer to the next update() in that case (the slot is free
+        // there - or a new live frame supersedes the poster anyway).
+        if (freshTexture || texUploadFrame_ != sapp_frame_count()) {
+            texture_.loadData(px.getData(), width_, height_, 4);
+            texUploadFrame_ = sapp_frame_count();
+            posterUploadPending_ = false;
+            posterPx_.clear();
+        } else {
+            posterPx_ = std::move(px);
+            posterUploadPending_ = true;
+        }
         posterActive_ = true;
         lastShownTime_ = timeSec;    // the picture now belongs to this moment
         firstFrameReceived_ = true;  // isReady: a real picture is on the texture
@@ -491,6 +535,7 @@ private:
             std::lock_guard<std::mutex> lock(mutex_);
             std::memset(pixels_, 0, width_ * height_ * 4);
             texture_.loadData(pixels_, width_, height_, 4);
+            texUploadFrame_ = sapp_frame_count();
         }
     }
 

--- a/core/include/tc/video/tcVideoPlayerBase.h
+++ b/core/include/tc/video/tcVideoPlayerBase.h
@@ -38,7 +38,10 @@ public:
 
     virtual void play() {
         if (!initialized_) return;
-        firstFrameReceived_ = false;
+        // NOTE: firstFrameReceived_ (isReady) is NOT reset here - the texture
+        // still holds the last picture, so drawing does not show black.
+        // It resets only when the texture actually goes empty/black:
+        // load(), stop() (clears the texture) and close().
         done_ = false;
         playImpl();
         playing_ = true;
@@ -81,11 +84,11 @@ public:
     bool isPlaying() const { return playing_ && !paused_; }
     bool isPaused() const { return paused_; }
     bool isFrameNew() const { return frameNew_ && firstFrameReceived_; }
-    // True once the texture holds a real decoded frame for the current
-    // playback — i.e. drawing shows actual video, not the cleared texture.
-    // False after load()/play()/stop() until the first frame arrives (the
-    // "would draw black" window). Seeking and pausing keep it true (the
-    // last frame stays on the texture).
+    // True while the texture holds a real decoded frame — i.e. drawing shows
+    // actual video, not the cleared (black) texture. False after load() and
+    // stop() (both leave the texture cleared) until the first frame arrives;
+    // play(), seeking and pausing keep it true (the last picture stays on
+    // the texture).
     bool isReady() const { return firstFrameReceived_; }
     bool isDone() const { return done_; }
 

--- a/core/include/tc/video/tcVideoPlayerBase.h
+++ b/core/include/tc/video/tcVideoPlayerBase.h
@@ -81,6 +81,12 @@ public:
     bool isPlaying() const { return playing_ && !paused_; }
     bool isPaused() const { return paused_; }
     bool isFrameNew() const { return frameNew_ && firstFrameReceived_; }
+    // True once the texture holds a real decoded frame for the current
+    // playback — i.e. drawing shows actual video, not the cleared texture.
+    // False after load()/play()/stop() until the first frame arrives (the
+    // "would draw black" window). Seeking and pausing keep it true (the
+    // last frame stays on the texture).
+    bool isReady() const { return firstFrameReceived_; }
     bool isDone() const { return done_; }
 
     // =========================================================================

--- a/core/include/tc/video/tcVideoPlayerBase.h
+++ b/core/include/tc/video/tcVideoPlayerBase.h
@@ -58,7 +58,10 @@ public:
         playing_ = false;
         paused_ = false;
         done_ = false;
-        firstFrameReceived_ = false;
+        // firstFrameReceived_ (isReady) is kept: the texture still holds a
+        // real picture (players poster frame 0 on stop, or keep the last
+        // frame). It only resets on load()/close(), when the texture is
+        // actually empty.
     }
 
     virtual void setPaused(bool paused) {
@@ -84,11 +87,10 @@ public:
     bool isPlaying() const { return playing_ && !paused_; }
     bool isPaused() const { return paused_; }
     bool isFrameNew() const { return frameNew_ && firstFrameReceived_; }
-    // True while the texture holds a real decoded frame — i.e. drawing shows
-    // actual video, not the cleared (black) texture. False after load() and
-    // stop() (both leave the texture cleared) until the first frame arrives;
-    // play(), seeking and pausing keep it true (the last picture stays on
-    // the texture).
+    // True while the texture holds a real picture — i.e. drawing shows
+    // actual video, not the cleared (black) texture. False only between
+    // load() and the first picture (poster or decoded frame); play(),
+    // stop(), seeking and pausing all keep a real picture on the texture.
     bool isReady() const { return firstFrameReceived_; }
     bool isDone() const { return done_; }
 

--- a/core/include/tc/video/tcVideoRecorder.h
+++ b/core/include/tc/video/tcVideoRecorder.h
@@ -350,6 +350,7 @@ private:
         if (!writer_.open(path, w, h, settings)) return false;
         source_ = src;
         fbo_ = fbo;
+        fboAlive_ = fbo ? fbo->lifetimeToken() : std::shared_ptr<void>{};
         duration_ = settings.duration;
         startElapsed_ = getElapsedTimef();
         nextCaptureTime_ = -1.0f;
@@ -361,6 +362,14 @@ private:
 
     void onAfterFrame() {
         if (!writer_.isOpen()) return;
+        // Recorded Fbo was destroyed: finalize instead of reading a dangling
+        // pointer. The file stays valid up to the last captured frame.
+        if (source_ == Source::Fbo && fboAlive_.expired()) {
+            logWarning("ScreenRecorder")
+                << "recorded Fbo was destroyed; stopping and finalizing";
+            stop();
+            return;
+        }
         float now = getElapsedTimef();
 
         // Fixed-duration cutoff. `t` is the wall-clock PTS this frame would carry;
@@ -437,6 +446,7 @@ private:
     VideoWriter writer_;
     Source source_ = Source::None;
     const Fbo* fbo_ = nullptr;
+    std::weak_ptr<void> fboAlive_;  // expires when the recorded Fbo dies
     float startElapsed_ = 0.0f;
     float duration_ = 0.0f;           // fixed-length cutoff in seconds (0 = unlimited)
     float nextCaptureTime_ = -1.0f;   // scheduled time of the next frame to capture
@@ -470,6 +480,22 @@ TC_PLATFORMS("macos,windows,linux,android,ios") inline bool startRecording(const
 TC_PLATFORMS("macos,windows,linux,android,ios") inline bool startRecording(const std::string& path,
                            float durationSec) {
     return internal::globalScreenRecorder().start(path, durationSec);
+}
+
+// Record an offscreen Fbo instead of the window (clean, GUI-free output).
+// The Fbo must stay alive while recording — if it is destroyed mid-recording,
+// the recording stops and finalizes automatically.
+TC_PLATFORMS("macos,windows,linux,android,ios") inline bool startRecording(const Fbo& fbo,
+                           const std::string& path,
+                           const VideoRecordSettings& settings = {}) {
+    return internal::globalScreenRecorder().start(fbo, path, settings);
+}
+
+// Fixed-duration Fbo recording (see above).
+TC_PLATFORMS("macos,windows,linux,android,ios") inline bool startRecording(const Fbo& fbo,
+                           const std::string& path,
+                           float durationSec) {
+    return internal::globalScreenRecorder().start(fbo, path, durationSec);
 }
 
 inline void stopRecording() { internal::globalScreenRecorder().stop(); }

--- a/core/platform/ios/tcPlatform_ios.mm
+++ b/core/platform/ios/tcPlatform_ios.mm
@@ -120,12 +120,13 @@ void setWindowSizeLogical(int width, int height) {
 
 std::string getExecutablePath() {
     NSString* path = [[NSBundle mainBundle] executablePath];
-    return std::string([path UTF8String]);
+    return path ? std::string([path UTF8String]) : "";
 }
 
 std::string getExecutableDir() {
     NSString* path = [[NSBundle mainBundle] executablePath];
     NSString* dir = [path stringByDeletingLastPathComponent];
+    if (!dir || dir.length == 0) return "";
     return std::string([dir UTF8String]) + "/";
 }
 

--- a/core/platform/ios/tcVideoPlayer_ios.mm
+++ b/core/platform/ios/tcVideoPlayer_ios.mm
@@ -6,6 +6,7 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 #import <CoreVideo/CoreVideo.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 #include "TrussC.h"
 
@@ -827,6 +828,110 @@ bool VideoPlayer::isUsingHwAccelPlatform() const {
 
 std::string VideoPlayer::getHwAccelNamePlatform() const {
     return platformHandle_ ? "videotoolbox" : "none";
+}
+
+// =============================================================================
+// Static frame extraction (thread-safe, no GPU) — same code as macOS
+// =============================================================================
+
+// Deprecation-wrapped helpers (sync AVAsset APIs; fine for one-shot extraction)
+static NSArray<AVAssetTrack*>* tcv_tracks_with_media_type_ios(AVAsset* asset, NSString* mediaType) {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [asset tracksWithMediaType:mediaType];
+    #pragma clang diagnostic pop
+}
+
+static CGImageRef tcv_copy_cgimage_at_time_ios(AVAssetImageGenerator* gen,
+                                               CMTime requestTime,
+                                               CMTime* actualTime,
+                                               NSError** error) CF_RETURNS_RETAINED {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [gen copyCGImageAtTime:requestTime actualTime:actualTime error:error];
+    #pragma clang diagnostic pop
+}
+
+// Shared implementation for both extract paths (see mac version for details):
+// exact=true -> zero tolerance (frame-accurate); exact=false -> nearest
+// keyframe at or before the requested time (fast, time-approximate).
+static bool tcv_extract_frame_ios(const std::string& path, Pixels& outPixels,
+                                  float timeSec, float* outDuration, bool exact) {
+    @autoreleasepool {
+        NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path.c_str()]];
+        if (!url) return false;
+
+        AVURLAsset* asset = [AVURLAsset URLAssetWithURL:url options:@{
+            AVURLAssetPreferPreciseDurationAndTimingKey: @(YES)
+        }];
+        if (!asset) return false;
+
+        float duration = (float)CMTimeGetSeconds(asset.duration);
+        if (outDuration) *outDuration = duration;
+
+        if (timeSec > duration) timeSec = duration * 0.1f;
+        if (timeSec < 0) timeSec = 0;
+
+        NSArray* videoTracks = tcv_tracks_with_media_type_ios(asset, AVMediaTypeVideo);
+        if (videoTracks.count == 0) return false;
+
+        AVAssetImageGenerator* generator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
+        generator.appliesPreferredTrackTransform = YES;
+        if (exact) {
+            generator.requestedTimeToleranceBefore = kCMTimeZero;
+            generator.requestedTimeToleranceAfter  = kCMTimeZero;
+        } else {
+            generator.requestedTimeToleranceBefore = kCMTimePositiveInfinity;
+            generator.requestedTimeToleranceAfter  = kCMTimeZero;
+        }
+
+        CMTime requestTime = CMTimeMakeWithSeconds(timeSec, NSEC_PER_SEC);
+        NSError* error = nil;
+        CGImageRef cgImage = tcv_copy_cgimage_at_time_ios(generator, requestTime, NULL, &error);
+        if (!cgImage) {
+            if (error) {
+                NSLog(@"TCVideoPlayer::extractFrame error: %@", error);
+            }
+            return false;
+        }
+
+        int w = (int)CGImageGetWidth(cgImage);
+        int h = (int)CGImageGetHeight(cgImage);
+
+        // Use the image's own color space: no color conversion, so the poster
+        // is pixel-consistent with live playback frames (see mac version).
+        outPixels.allocate(w, h, 4);
+        CGColorSpaceRef srcSpace = CGImageGetColorSpace(cgImage);
+        bool srcUsable = srcSpace && CGColorSpaceGetModel(srcSpace) == kCGColorSpaceModelRGB;
+        CGColorSpaceRef colorSpace =
+            srcUsable ? CGColorSpaceRetain(srcSpace) : CGColorSpaceCreateDeviceRGB();
+        CGContextRef ctx = CGBitmapContextCreate(
+            outPixels.getData(), w, h, 8, w * 4,
+            colorSpace,
+            (CGBitmapInfo)kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+
+        CGContextDrawImage(ctx, CGRectMake(0, 0, w, h), cgImage);
+
+        CGContextRelease(ctx);
+        CGColorSpaceRelease(colorSpace);
+        CGImageRelease(cgImage);
+
+        return true;
+    }
+}
+
+bool VideoPlayer::extractFramePlatform(const std::string& path, Pixels& outPixels,
+                                       float timeSec, float* outDuration) {
+    return tcv_extract_frame_ios(path, outPixels, timeSec, outDuration, /*exact=*/true);
+}
+
+bool VideoPlayer::extractKeyFramePlatform(const std::string& path, Pixels& outPixels,
+                                          float timeSec, float* outDuration) {
+    if (tcv_extract_frame_ios(path, outPixels, timeSec, outDuration, /*exact=*/false)) {
+        return true;
+    }
+    // No keyframe reachable - fall back to an exact decode.
+    return tcv_extract_frame_ios(path, outPixels, timeSec, outDuration, /*exact=*/true);
 }
 
 } // namespace trussc

--- a/core/platform/ios/tcVideoPlayer_ios.mm
+++ b/core/platform/ios/tcVideoPlayer_ios.mm
@@ -30,6 +30,11 @@
 @property (nonatomic, assign) BOOL hasNewFrame;
 @property (nonatomic, assign) BOOL loop;
 
+// Desired playback rate. On iOS play must go through
+// playImmediatelyAtRate: (see -play), so the rate is kept here instead of
+// being poked into player.rate directly.
+@property (nonatomic, assign) float playbackRate;
+
 // Pixel buffer for C++ side
 @property (nonatomic, assign) unsigned char* pixelBuffer;
 @property (nonatomic, assign) size_t pixelBufferSize;
@@ -213,9 +218,13 @@
         return NO;
     }
 
-    // Create video output (BGRA format for macOS)
+    // Create video output (BGRA). On iOS the buffers must be IOSurface-backed
+    // and Metal-compatible, otherwise copyPixelBufferForItemTime can hand back
+    // unusable/uninitialized buffers.
     NSDictionary* pixelBufferAttributes = @{
-        (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)
+        (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
+        (id)kCVPixelBufferIOSurfacePropertiesKey: @{},
+        (id)kCVPixelBufferMetalCompatibilityKey: @(YES),
     };
     self.videoOutput = [[AVPlayerItemVideoOutput alloc]
                         initWithPixelBufferAttributes:pixelBufferAttributes];
@@ -241,6 +250,12 @@
         return NO;
     }
 
+    // iOS defaults this to YES; a play() issued before the item reaches
+    // ReadyToPlay then parks the player in "waiting to play" forever
+    // (local files never trigger the un-stall). Disable it: we only play
+    // local files, so stall protection is not needed.
+    self.player.automaticallyWaitsToMinimizeStalling = NO;
+
     // Observe end of playback
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(playerDidFinishPlaying:)
@@ -252,6 +267,7 @@
     _pixelBuffer = new unsigned char[_pixelBufferSize];
     memset(_pixelBuffer, 0, _pixelBufferSize);
 
+    _playbackRate = 1.0f;
     _isReady = YES;
     _isFinished = NO;
 
@@ -297,7 +313,7 @@
         [self.player seekToTime:kCMTimeZero
                 toleranceBefore:kCMTimeZero
                  toleranceAfter:kCMTimeZero];
-        [self.player play];
+        [self.player playImmediatelyAtRate:(_playbackRate > 0.0f ? _playbackRate : 1.0f)];
         _isFinished = NO;
     }
 }
@@ -358,7 +374,9 @@
         _isFinished = NO;
     }
 
-    [self.player play];
+    // playImmediatelyAtRate bypasses the ReadyToPlay wait that a plain
+    // [player play] is subject to on iOS.
+    [self.player playImmediatelyAtRate:(_playbackRate > 0.0f ? _playbackRate : 1.0f)];
 }
 
 - (void)stop {
@@ -377,7 +395,7 @@
     if (paused) {
         [self.player pause];
     } else {
-        [self.player play];
+        [self.player playImmediatelyAtRate:(_playbackRate > 0.0f ? _playbackRate : 1.0f)];
     }
 }
 
@@ -417,7 +435,12 @@
         speed = 0.0f;
     }
 
-    self.player.rate = speed;
+    _playbackRate = speed;
+    // Only apply immediately if currently playing; a paused player keeps the
+    // new rate for the next play (setting player.rate would start playback).
+    if (self.player.rate != 0.0f) {
+        [self.player playImmediatelyAtRate:speed];
+    }
 }
 
 - (int)getCurrentFrame {

--- a/core/platform/mac/tcVideoPlayer_mac.mm
+++ b/core/platform/mac/tcVideoPlayer_mac.mm
@@ -918,9 +918,17 @@ static bool tcv_extract_frame_mac(const std::string& path, Pixels& outPixels,
         int w = (int)CGImageGetWidth(cgImage);
         int h = (int)CGImageGetHeight(cgImage);
 
-        // Draw into RGBA bitmap context
+        // Draw into RGBA bitmap context. Use the image's OWN color space so
+        // CoreGraphics performs no color conversion - this matches the playback
+        // path (AVPlayerItemVideoOutput emits BGRA in the video's color space,
+        // unmanaged), so a poster extracted here is pixel-consistent with the
+        // live frames that replace it. DeviceRGB here would color-match to the
+        // display profile and come out ~2% brighter than playback.
         outPixels.allocate(w, h, 4);
-        CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+        CGColorSpaceRef srcSpace = CGImageGetColorSpace(cgImage);
+        bool srcUsable = srcSpace && CGColorSpaceGetModel(srcSpace) == kCGColorSpaceModelRGB;
+        CGColorSpaceRef colorSpace =
+            srcUsable ? CGColorSpaceRetain(srcSpace) : CGColorSpaceCreateDeviceRGB();
         CGContextRef ctx = CGBitmapContextCreate(
             outPixels.getData(), w, h, 8, w * 4,
             colorSpace,

--- a/core/platform/web/tcVideoPlayer_web.cpp
+++ b/core/platform/web/tcVideoPlayer_web.cpp
@@ -41,6 +41,9 @@ bool VideoPlayer::loadPlatform(const std::string& path) {
             var video = document.createElement('video');
             video.setAttribute('playsinline', '');
             video.crossOrigin = 'anonymous';
+            // preload the first frame so update() can upload it BEFORE play()
+            // (the web equivalent of the auto-poster: no black flash)
+            video.preload = 'auto';
             video.style.display = 'none';
             document.body.appendChild(video);
             window._trussc_player_video = video;
@@ -390,6 +393,20 @@ bool VideoPlayer::isUsingHwAccelPlatform() const {
 
 std::string VideoPlayer::getHwAccelNamePlatform() const {
     return platformHandle_ ? "browser" : "none";
+}
+
+// =============================================================================
+// Frame extraction - unsupported on web (browsers have no synchronous media
+// decode). The auto-poster path is covered natively instead: the <video>
+// element preloads its first frame and update() uploads it before play().
+// =============================================================================
+
+bool VideoPlayer::extractFramePlatform(const std::string&, Pixels&, float, float*) {
+    return false;
+}
+
+bool VideoPlayer::extractKeyFramePlatform(const std::string&, Pixels&, float, float*) {
+    return false;
 }
 
 } // namespace trussc

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1119,7 +1119,7 @@ A point cloud isn't a dedicated class — it uses **`tc::Mesh` directly.** The r
 ### How do I record video? (startRecording / VideoWriter)
 
 Two ways:
-- **Screen recording (easy)**: `startRecording("out.mp4")` to start, `stopRecording()` to stop, `isRecording()` for status. Records the on-screen output directly.
+- **Screen recording (easy)**: `startRecording("out.mp4")` to start, `stopRecording()` to stop, `isRecording()` for status. Records the on-screen output directly. `startRecording(fbo, "clean.mp4")` records an offscreen Fbo instead (clean, GUI-free; auto-finalizes if the Fbo is destroyed mid-recording). Calling `startRecording` while already recording finalizes the current file first, then starts fresh — same path = the old file is overwritten.
 - **Write arbitrary frames**: use `VideoWriter` — `open(path, w, h, settings)` → `addFrame(fbo)` / `addFrame(pixels)` (timestamped via `addFrameAt(frame, timeSec)`) → `close()`. For writing offscreen (FBO) content at a steady rate.
 Encoder settings: `VideoRecordSettings`. Platforms: macOS / Windows / Linux / Android / iOS.
 
@@ -1143,7 +1143,7 @@ player.load(path); player.play();
 player.isReady() ? player.draw(0, 0) : still.draw(0, 0);
 ```
 
-`isReady()` is exactly the "would this draw black?" test: false after `load()`/`play()`/`stop()` until the first decoded frame lands on the texture; seeking and pausing keep it true (the last frame stays). Don't branch the draw on `isFrameNew()` — that flag is momentary (true only on updates where a NEW frame arrived), so at 60fps app / 30fps video the still would flicker back every other frame.
+`isReady()` is exactly the "would this draw black?" test: false only while the texture is actually empty — after `load()` and after `stop()` (which clears the texture) — until the first decoded frame lands; `play()`, seeking and pausing keep it true (the last picture stays on the texture). Don't branch the draw on `isFrameNew()` — that flag is momentary (true only on updates where a NEW frame arrived), so at 60fps app / 30fps video the still would flicker back every other frame.
 
 Use `extractKeyFrame(path, img, 0.0f)` here rather than `extractFrame`: frame 0 is always a keyframe, so it is the exact first frame *and* the fastest to fetch (seek only, no forward decode). The `Image` overload allocates and uploads for you (main thread only); a `Pixels` overload exists for background work. If the player is already loaded you can also use the instance form `player.extractKeyFrame(img, 0.0f)`.
 
@@ -1178,7 +1178,7 @@ grabber.setup(1280, 720);
 
 // each frame, drain everything captured since the last call:
 vector<GrabberFrame> frames;     // Pixels + timestamp travel together (no race)
-grabber.getBufferFrames(frames); // oldest first; each delivered exactly once
+grabber.getQueuedFrames(frames); // oldest first; each delivered exactly once
 for (auto& f : frames) {
     // f.pixels — RGBA8 Pixels (has its own width/height; move-only, clone() to copy)
     // f.timestampUs — steady_clock µs, stamped on the CAPTURE thread
@@ -1760,7 +1760,7 @@ void setWindowPosition(int x, int y) [macos,windows]  // Set window position in 
 void setWindowSize(int width, int height)  // Set window size
 void setWindowSizeLogical(int width, int height)  // Resize the window to the given logical size (logical pixels)
 void setWindowTitle(const std::string & title)  // Set window title
-bool startRecording(const std::string & path, const VideoRecordSettings & settings = {}) [+1] [macos,windows,linux,android,ios]  // Start recording the window to a video file (native encoder, no ffmpeg). Pass a seconds argument (or VideoRecordSettings.duration) for a fixed-length clip that auto-stops and finalizes itself; 0 = unlimited
+bool startRecording(const std::string & path, const VideoRecordSettings & settings = {}) [+3] [macos,windows,linux,android,ios]  // Start recording the window — or an Fbo (clean, GUI-free output) — to a video file (native encoder, no ffmpeg). Pass a seconds argument (or VideoRecordSettings.duration) for a fixed-length clip that auto-stops and finalizes itself; 0 = unlimited. Calling it again while recording finalizes the current file first, then starts fresh (same path = the old file is overwritten)
 void stopRecording()  // Stop the current recording and finalize the file
 void toggleFullscreen()  // Toggle fullscreen mode
 ```
@@ -2369,6 +2369,7 @@ sg_view Fbo::getTextureView() const  // Return the underlying sokol-gfx color te
 int Fbo::getWidth() const  // Get width
 bool Fbo::isActive() const  // Check if currently rendering to FBO
 bool Fbo::isAllocated() const  // Check if allocated
+std::shared_ptr<void> Fbo::lifetimeToken() const  // Lifetime token for observers holding a raw pointer to this Fbo (e.g. ScreenRecorder auto-stops when the recorded Fbo dies). Per-object: it does not transfer on move
 bool Fbo::readPixels(unsigned char * pixels) const [macos,windows,linux,ios,android]  // Read FBO contents into a CPU buffer (8-bit per channel)
 bool Fbo::readPixelsFloat(float * pixels) const [macos,windows,linux,android]  // Read FBO contents into a CPU buffer (32-bit float per channel)
 bool Fbo::save(const fs::path & path) const  // Save FBO contents to file
@@ -2479,7 +2480,7 @@ void FullscreenShader::createVertexBuffer()  // Create the fullscreen-quad verte
 void FullscreenShader::draw()  // Draw a fullscreen quad with this shader applied
 ```
 
-### GrabberFrame — One captured camera frame with its capture-time timestamp: Pixels (RGBA8) plus timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getBufferFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time
+### GrabberFrame — One captured camera frame with its capture-time timestamp: Pixels (RGBA8) plus timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getQueuedFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time
 
 ```cpp
 ```
@@ -3227,7 +3228,7 @@ bool Reflector::visit(const char * name, float & v) [+7]  // Handle one reflecte
 int ScreenRecorder::getFrameCount() const  // Number of frames captured so far
 const std::string & ScreenRecorder::getPath() const  // Output file path of the current recording
 bool ScreenRecorder::isRecording() const  // Check if the screen recorder is currently capturing
-bool ScreenRecorder::start(const std::string & path, const VideoRecordSettings & settings = {}) [+3]  // Start live capture (window, or an Fbo for clean GUI-free output); size is taken automatically
+bool ScreenRecorder::start(const std::string & path, const VideoRecordSettings & settings = {}) [+3]  // Start live capture (window, or an Fbo for clean GUI-free output); size is taken automatically. Calling start while recording finalizes the current file first. If the recorded Fbo is destroyed mid-recording, the recording stops and finalizes automatically
 void ScreenRecorder::stop()  // Stop live capture and finalize the file
 VideoWriter & ScreenRecorder::writer()  // Access the underlying VideoWriter for advanced introspection
 ```
@@ -3787,13 +3788,13 @@ const std::string & VideoDeviceInfo::getUniqueId() const  // Get the stable uniq
 bool VideoGrabber::checkCameraPermission()  // Return whether camera access has been granted (macOS 10.14+)
 void VideoGrabber::close()  // Stop the camera and release its resources
 void VideoGrabber::copyToImage(Image & image) const  // Copy the current frame into an Image (allocating/updating it as needed)
-size_t VideoGrabber::getBufferFrames(std::vector<GrabberFrame> & out) [macos,windows,linux]  // Drain all frames captured since the last call (appended to the given vector, oldest first; returns the count). Each GrabberFrame carries a monotonic timestamp stamped on the capture thread, so timestamps stay truthful even if the main loop stalls, and no frame is lost when the camera runs faster than the app loop. Requires setFrameQueueSize() > 0; getPixels()/isFrameNew() are unaffected
 int VideoGrabber::getDesiredFrameRate() const  // Return the requested frame rate (-1 if unspecified)
 int VideoGrabber::getDeviceID() const  // Return the selected device ID
 const std::string & VideoGrabber::getDeviceName() const  // Return the name of the active capture device
 size_t VideoGrabber::getFrameQueueSize() const [macos,windows,linux]  // Return the frame queue capacity (0 = queueing disabled)
 int VideoGrabber::getHeight() const  // Return the captured frame height in pixels
 unsigned char * VideoGrabber::getPixels() [+1]  // Return a pointer to the current RGBA pixel buffer
+size_t VideoGrabber::getQueuedFrames(std::vector<GrabberFrame> & out) [macos,windows,linux]  // Drain all frames captured since the last call (appended to the given vector, oldest first; returns the count). Each GrabberFrame carries a monotonic timestamp stamped on the capture thread, so timestamps stay truthful even if the main loop stalls, and no frame is lost when the camera runs faster than the app loop. Requires setFrameQueueSize() > 0; getPixels()/isFrameNew() are unaffected
 Texture & VideoGrabber::getTexture() [+1]  // Return the texture holding the live camera frame (HasTexture override)
 int VideoGrabber::getWidth() const  // Return the captured frame width in pixels
 bool VideoGrabber::isFrameNew() const  // Return true if a new frame arrived during the most recent update()
@@ -3815,8 +3816,8 @@ void VideoGrabber::update()  // Poll for a new frame and upload it to the textur
 ```cpp
 void VideoPlayer::close()  // Close the video and release resources
 void VideoPlayer::draw(float x, float y) const [+1]  // Draw the current video frame at (x, y), optionally scaled to w x h
-bool VideoPlayer::extractFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+3]  // Extract the exact frame at a given time from a video file. Frame-accurate on every platform
-bool VideoPlayer::extractKeyFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+3]  // Extract the nearest keyframe at or before a given time. Faster than extractFrame but time-approximate
+bool VideoPlayer::extractFrame(const std::string & path, Pixels & outPixels, float timeSec, float * outDuration = nullptr) [+3]  // Extract the exact frame at a given time from a video file. Frame-accurate on every platform
+bool VideoPlayer::extractKeyFrame(const std::string & path, Pixels & outPixels, float timeSec, float * outDuration = nullptr) [+3]  // Extract the nearest keyframe at or before a given time. Faster than extractFrame but time-approximate
 int VideoPlayer::getAudioChannels() const [macos,windows,linux,ios]  // Number of audio channels (0 if no audio)
 uint32_t VideoPlayer::getAudioCodec() const [macos,windows,linux,ios]  // FourCC of the audio codec in the loaded video (0 if none)
 std::vector<uint8_t> VideoPlayer::getAudioData() const [macos,windows,linux,ios]  // Raw decoded audio data for the loaded video
@@ -3881,7 +3882,7 @@ bool VideoPlayerBase::isLoaded() const  // Check if a video is loaded
 bool VideoPlayerBase::isLoop() const  // Check if looping is enabled
 bool VideoPlayerBase::isPaused() const  // Check if video is paused
 bool VideoPlayerBase::isPlaying() const  // Check if video is currently playing (not paused)
-bool VideoPlayerBase::isReady() const  // True once the texture holds a real decoded frame for the current playback — i.e. drawing shows actual video, not black
+bool VideoPlayerBase::isReady() const  // True while the texture holds a real decoded frame — i.e. drawing shows actual video, not black. False only while the texture is cleared (after load/stop, before the first frame)
 bool VideoPlayerBase::isUsingHwAccel() const  // Return true if hardware-accelerated decoding is currently active.
 bool VideoPlayerBase::load(const std::string & path)  // Load a video from the given file path; return true on success.
 void VideoPlayerBase::markDone()  // Mark playback as done, clearing playing unless looping.

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1133,17 +1133,14 @@ Yes — every TrussC app in MCP mode (`TRUSSC_MCP=1`) exposes `start_recording` 
 
 ### How do I avoid a black first frame when a VideoPlayer starts?
 
-`VideoPlayer::load()` / `play()` decode **asynchronously**, so for the first few frames the player has no picture yet and draws **black**. To hide that flash, synchronously extract frame 0 as a still and show it until the live player has a real frame:
+**You don't need to do anything** — the auto poster (default ON) already handles it. `load()` synchronously puts frame 0 on the texture, `stop()` posters frame 0 (matching the rewound position), and `play()` after a seek bridges with the exact frame at the new position. The invariant is "the texture always shows the frame AT the playback position", so `draw()` never shows black or a stale picture, and `isReady()` is true from `load()` on.
 
 ```cpp
-Image still;
-VideoPlayer::extractKeyFrame(path, still, 0.0f);  // frame 0, ready to draw
 player.load(path); player.play();
-// draw():
-player.isReady() ? player.draw(0, 0) : still.draw(0, 0);
+player.draw(0, 0);   // real picture from the very first frame
 ```
 
-`isReady()` is exactly the "would this draw black?" test: false only while the texture is actually empty — after `load()` and after `stop()` (which clears the texture) — until the first decoded frame lands; `play()`, seeking and pausing keep it true (the last picture stays on the texture). Don't branch the draw on `isFrameNew()` — that flag is momentary (true only on updates where a NEW frame arrived), so at 60fps app / 30fps video the still would flicker back every other frame.
+Only if you opt out (`player.setAutoPoster(false)` — e.g. to avoid the one-time synchronous decode at load) do you need the manual bridge: extract a still (`VideoPlayer::extractKeyFrame(path, img, 0.0f)`) and draw it while `!player.isReady()`. On the web the video element preloads its first frame natively; on Android VideoPlayer is not implemented yet. Don't branch the draw on `isFrameNew()` — that flag is momentary (true only on updates where a NEW frame arrived), so at 60fps app / 30fps video the still would flicker back every other frame.
 
 Use `extractKeyFrame(path, img, 0.0f)` here rather than `extractFrame`: frame 0 is always a keyframe, so it is the exact first frame *and* the fastest to fetch (seek only, no forward decode). The `Image` overload allocates and uploads for you (main thread only); a `Pixels` overload exists for background work. If the player is already loaded you can also use the instance form `player.extractKeyFrame(img, 0.0f)`.
 
@@ -3822,6 +3819,7 @@ int VideoPlayer::getAudioChannels() const [macos,windows,linux,ios]  // Number o
 uint32_t VideoPlayer::getAudioCodec() const [macos,windows,linux,ios]  // FourCC of the audio codec in the loaded video (0 if none)
 std::vector<uint8_t> VideoPlayer::getAudioData() const [macos,windows,linux,ios]  // Raw decoded audio data for the loaded video
 int VideoPlayer::getAudioSampleRate() const [macos,windows,linux,ios]  // Audio sample rate in Hz (0 if no audio)
+bool VideoPlayer::getAutoPoster() const  // Return whether the auto poster is enabled (default true)
 int VideoPlayer::getCurrentFrame() const  // Get current frame number
 float VideoPlayer::getDuration() const  // Get total duration in seconds
 float VideoPlayer::getGammaCorrection() const  // Get current gamma correction value
@@ -3837,8 +3835,10 @@ bool VideoPlayer::hasAudio() const  // Check if the loaded video has an audio tr
 bool VideoPlayer::isUsingHwAccel() const  // Check if hardware decoding is currently active (after load)
 bool VideoPlayer::load(const std::string & path)  // Load a video file
 void VideoPlayer::nextFrame()  // Advance to the next frame
+void VideoPlayer::play()  // Start or resume playback. With the auto poster (default), a seek made while stopped/paused is bridged with the exact frame at the new position before playback, so it never starts on a stale picture
 void VideoPlayer::playImpl()  // Backend implementation of playImpl for this platform's video player.
 void VideoPlayer::previousFrame()  // Go back to the previous frame
+void VideoPlayer::setAutoPoster(bool on)  // Auto poster (default ON): on load/stop/play the player synchronously puts the frame at the current position on the texture, so drawing never shows black or a stale picture. Turn off to skip the one-time synchronous decode
 void VideoPlayer::setFrame(int frame)  // Seek to a specific frame number
 void VideoPlayer::setGammaCorrection(float gamma)  // Set gamma correction (1.0 = none). Use ~0.45 to brighten on platforms with dark output (e.g. macOS AVFoundation)
 void VideoPlayer::setLoopImpl(bool loop)  // Backend implementation of setLoopImpl for this platform's video player.
@@ -3882,7 +3882,7 @@ bool VideoPlayerBase::isLoaded() const  // Check if a video is loaded
 bool VideoPlayerBase::isLoop() const  // Check if looping is enabled
 bool VideoPlayerBase::isPaused() const  // Check if video is paused
 bool VideoPlayerBase::isPlaying() const  // Check if video is currently playing (not paused)
-bool VideoPlayerBase::isReady() const  // True while the texture holds a real decoded frame — i.e. drawing shows actual video, not black. False only while the texture is cleared (after load/stop, before the first frame)
+bool VideoPlayerBase::isReady() const  // True while the texture holds a real picture — i.e. drawing shows actual video, not black. With the default auto poster this is true from load() on; false only if the poster failed and no frame has arrived yet
 bool VideoPlayerBase::isUsingHwAccel() const  // Return true if hardware-accelerated decoding is currently active.
 bool VideoPlayerBase::load(const std::string & path)  // Load a video from the given file path; return true on success.
 void VideoPlayerBase::markDone()  // Mark playback as done, clearing playing unless looping.

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1177,10 +1177,10 @@ grabber.setFrameQueueSize(16);   // opt-in; 0 (default) = off, zero overhead
 grabber.setup(1280, 720);
 
 // each frame, drain everything captured since the last call:
-vector<GrabberFrame> frames;     // pixels + timestamp travel together (no race)
+vector<GrabberFrame> frames;     // Pixels + timestamp travel together (no race)
 grabber.getBufferFrames(frames); // oldest first; each delivered exactly once
 for (auto& f : frames) {
-    // f.pixels (RGBA), f.width, f.height,
+    // f.pixels — RGBA8 Pixels (has its own width/height; move-only, clone() to copy)
     // f.timestampUs — steady_clock µs, stamped on the CAPTURE thread
 }
 ```
@@ -2479,7 +2479,7 @@ void FullscreenShader::createVertexBuffer()  // Create the fullscreen-quad verte
 void FullscreenShader::draw()  // Draw a fullscreen quad with this shader applied
 ```
 
-### GrabberFrame — One captured camera frame with its capture-time timestamp: RGBA pixels, width/height, and timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getBufferFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time
+### GrabberFrame — One captured camera frame with its capture-time timestamp: Pixels (RGBA8) plus timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getBufferFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time
 
 ```cpp
 ```

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1139,13 +1139,11 @@ Yes — every TrussC app in MCP mode (`TRUSSC_MCP=1`) exposes `start_recording` 
 Image still;
 VideoPlayer::extractKeyFrame(path, still, 0.0f);  // frame 0, ready to draw
 player.load(path); player.play();
-// update(): latch a bool on the first player.isFrameNew() - isFrameNew() is
-//           momentary (true only when a NEW frame arrived), so branch on the
-//           latched flag in draw(), never on isFrameNew() itself, or the
-//           still would flicker back whenever the app outpaces the video fps.
-// draw():   ready ? player.draw(...) : still.draw(...)
-// (reloading another video? reset the latch to false.)
+// draw():
+player.isReady() ? player.draw(0, 0) : still.draw(0, 0);
 ```
+
+`isReady()` is exactly the "would this draw black?" test: false after `load()`/`play()`/`stop()` until the first decoded frame lands on the texture; seeking and pausing keep it true (the last frame stays). Don't branch the draw on `isFrameNew()` — that flag is momentary (true only on updates where a NEW frame arrived), so at 60fps app / 30fps video the still would flicker back every other frame.
 
 Use `extractKeyFrame(path, img, 0.0f)` here rather than `extractFrame`: frame 0 is always a keyframe, so it is the exact first frame *and* the fastest to fetch (seek only, no forward decode). The `Image` overload allocates and uploads for you (main thread only); a `Pixels` overload exists for background work. If the player is already loaded you can also use the instance form `player.extractKeyFrame(img, 0.0f)`.
 
@@ -3883,6 +3881,7 @@ bool VideoPlayerBase::isLoaded() const  // Check if a video is loaded
 bool VideoPlayerBase::isLoop() const  // Check if looping is enabled
 bool VideoPlayerBase::isPaused() const  // Check if video is paused
 bool VideoPlayerBase::isPlaying() const  // Check if video is currently playing (not paused)
+bool VideoPlayerBase::isReady() const  // True once the texture holds a real decoded frame for the current playback — i.e. drawing shows actual video, not black
 bool VideoPlayerBase::isUsingHwAccel() const  // Return true if hardware-accelerated decoding is currently active.
 bool VideoPlayerBase::load(const std::string & path)  // Load a video from the given file path; return true on success.
 void VideoPlayerBase::markDone()  // Mark playback as done, clearing playing unless looping.

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1136,22 +1136,22 @@ Yes — every TrussC app in MCP mode (`TRUSSC_MCP=1`) exposes `start_recording` 
 `VideoPlayer::load()` / `play()` decode **asynchronously**, so for the first few frames the player has no picture yet and draws **black**. To hide that flash, synchronously extract frame 0 as a still and show it until the live player has a real frame:
 
 ```cpp
-Pixels still; Texture stillTex;
-if (VideoPlayer::extractKeyFrame(path, still, 0.0f) && still.getWidth() > 0) {
-    stillTex.allocate(still.getWidth(), still.getHeight(), 4, TextureUsage::Stream);
-    stillTex.loadData(still.getData(), still.getWidth(), still.getHeight(), 4);
-}
+Image still;
+VideoPlayer::extractKeyFrame(path, still, 0.0f);  // frame 0, ready to draw
 player.load(path); player.play();
-// in draw(): show the live player once player.isFrameNew() has fired at least
-// once, otherwise draw stillTex. In update(): flip a "ready" flag on the first
-// isFrameNew().
+// update(): latch a bool on the first player.isFrameNew() - isFrameNew() is
+//           momentary (true only when a NEW frame arrived), so branch on the
+//           latched flag in draw(), never on isFrameNew() itself, or the
+//           still would flicker back whenever the app outpaces the video fps.
+// draw():   ready ? player.draw(...) : still.draw(...)
+// (reloading another video? reset the latch to false.)
 ```
 
-Use `extractKeyFrame(path, px, 0.0f)` here rather than `extractFrame`: frame 0 is always a keyframe, so it is the exact first frame *and* the fastest to fetch (seek only, no forward decode). If the player is already loaded you can also use the instance form `player.extractKeyFrame(px, 0.0f)`.
+Use `extractKeyFrame(path, img, 0.0f)` here rather than `extractFrame`: frame 0 is always a keyframe, so it is the exact first frame *and* the fastest to fetch (seek only, no forward decode). The `Image` overload allocates and uploads for you (main thread only); a `Pixels` overload exists for background work. If the player is already loaded you can also use the instance form `player.extractKeyFrame(img, 0.0f)`.
 
 ### How do I grab a single frame (thumbnail / poster) from a video?
 
-Two single-shot helpers, both **static, thread-safe, GPU-free**, returning RGBA `Pixels`. Each has a static form (pass a path, no `load()` needed) and an instance form (uses the already-loaded `player.getPath()`):
+Two single-shot helpers. Each has a static form (pass a path, no `load()` needed) and an instance form (uses the already-loaded `player.getPath()`), and each accepts either a `Pixels` (**thread-safe, GPU-free** — safe on background threads) or an `Image` (ready to draw, allocation + texture upload included — **main thread only**):
 
 ```cpp
 // exact frame at 3.5s — frame-accurate (seeks to the preceding keyframe, then
@@ -1161,6 +1161,9 @@ VideoPlayer::extractFrame(path, px, 3.5f);
 VideoPlayer::extractKeyFrame(path, px, 3.5f);
 // instance form (video already loaded):
 video.extractFrame(px, 3.5f);
+// Image overload: ready to draw, no manual texture upload (main thread only)
+Image img;
+VideoPlayer::extractFrame(path, img, 3.5f);
 ```
 
 Pick by need: **`extractFrame` = frame-accurate but heavier; `extractKeyFrame` = fast but time-approximate** (good for coarse thumbnails or scrub previews; falls back to an exact decode if no keyframe is reachable). Both take an optional `float* outDuration` that receives the clip length in seconds. Implemented on **macOS (AVFoundation), Windows (Media Foundation), Linux (FFmpeg)**; Android stubs them and iOS/web are unsupported (return false).
@@ -3814,8 +3817,8 @@ void VideoGrabber::update()  // Poll for a new frame and upload it to the textur
 ```cpp
 void VideoPlayer::close()  // Close the video and release resources
 void VideoPlayer::draw(float x, float y) const [+1]  // Draw the current video frame at (x, y), optionally scaled to w x h
-bool VideoPlayer::extractFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+1]  // Extract the exact frame at a given time from a video file. Frame-accurate on every platform
-bool VideoPlayer::extractKeyFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+1]  // Extract the nearest keyframe at or before a given time. Faster than extractFrame but time-approximate
+bool VideoPlayer::extractFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+3]  // Extract the exact frame at a given time from a video file. Frame-accurate on every platform
+bool VideoPlayer::extractKeyFrame(const std::string & path, Pixels & outPixels, float timeSec = 1.0, float * outDuration = nullptr) [+3]  // Extract the nearest keyframe at or before a given time. Faster than extractFrame but time-approximate
 int VideoPlayer::getAudioChannels() const [macos,windows,linux,ios]  // Number of audio channels (0 if no audio)
 uint32_t VideoPlayer::getAudioCodec() const [macos,windows,linux,ios]  // FourCC of the audio codec in the loaded video (0 if none)
 std::vector<uint8_t> VideoPlayer::getAudioData() const [macos,windows,linux,ios]  // Raw decoded audio data for the loaded video

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1428,7 +1428,7 @@ void beginShape()  // Begin drawing a shape
 void beginStroke()  // Begin drawing a stroke (uses StrokeMesh internally)
 void drawArc(Vec3 center, float radius, float angleBegin, float angleEnd) [+1]  // Draw arc (partial circle, angles in radians)
 void drawBezier(Vec3 p0, Vec3 p1, Vec3 p2, Vec3 p3) [+2]  // Draw bezier curve (cubic with 4 points, quadratic with 3, or N-th order via vector)
-void drawBitmapString(const std::string & text, Vec3 pos, bool screenFixed = true) [+5]  // Draw text
+void drawBitmapString(const std::string & text, Vec3 pos, bool screenFixed = true) [+5]  // Draw text. The Vec3 overloads project through the current camera context — a screen-aligned 3D label; z=0 on the default screen matches plain 2D; behind-camera draws nothing; screenFixed picks fixed-pixel vs perspective size
 void drawBitmapStringHighlight(const std::string & text, float x, float y, const Color & background = Color(0, 0, 0), const Color & foreground = Color(1, 1, 1))  // Draw text with background highlight
 void drawBox(float w, float h, float d) [+5]  // Draw 3D box (respects fill/noFill)
 void drawCircle(Vec3 center, float radius) [+1]  // Draw circle
@@ -1759,7 +1759,7 @@ void setWindowPosition(int x, int y) [macos,windows]  // Set window position in 
 void setWindowSize(int width, int height)  // Set window size
 void setWindowSizeLogical(int width, int height)  // Resize the window to the given logical size (logical pixels)
 void setWindowTitle(const std::string & title)  // Set window title
-bool startRecording(const std::string & path, const VideoRecordSettings & settings = {}) [+1] [macos,windows,linux,android,ios]  // Start recording the window to a video file (native encoder, no ffmpeg)
+bool startRecording(const std::string & path, const VideoRecordSettings & settings = {}) [+1] [macos,windows,linux,android,ios]  // Start recording the window to a video file (native encoder, no ffmpeg). Pass a seconds argument (or VideoRecordSettings.duration) for a fixed-length clip that auto-stops and finalizes itself; 0 = unlimited
 void stopRecording()  // Stop the current recording and finalize the file
 void toggleFullscreen()  // Toggle fullscreen mode
 ```

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10466,18 +10466,18 @@ description.ko = "현재 재생 중인지 확인 (일시정지 시 false)"
 ["VideoPlayerBase::isReady"]
 category = "video"
 keywords = ["ready", "first frame", "black flash", "decoded", "has picture"]
-description.en = "True while the texture holds a real decoded frame — i.e. drawing shows actual video, not black. False only while the texture is cleared (after load/stop, before the first frame)"
-description.ja = "実フレームがテクスチャに載っていれば true ＝ 描画すると黒ではなく実映像が出る状態。false になるのはテクスチャが空の間だけ（load/stop 後〜最初のフレーム到着まで）"
-description.ko = "실제 디코드된 프레임이 텍스처에 있으면 true — 그리면 검은 화면이 아니라 실제 영상이 나오는 상태. 텍스처가 빈 동안(load/stop 후 첫 프레임 전)만 false"
+description.en = "True while the texture holds a real picture — i.e. drawing shows actual video, not black. With the default auto poster this is true from load() on; false only if the poster failed and no frame has arrived yet"
+description.ja = "実フレームがテクスチャに載っていれば true ＝ 描画すると黒ではなく実映像が出る状態。デフォルトの自動ポスターでは load() 直後から true。false はポスター失敗かつフレーム未到着の間だけ"
+description.ko = "실제 그림이 텍스처에 있으면 true — 그리면 검은 화면이 아니라 실제 영상이 나오는 상태. 기본 자동 포스터에서는 load() 직후부터 true. 포스터 실패 & 프레임 미도착일 때만 false"
 related = ["VideoPlayerBase::isFrameNew", "VideoPlayerBase::isLoaded", "VideoPlayer::extractKeyFrame"]
 details.en = '''
-`load()`/`play()` decode asynchronously, so right after load the player would
-draw its cleared (black) texture. `isReady()` is exactly the "would this draw
-black?" test: it turns true when the first decoded frame lands on the texture,
-and resets to false only when the texture actually goes empty — on `load()`
-and on `stop()` (which clears the texture back to black). `play()`, seeking
-and pausing keep it **true**: the last picture stays on the texture, so
-drawing still shows real video.
+`isReady()` is the "would drawing show a real picture?" test. With the
+default [auto poster](#VideoPlayer::setAutoPoster) it is true from `load()`
+on — the poster puts frame 0 on the texture synchronously — and stays true
+through `play()`, `stop()`, seeking and pausing (the texture always holds a
+real picture). It is false only between `load()` and the first picture when
+the poster is disabled or unavailable (`setAutoPoster(false)`, or platforms
+without frame extraction).
 
 Typical use — avoid the black flash at playback start by bridging with a
 still (see [`extractKeyFrame`](#VideoPlayer::extractKeyFrame)):
@@ -10492,12 +10492,12 @@ be black) and [`isFrameNew`](#VideoPlayerBase::isFrameNew) (momentary
 branch your draw on it directly).
 '''
 details.ja = '''
-`load()`/`play()` は非同期でデコードするため、load 直後はクリア済みの黒
-テクスチャが描画されてしまう。`isReady()` は「描画したら黒か？」の判定そのもの:
-最初のデコード済みフレームがテクスチャに載った時点で true になり、false に戻る
-のは**テクスチャが実際に空になる時だけ** — `load()` と `stop()`（テクスチャを黒に
-クリアする）。`play()`・シーク・一時停止では **true のまま**（直前のフレームが
-テクスチャに残っているので、描画すれば実映像が出る）。
+`isReady()` は「描画したら実映像が出るか？」の判定。デフォルトの
+[自動ポスター](#VideoPlayer::setAutoPoster) が有効なら `load()` 直後から true
+（ポスターが同期的にフレーム0を載せる）で、`play()`・`stop()`・シーク・一時停止を
+通して true のまま（テクスチャには常に実映像が載っている）。false になるのは
+ポスターが無効/利用不可（`setAutoPoster(false)` や抽出未対応プラットフォーム）で、
+load 後まだ最初のフレームが来ていない間だけ。
 
 典型的な用途は再生開始時の黒フラッシュ回避（静止画でつなぐ。
 [`extractKeyFrame`](#VideoPlayer::extractKeyFrame) 参照）:
@@ -10511,6 +10511,63 @@ player.isReady() ? player.draw(0, 0) : still.draw(0, 0);
 来た」という単発フラグ。動画レートで点滅するので draw の分岐に直接使わない）
 とは別物。
 '''
+
+["VideoPlayer::play"]
+category = "video"
+description.en = "Start or resume playback. With the auto poster (default), a seek made while stopped/paused is bridged with the exact frame at the new position before playback, so it never starts on a stale picture"
+description.ja = "再生を開始/再開。自動ポスター（デフォルト）有効時は、停止/一時停止中のシークがあれば新しい位置の正確なフレームを載せてから再生するので、古い絵のまま再生が始まらない"
+description.ko = "재생 시작/재개. 자동 포스터(기본) 활성 시 정지/일시정지 중 시크가 있으면 새 위치의 정확한 프레임을 올린 뒤 재생하므로 오래된 그림으로 시작하지 않음"
+related = ["VideoPlayer::setAutoPoster", "VideoPlayerBase::play"]
+
+["VideoPlayer::setAutoPoster"]
+category = "video"
+keywords = ["poster", "first frame", "black flash", "auto", "preload"]
+description.en = "Auto poster (default ON): on load/stop/play the player synchronously puts the frame at the current position on the texture, so drawing never shows black or a stale picture. Turn off to skip the one-time synchronous decode"
+description.ja = "自動ポスター（デフォルトON）。load/stop/play 時に現在位置のフレームを同期的にテクスチャへ載せるので、描画が黒や古い絵になる瞬間が無い。同期デコード（1回きり）を避けたい場合のみオフにする"
+description.ko = "자동 포스터(기본 ON). load/stop/play 시 현재 위치의 프레임을 동기적으로 텍스처에 올려 검은 화면이나 오래된 그림이 그려지는 순간이 없음. 일회성 동기 디코드를 피하려면 끈다"
+related = ["VideoPlayer::getAutoPoster", "VideoPlayerBase::isReady", "VideoPlayer::extractKeyFrame"]
+details.en = '''
+Maintains the invariant "the texture always shows the frame AT the playback
+position":
+
+- `load()` — extracts frame 0 (always a keyframe: exact and fast) before
+  returning, so [`isReady`](#VideoPlayerBase::isReady) is true immediately and
+  the first `draw()` shows a real picture.
+- `stop()` — rewinds, so the poster becomes frame 0 (picture matches the
+  rewound position).
+- `play()` — if the position moved while stopped/paused (seek), the exact
+  frame at the new position is extracted synchronously before playback, so
+  playback never starts on a stale picture.
+
+The synchronous extraction costs one decode (keyframe-fast at position 0,
+seek+decode elsewhere). `setAutoPoster(false)` restores the previous behavior
+(texture stays black until the first live frame).
+
+Platforms without frame extraction: web bridges natively (the video element
+preloads its first frame), Android has no VideoPlayer yet — both no-op safely.
+'''
+details.ja = '''
+「テクスチャには常に再生位置のフレームが載っている」という不変条件を維持する:
+
+- `load()` — 返る前にフレーム0（必ずキーフレーム＝正確かつ高速）を抽出して
+  載せる。[`isReady`](#VideoPlayerBase::isReady) は即 true になり、最初の
+  `draw()` から実映像が出る。
+- `stop()` — 先頭に巻き戻るので、ポスターもフレーム0になる（絵と位置が一致）。
+- `play()` — 停止/一時停止中にシークで位置が動いていたら、新しい位置の正確な
+  フレームを同期抽出してから再生する。古い絵のまま再生が始まることがない。
+
+同期抽出のコストはデコード1回（位置0はキーフレームで高速、それ以外はシーク+
+デコード）。`setAutoPoster(false)` で従来挙動（最初のライブフレームまで黒）に戻る。
+
+フレーム抽出が無いプラットフォーム: web は video 要素のプリロードで自然に
+カバー、Android は VideoPlayer 自体が未実装。どちらも安全に no-op。
+'''
+
+["VideoPlayer::getAutoPoster"]
+category = "video"
+description.en = "Return whether the auto poster is enabled (default true)"
+description.ja = "自動ポスターが有効かを返す（デフォルト true）"
+description.ko = "자동 포스터가 활성화되어 있는지 반환 (기본 true)"
 
 ["VideoPlayerBase::play"]
 category = "video"

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -9882,25 +9882,15 @@ description.ko = "디바이스의 안정적인 고유 식별자"
 
 ["GrabberFrame"]
 keywords = ["webcam", "camera", "frame", "timestamp", "queue", "measurement"]
-description.en = "One captured camera frame with its capture-time timestamp: RGBA pixels, width/height, and timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getBufferFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time"
-description.ja = "キャプチャ時刻付きのカメラ1フレーム。RGBAピクセル・width/height・timestampUs（monotonicなsteady_clockのマイクロ秒。キャプチャスレッドで打刻）を持つ。VideoGrabber::getBufferFrames() が返す。ピクセルと時刻が一体なので「ピクセル取得と時刻取得の間に次フレームが割り込む」競合が起きない。カメラを計測/測定に使うときの基本単位"
-description.ko = "캡처 시각이 붙은 카메라 1프레임. RGBA 픽셀, width/height, timestampUs(단조 steady_clock 마이크로초, 캡처 스레드에서 기록)를 가짐. VideoGrabber::getBufferFrames()가 반환. 픽셀과 시각이 한 구조체로 오므로 둘을 따로 읽는 사이에 다음 프레임이 끼어드는 경쟁이 없음"
+description.en = "One captured camera frame with its capture-time timestamp: Pixels (RGBA8) plus timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getBufferFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time"
+description.ja = "キャプチャ時刻付きのカメラ1フレーム。Pixels（RGBA8）と timestampUs（monotonicなsteady_clockのマイクロ秒。キャプチャスレッドで打刻）を持つ。VideoGrabber::getBufferFrames() が返す。ピクセルと時刻が一体なので「ピクセル取得と時刻取得の間に次フレームが割り込む」競合が起きない。カメラを計測/測定に使うときの基本単位"
+description.ko = "캡처 시각이 붙은 카메라 1프레임. Pixels(RGBA8)와 timestampUs(단조 steady_clock 마이크로초, 캡처 스레드에서 기록)를 가짐. VideoGrabber::getBufferFrames()가 반환. 픽셀과 시각이 한 구조체로 오므로 둘을 따로 읽는 사이에 다음 프레임이 끼어드는 경쟁이 없음"
 related = ["VideoGrabber", "VideoGrabber::getBufferFrames", "VideoGrabber::setFrameQueueSize"]
 
 ["GrabberFrame::pixels"]
-description.en = "RGBA8 pixel data (width * height * 4 bytes)"
-description.ja = "RGBA8 のピクセルデータ（width * height * 4 バイト）"
-description.ko = "RGBA8 픽셀 데이터 (width * height * 4 바이트)"
-
-["GrabberFrame::width"]
-description.en = "Frame width in pixels"
-description.ja = "フレームの幅（ピクセル）"
-description.ko = "프레임 너비(픽셀)"
-
-["GrabberFrame::height"]
-description.en = "Frame height in pixels"
-description.ja = "フレームの高さ（ピクセル）"
-description.ko = "프레임 높이(픽셀)"
+description.en = "The frame as RGBA8 Pixels (carries its own width/height). Pixels is move-only - use clone() if you need a copy"
+description.ja = "フレーム本体（RGBA8 の Pixels。width/height は Pixels が持つ）。Pixels はムーブ専用なので、コピーが要る時は clone() を使う"
+description.ko = "프레임 본체(RGBA8 Pixels, width/height는 Pixels가 가짐). Pixels는 이동 전용이므로 복사가 필요하면 clone() 사용"
 
 ["GrabberFrame::timestampUs"]
 description.en = "Capture time in microseconds on the monotonic clock (std::chrono::steady_clock), stamped on the capture thread the moment the frame arrived from the driver. Not wall-clock time — use for interval math and cross-source sync only"

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10079,7 +10079,7 @@ keywords = ["thumbnail", "snapshot", "grab", "single frame", "poster", "exact fr
 description.en = "Extract the exact frame at a given time from a video file. Frame-accurate on every platform"
 description.ja = "ビデオファイルの指定時刻の正確なフレームを抽出。全プラットフォームでフレーム精度"
 description.ko = "비디오 파일에서 지정한 시간의 정확한 프레임을 추출. 모든 플랫폼에서 프레임 정확도"
-related = ["Pixels", "VideoPlayer", "VideoPlayer::load", "VideoPlayer::extractKeyFrame", "VideoPlayer::getPath"]
+related = ["Pixels", "Image", "VideoPlayer", "VideoPlayer::load", "VideoPlayer::extractKeyFrame", "VideoPlayer::getPath"]
 platform_note.en = "Implemented on macOS (AVAssetImageGenerator), Windows (Media Foundation / IMFSourceReader), and Linux (FFmpeg). Android stubs it (`return false`); iOS and web have no extractFramePlatform() definition and are unsupported."
 platform_note.ja = "macOS（AVAssetImageGenerator）・Windows（Media Foundation / IMFSourceReader）・Linux（FFmpeg）で実装済み。android は false を返すスタブ、ios/web は extractFramePlatform() の定義自体が無く未対応。"
 details.en = '''
@@ -10095,6 +10095,12 @@ Comes in two forms:
   good for thumbnails/posters from a file you are not playing.
 - **Instance** — `player.extractFrame(px, timeSec)`. Uses the currently loaded
   file ([`getPath`](#VideoPlayer::getPath)); returns false if nothing is loaded.
+
+Both forms also take an [`Image`](#Image) instead of `Pixels`
+(`extractFrame(path, img, timeSec)` / `player.extractFrame(img, timeSec)`):
+the result lands in a ready-to-draw Image (allocation + texture upload
+included). The upload touches the GPU, so the Image overloads are
+**main-thread only** — for background work use the `Pixels` forms.
 
 If you only need the nearest keyframe (faster, time-approximate — e.g. a rough
 thumbnail), use [`extractKeyFrame`](#VideoPlayer::extractKeyFrame) instead. These
@@ -10115,6 +10121,12 @@ details.ja = '''
 - **インスタンス** — `player.extractFrame(px, timeSec)`。現在ロード中のファイル
   （[`getPath`](#VideoPlayer::getPath)）を使う。未ロードなら false。
 
+どちらの形も `Pixels` の代わりに [`Image`](#Image) を渡せる
+（`extractFrame(path, img, timeSec)` / `player.extractFrame(img, timeSec)`）。
+確保〜テクスチャアップロード込みで、そのまま draw できる Image が返る。
+GPU に触るため Image 版は**メインスレッド限定** — バックグラウンド処理には
+`Pixels` 版を使う。
+
 最寄りキーフレームで十分（速い・時刻は近似、例えばラフなサムネイル）なら
 [`extractKeyFrame`](#VideoPlayer::extractKeyFrame) を使う。これらは単発取得用で、
 連続再生には**使わない**（呼ぶたびにデコードコンテキストを開くため重い）。再生は
@@ -10127,7 +10139,7 @@ keywords = ["thumbnail", "snapshot", "keyframe", "fast", "single frame", "poster
 description.en = "Extract the nearest keyframe at or before a given time. Faster than extractFrame but time-approximate"
 description.ja = "指定時刻以前の最寄りキーフレームを抽出。extractFrame より速いが時刻は近似"
 description.ko = "지정한 시간 이전의 가장 가까운 키프레임을 추출. extractFrame보다 빠르지만 시간은 근사치"
-related = ["Pixels", "VideoPlayer", "VideoPlayer::load", "VideoPlayer::extractFrame", "VideoPlayer::getPath"]
+related = ["Pixels", "Image", "VideoPlayer", "VideoPlayer::load", "VideoPlayer::extractFrame", "VideoPlayer::getPath"]
 platform_note.en = "Implemented on macOS (AVAssetImageGenerator), Windows (Media Foundation / IMFSourceReader), and Linux (FFmpeg). Android stubs it (`return false`); iOS and web are unsupported."
 platform_note.ja = "macOS（AVAssetImageGenerator）・Windows（Media Foundation / IMFSourceReader）・Linux（FFmpeg）で実装済み。android は false を返すスタブ、ios/web は未対応。"
 details.en = '''
@@ -10145,7 +10157,9 @@ fastest here — handy for the black-flash stopgap).
 Same two forms as [`extractFrame`](#VideoPlayer::extractFrame): static
 (`VideoPlayer::extractKeyFrame(path, px, timeSec)`, no `load()` needed) and
 instance (`player.extractKeyFrame(px, timeSec)`, uses the loaded
-[`getPath`](#VideoPlayer::getPath)). Single-shot only — not for playback.
+[`getPath`](#VideoPlayer::getPath)) — plus [`Image`](#Image) overloads of both
+that return a ready-to-draw Image (main-thread only). Single-shot only — not
+for playback.
 '''
 details.ja = '''
 [`extractFrame`](#VideoPlayer::extractFrame) と同様だが、**`timeSec` 以下の最寄り
@@ -10161,7 +10175,9 @@ details.ja = '''
 [`extractFrame`](#VideoPlayer::extractFrame) と同じく 2 種類:静的
 （`VideoPlayer::extractKeyFrame(path, px, timeSec)`、`load()` 不要）とインスタンス
 （`player.extractKeyFrame(px, timeSec)`、ロード中の
-[`getPath`](#VideoPlayer::getPath) を使う）。単発取得用で再生には使わない。
+[`getPath`](#VideoPlayer::getPath) を使う）。さらに両方に [`Image`](#Image) 版が
+あり、そのまま draw できる Image を返す（メインスレッド限定）。単発取得用で再生には
+使わない。
 '''
 
 ["VideoPlayer::getAudioChannels"]

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10468,6 +10468,54 @@ description.en = "Check if video is currently playing (not paused)"
 description.ja = "再生中か確認（一時停止中は false）"
 description.ko = "현재 재생 중인지 확인 (일시정지 시 false)"
 
+["VideoPlayerBase::isReady"]
+category = "video"
+keywords = ["ready", "first frame", "black flash", "decoded", "has picture"]
+description.en = "True once the texture holds a real decoded frame for the current playback — i.e. drawing shows actual video, not black"
+description.ja = "現在の再生の実フレームがテクスチャに載っていれば true ＝ 描画すると黒ではなく実映像が出る状態"
+description.ko = "현재 재생의 실제 디코드된 프레임이 텍스처에 있으면 true — 그리면 검은 화면이 아니라 실제 영상이 나오는 상태"
+related = ["VideoPlayerBase::isFrameNew", "VideoPlayerBase::isLoaded", "VideoPlayer::extractKeyFrame"]
+details.en = '''
+`load()`/`play()` decode asynchronously, so right after them the player would
+draw its cleared (black) texture. `isReady()` marks the end of that window: it
+turns true when the first decoded frame of the current playback lands on the
+texture, and resets to false on `load()`, `play()` and `stop()` (stop also
+clears the texture back to black). Seeking and pausing keep it **true** — the
+last frame stays on the texture, so drawing still shows real video.
+
+Typical use — avoid the black flash at playback start by bridging with a
+still (see [`extractKeyFrame`](#VideoPlayer::extractKeyFrame)):
+
+```cpp
+player.isReady() ? player.draw(0, 0) : still.draw(0, 0);
+```
+
+Distinct from [`isLoaded`](#VideoPlayerBase::isLoaded) (file opened, may still
+be black) and [`isFrameNew`](#VideoPlayerBase::isFrameNew) (momentary
+"a new frame arrived during this update()" — flickers at video rate, so never
+branch your draw on it directly).
+'''
+details.ja = '''
+`load()`/`play()` は非同期でデコードするため、直後はクリア済みの黒テクスチャが
+描画されてしまう。`isReady()` はその期間の終わりを示す: 現在の再生の最初の
+デコード済みフレームがテクスチャに載った時点で true になり、`load()`・`play()`・
+`stop()` で false に戻る（stop はテクスチャも黒にクリアする）。シークと一時停止
+では **true のまま**（直前のフレームがテクスチャに残っているので、描画すれば
+実映像が出る）。
+
+典型的な用途は再生開始時の黒フラッシュ回避（静止画でつなぐ。
+[`extractKeyFrame`](#VideoPlayer::extractKeyFrame) 参照）:
+
+```cpp
+player.isReady() ? player.draw(0, 0) : still.draw(0, 0);
+```
+
+[`isLoaded`](#VideoPlayerBase::isLoaded)（ファイルは開けたがまだ黒かもしれない）
+や [`isFrameNew`](#VideoPlayerBase::isFrameNew)（「この update() で新フレームが
+来た」という単発フラグ。動画レートで点滅するので draw の分岐に直接使わない）
+とは別物。
+'''
+
 ["VideoPlayerBase::play"]
 category = "video"
 keywords = ["start", "resume", "go", "playback"]

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -1958,6 +1958,11 @@ description.en = "Check if currently rendering to FBO"
 description.ja = "FBOに描画中か確認"
 description.ko = "현재 FBO 렌더링 중인지 확인"
 
+["Fbo::lifetimeToken"]
+description.en = "Lifetime token for observers holding a raw pointer to this Fbo (e.g. ScreenRecorder auto-stops when the recorded Fbo dies). Per-object: it does not transfer on move"
+description.ja = "この Fbo への生ポインタを持つ監視者向けの生存トークン（例: ScreenRecorder は録画中の Fbo が破棄されると自動停止する）。オブジェクト固有で、ムーブしても移らない"
+description.ko = "이 Fbo의 원시 포인터를 가진 관찰자를 위한 수명 토큰(예: ScreenRecorder는 녹화 중인 Fbo가 파괴되면 자동 정지). 객체 고유이며 이동해도 옮겨지지 않음"
+
 ["Fbo::isAllocated"]
 description.en = "Check if allocated"
 description.ja = "確保されているか確認"
@@ -6845,9 +6850,9 @@ description.ko = "화면 녹화가 현재 캡처 중인지 확인"
 ["ScreenRecorder::start"]
 category = "video"
 keywords = ["begin", "record", "capture", "go"]
-description.en = "Start live capture (window, or an Fbo for clean GUI-free output); size is taken automatically"
-description.ja = "ライブ録画開始（ウィンドウ、またはGUIなしのクリーン出力はFbo）。サイズは自動取得"
-description.ko = "라이브 녹화 시작 (윈도우, 또는 GUI 없는 클린 출력은 Fbo); 크기는 자동 취득"
+description.en = "Start live capture (window, or an Fbo for clean GUI-free output); size is taken automatically. Calling start while recording finalizes the current file first. If the recorded Fbo is destroyed mid-recording, the recording stops and finalizes automatically"
+description.ja = "ライブ録画開始（ウィンドウ、またはGUIなしのクリーン出力はFbo）。サイズは自動取得。録画中に start を呼ぶと現在のファイルを確定してから新規開始。録画中の Fbo が破棄された場合は自動で停止・確定する"
+description.ko = "라이브 녹화 시작 (윈도우, 또는 GUI 없는 클린 출력은 Fbo); 크기는 자동 취득. 녹화 중에 start를 호출하면 현재 파일을 마무리한 뒤 새로 시작. 녹화 중인 Fbo가 파괴되면 자동으로 정지·마무리"
 
 ["ScreenRecorder::stop"]
 category = "video"
@@ -9882,10 +9887,10 @@ description.ko = "디바이스의 안정적인 고유 식별자"
 
 ["GrabberFrame"]
 keywords = ["webcam", "camera", "frame", "timestamp", "queue", "measurement"]
-description.en = "One captured camera frame with its capture-time timestamp: Pixels (RGBA8) plus timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getBufferFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time"
-description.ja = "キャプチャ時刻付きのカメラ1フレーム。Pixels（RGBA8）と timestampUs（monotonicなsteady_clockのマイクロ秒。キャプチャスレッドで打刻）を持つ。VideoGrabber::getBufferFrames() が返す。ピクセルと時刻が一体なので「ピクセル取得と時刻取得の間に次フレームが割り込む」競合が起きない。カメラを計測/測定に使うときの基本単位"
-description.ko = "캡처 시각이 붙은 카메라 1프레임. Pixels(RGBA8)와 timestampUs(단조 steady_clock 마이크로초, 캡처 스레드에서 기록)를 가짐. VideoGrabber::getBufferFrames()가 반환. 픽셀과 시각이 한 구조체로 오므로 둘을 따로 읽는 사이에 다음 프레임이 끼어드는 경쟁이 없음"
-related = ["VideoGrabber", "VideoGrabber::getBufferFrames", "VideoGrabber::setFrameQueueSize"]
+description.en = "One captured camera frame with its capture-time timestamp: Pixels (RGBA8) plus timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getQueuedFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time"
+description.ja = "キャプチャ時刻付きのカメラ1フレーム。Pixels（RGBA8）と timestampUs（monotonicなsteady_clockのマイクロ秒。キャプチャスレッドで打刻）を持つ。VideoGrabber::getQueuedFrames() が返す。ピクセルと時刻が一体なので「ピクセル取得と時刻取得の間に次フレームが割り込む」競合が起きない。カメラを計測/測定に使うときの基本単位"
+description.ko = "캡처 시각이 붙은 카메라 1프레임. Pixels(RGBA8)와 timestampUs(단조 steady_clock 마이크로초, 캡처 스레드에서 기록)를 가짐. VideoGrabber::getQueuedFrames()가 반환. 픽셀과 시각이 한 구조체로 오므로 둘을 따로 읽는 사이에 다음 프레임이 끼어드는 경쟁이 없음"
+related = ["VideoGrabber", "VideoGrabber::getQueuedFrames", "VideoGrabber::setFrameQueueSize"]
 
 ["GrabberFrame::pixels"]
 description.en = "The frame as RGBA8 Pixels (carries its own width/height). Pixels is move-only - use clone() if you need a copy"
@@ -9923,7 +9928,7 @@ description.en = "Copy the current frame into an Image (allocating/updating it a
 description.ja = "現在のフレームを Image にコピー（必要に応じて確保・更新する）"
 description.ko = "현재 프레임을 Image로 복사(필요에 따라 할당/갱신)"
 
-["VideoGrabber::getBufferFrames"]
+["VideoGrabber::getQueuedFrames"]
 category = "video"
 keywords = ["frame queue", "timestamp", "drain", "all frames", "high fps", "sync", "measurement", "sensor", "latency", "analysis"]
 description.en = "Drain all frames captured since the last call (appended to the given vector, oldest first; returns the count). Each GrabberFrame carries a monotonic timestamp stamped on the capture thread, so timestamps stay truthful even if the main loop stalls, and no frame is lost when the camera runs faster than the app loop. Requires setFrameQueueSize() > 0; getPixels()/isFrameNew() are unaffected"
@@ -10021,7 +10026,7 @@ keywords = ["frame queue", "enable", "capacity", "buffer", "measurement"]
 description.en = "Enable the timestamped frame queue and set its capacity (0 = disable, the default; zero overhead when off). When full, the oldest frame is dropped so a slow consumer never blocks capture. Sizing hint: at least ceil(cameraFps / appFps) plus headroom; 8-16 is plenty. Can be called before or after setup()"
 description.ja = "タイムスタンプ付きフレームキューを有効化し容量を設定（0 = 無効。デフォルトで、オフ時のオーバーヘッドはゼロ）。満杯時は古いフレームから捨てるので、取り出しが遅れてもキャプチャは止まらない。容量目安は ceil(カメラfps / アプリfps) + 余裕で、8〜16 で十分。setup() の前後どちらでも呼べる"
 description.ko = "타임스탬프 프레임 큐를 활성화하고 용량을 설정 (0 = 비활성, 기본값. 꺼져 있으면 오버헤드 없음). 가득 차면 오래된 프레임부터 버려서 소비가 늦어도 캡처가 막히지 않음. 용량은 ceil(카메라fps / 앱fps) + 여유, 8~16이면 충분. setup() 전후 어느 쪽에서도 호출 가능"
-related = ["VideoGrabber::getBufferFrames", "VideoGrabber::getFrameQueueSize", "GrabberFrame"]
+related = ["VideoGrabber::getQueuedFrames", "VideoGrabber::getFrameQueueSize", "GrabberFrame"]
 
 ["VideoGrabber::setVerbose"]
 description.en = "Enable or disable verbose logging"
@@ -10461,17 +10466,18 @@ description.ko = "현재 재생 중인지 확인 (일시정지 시 false)"
 ["VideoPlayerBase::isReady"]
 category = "video"
 keywords = ["ready", "first frame", "black flash", "decoded", "has picture"]
-description.en = "True once the texture holds a real decoded frame for the current playback — i.e. drawing shows actual video, not black"
-description.ja = "現在の再生の実フレームがテクスチャに載っていれば true ＝ 描画すると黒ではなく実映像が出る状態"
-description.ko = "현재 재생의 실제 디코드된 프레임이 텍스처에 있으면 true — 그리면 검은 화면이 아니라 실제 영상이 나오는 상태"
+description.en = "True while the texture holds a real decoded frame — i.e. drawing shows actual video, not black. False only while the texture is cleared (after load/stop, before the first frame)"
+description.ja = "実フレームがテクスチャに載っていれば true ＝ 描画すると黒ではなく実映像が出る状態。false になるのはテクスチャが空の間だけ（load/stop 後〜最初のフレーム到着まで）"
+description.ko = "실제 디코드된 프레임이 텍스처에 있으면 true — 그리면 검은 화면이 아니라 실제 영상이 나오는 상태. 텍스처가 빈 동안(load/stop 후 첫 프레임 전)만 false"
 related = ["VideoPlayerBase::isFrameNew", "VideoPlayerBase::isLoaded", "VideoPlayer::extractKeyFrame"]
 details.en = '''
-`load()`/`play()` decode asynchronously, so right after them the player would
-draw its cleared (black) texture. `isReady()` marks the end of that window: it
-turns true when the first decoded frame of the current playback lands on the
-texture, and resets to false on `load()`, `play()` and `stop()` (stop also
-clears the texture back to black). Seeking and pausing keep it **true** — the
-last frame stays on the texture, so drawing still shows real video.
+`load()`/`play()` decode asynchronously, so right after load the player would
+draw its cleared (black) texture. `isReady()` is exactly the "would this draw
+black?" test: it turns true when the first decoded frame lands on the texture,
+and resets to false only when the texture actually goes empty — on `load()`
+and on `stop()` (which clears the texture back to black). `play()`, seeking
+and pausing keep it **true**: the last picture stays on the texture, so
+drawing still shows real video.
 
 Typical use — avoid the black flash at playback start by bridging with a
 still (see [`extractKeyFrame`](#VideoPlayer::extractKeyFrame)):
@@ -10486,12 +10492,12 @@ be black) and [`isFrameNew`](#VideoPlayerBase::isFrameNew) (momentary
 branch your draw on it directly).
 '''
 details.ja = '''
-`load()`/`play()` は非同期でデコードするため、直後はクリア済みの黒テクスチャが
-描画されてしまう。`isReady()` はその期間の終わりを示す: 現在の再生の最初の
-デコード済みフレームがテクスチャに載った時点で true になり、`load()`・`play()`・
-`stop()` で false に戻る（stop はテクスチャも黒にクリアする）。シークと一時停止
-では **true のまま**（直前のフレームがテクスチャに残っているので、描画すれば
-実映像が出る）。
+`load()`/`play()` は非同期でデコードするため、load 直後はクリア済みの黒
+テクスチャが描画されてしまう。`isReady()` は「描画したら黒か？」の判定そのもの:
+最初のデコード済みフレームがテクスチャに載った時点で true になり、false に戻る
+のは**テクスチャが実際に空になる時だけ** — `load()` と `stop()`（テクスチャを黒に
+クリアする）。`play()`・シーク・一時停止では **true のまま**（直前のフレームが
+テクスチャに残っているので、描画すれば実映像が出る）。
 
 典型的な用途は再生開始時の黒フラッシュ回避（静止画でつなぐ。
 [`extractKeyFrame`](#VideoPlayer::extractKeyFrame) 参照）:
@@ -14546,9 +14552,9 @@ related = ["VideoPlayer::setGammaCorrection"]
 ["startRecording"]
 category = "window_system"
 keywords = ["record", "video", "capture", "movie", "mp4"]
-description.en = "Start recording the window to a video file (native encoder, no ffmpeg). Pass a seconds argument (or VideoRecordSettings.duration) for a fixed-length clip that auto-stops and finalizes itself; 0 = unlimited"
-description.ja = "ウィンドウを動画ファイルに録画開始（ネイティブエンコーダ、ffmpeg不要）。秒数引数（または VideoRecordSettings.duration）を渡すと、その長さで自動停止・確定する固定長クリップになる（0 = 無制限）"
-description.ko = "윈도우를 동영상 파일로 녹화 시작 (네이티브 인코더, ffmpeg 불필요). 초 인자(또는 VideoRecordSettings.duration)를 넘기면 그 길이에서 자동 정지·마무리되는 고정 길이 클립이 된다(0 = 무제한)"
+description.en = "Start recording the window — or an Fbo (clean, GUI-free output) — to a video file (native encoder, no ffmpeg). Pass a seconds argument (or VideoRecordSettings.duration) for a fixed-length clip that auto-stops and finalizes itself; 0 = unlimited. Calling it again while recording finalizes the current file first, then starts fresh (same path = the old file is overwritten)"
+description.ja = "ウィンドウ — または Fbo（GUI無しのクリーン出力）— を動画ファイルに録画開始（ネイティブエンコーダ、ffmpeg不要）。秒数引数（または VideoRecordSettings.duration）を渡すと、その長さで自動停止・確定する固定長クリップになる（0 = 無制限）。録画中にもう一度呼ぶと現在のファイルを確定してから新規開始（同じパスなら前のファイルは上書き）"
+description.ko = "윈도우 — 또는 Fbo(GUI 없는 클린 출력) — 를 동영상 파일로 녹화 시작 (네이티브 인코더, ffmpeg 불필요). 초 인자(또는 VideoRecordSettings.duration)를 넘기면 그 길이에서 자동 정지·마무리되는 고정 길이 클립이 된다(0 = 무제한). 녹화 중에 다시 호출하면 현재 파일을 마무리한 뒤 새로 시작(같은 경로면 이전 파일 덮어씀)"
 related = ["VideoRecordSettings", "stopRecording", "isRecording", "saveScreenshot"]
 platform_note.en = "Global convenience over the singleton ScreenRecorder; non-functional on web for the same reason (VideoWriter stub returns false)."
 platform_note.ja = "シングルトン ScreenRecorder への薄いラッパ。同じ理由で web では機能しない（VideoWriter スタブが false）。"

--- a/examples/video/videoGrabberFrameQueueExample/src/tcApp.cpp
+++ b/examples/video/videoGrabberFrameQueueExample/src/tcApp.cpp
@@ -27,7 +27,7 @@ void tcApp::update() {
     grabber_.update();  // classic path: live preview texture (unaffected)
 
     // Drain all frames captured since the last call (0..n per update).
-    // Each GrabberFrame carries pixels + width/height + timestampUs together.
+    // Each GrabberFrame carries Pixels + timestampUs together.
     frames_.clear();
     grabber_.getBufferFrames(frames_);
     total_ += frames_.size();
@@ -36,13 +36,13 @@ void tcApp::update() {
     // accept one loadData per frame)
     for (size_t k = frames_.size() > kStrip ? frames_.size() - kStrip : 0;
          k < frames_.size(); k++) {
-        GrabberFrame& f = frames_[k];
+        Pixels& px = frames_[k].pixels;
         Texture& t = tex_[head_];  // overwrite the next slot, wrap around
-        if (t.getWidth() != f.width) {
-            t.allocate(f.width, f.height, 4, TextureUsage::Stream);
+        if (t.getWidth() != px.getWidth()) {
+            t.allocate(px.getWidth(), px.getHeight(), 4, TextureUsage::Stream);
         }
-        t.loadData(f.pixels.data(), f.width, f.height, 4);
-        tUs_[head_] = f.timestampUs;
+        t.loadData(px.getData(), px.getWidth(), px.getHeight(), 4);
+        tUs_[head_] = frames_[k].timestampUs;
         head_ = (head_ + 1) % kStrip;
     }
 }

--- a/examples/video/videoGrabberFrameQueueExample/src/tcApp.cpp
+++ b/examples/video/videoGrabberFrameQueueExample/src/tcApp.cpp
@@ -29,7 +29,7 @@ void tcApp::update() {
     // Drain all frames captured since the last call (0..n per update).
     // Each GrabberFrame carries Pixels + timestampUs together.
     frames_.clear();
-    grabber_.getBufferFrames(frames_);
+    grabber_.getQueuedFrames(frames_);
     total_ += frames_.size();
     // a burst (e.g. after a stall) can return more frames than slots; only
     // the last kStrip would survive, so skip the rest (Stream textures also

--- a/examples/video/videoGrabberFrameQueueExample/src/tcApp.h
+++ b/examples/video/videoGrabberFrameQueueExample/src/tcApp.h
@@ -14,7 +14,7 @@ public:
 
 private:
     VideoGrabber grabber_;
-    vector<GrabberFrame> frames_;  // reused scratch for getBufferFrames()
+    vector<GrabberFrame> frames_;  // reused scratch for getQueuedFrames()
 
     // last kStrip frames; slots are overwritten in turn (head_ wraps around)
     static constexpr int kStrip = 8;

--- a/examples/video/videoPlayerExample/src/tcApp.cpp
+++ b/examples/video/videoPlayerExample/src/tcApp.cpp
@@ -15,6 +15,12 @@
 void tcApp::setup() {
     setWindowTitle("Video Player Example");
 
+    // Auto-load a bundled sample if present (the only way to load on iOS,
+    // where there is no file dialog / drag & drop)
+    if (std::filesystem::exists(getDataPath("test.mp4"))) {
+        loadVideo(getDataPath("test.mp4"));
+    }
+
     // You can set a video path here for testing
     // videoPath_ = "/path/to/your/video.mp4";
     // loadVideo(videoPath_);
@@ -157,13 +163,15 @@ void tcApp::keyPressed(int key) {
     else if (key == 'I') {
         showInfo_ = !showInfo_;
     }
+#if !(defined(__APPLE__) && TARGET_OS_IOS)
     else if (key == 'L') {
-        // Open file dialog
+        // Open file dialog (sync dialogs are unavailable on iOS)
         auto result = loadDialog("Select Video File", "");
         if (result.success) {
             loadVideo(result.filePath);
         }
     }
+#endif
 }
 
 void tcApp::filesDropped(const vector<string>& files) {


### PR DESCRIPTION
## Summary

VideoPlayer now works on **all 5 implemented backends — macOS, Windows,
Linux, web, and (for the first time ever) real playback on an actual
iPhone** 🎉 (Android remains a stub, untouched.)

The headline feature: **auto-poster**. Load a video and the texture instantly
shows frame 0. Stop, seek, play — the picture on screen *always* matches the
playback position. No black flash. No stale frame. Ever. Verified down to
byte-exact pixel comparison on macOS, and confirmed on Windows, Linux, web,
and now iOS on device.

Along the way this PR also fixes a color mismatch in extractFrame (posters are
now pixel-identical to live playback), tightens the v0.6.5 API (3 breaking
changes), and unbreaks the iOS build + data path that had never survived
contact with real hardware.

15 commits, 5 platforms, 0 black frames.

## Auto poster (new, default ON)

Invariant: **the texture always shows the frame at the playback position** —
no black flash, no stale frame.

- `load()` synchronously posters frame 0 (keyframe: exact + fast)
- `stop()` rewinds and posters frame 0
- `play()` after a seek posters the exact target frame (via pendingSeekSec_,
  async seeks make getCurrentTime unreliable)
- `isReady()` = "the texture holds a real picture" (true from load on)
- Stream textures accept one loadData per app frame → deferred re-upload path
  when a live frame took the slot
- Opt out with `setAutoPoster(false)`
- web: `preload='auto'` (no synchronous extract there)

## extractFrame / extractKeyFrame

- Color-matches playback: draw in the source color space, not DeviceRGB
  (poster was +4.8/255 brighter; now byte-identical to live frames, diff 0.0)
- Ported to iOS (AVAssetImageGenerator + CoreGraphics)
- `Image` overloads added alongside `Pixels`

## API tightening (v0.6.5, breaking)

- `getBufferFrames` → **`getQueuedFrames`** ("queue" vocabulary; "buffer"
  collides with Fbo)
- **`GrabberFrame` carries `Pixels`** (drops raw `vector<uint8_t>` + width/height)
- extractFrame/extractKeyFrame **`timeSec` is now required** (no default)
- Fbo recording safety + `startRecording(fbo)` free functions

## iOS fixes

- **Live playback**: a plain `play()` before ReadyToPlay parked the AVPlayer in
  "waiting" forever (time frozen, no frames). Now
  `playImmediatelyAtRate:` + `automaticallyWaitsToMinimizeStalling = NO`, and
  the video output requests IOSurface-backed / Metal-compatible pixel buffers.
- **Data path**: iOS uses a flat bundle (`App.app/data`), but `#ifdef __APPLE__`
  hardcoded macOS's `../../../data/`. The root is now resolved lazily by
  probing which layout exists next to the executable.
- **Build fix**: attribute order in tcFileDialog.h (`TC_PLATFORMS` annotate must
  precede `__attribute__((unavailable))`); iOS builds were broken since
  TC_PLATFORMS landed.
- nil-guard in getExecutablePath/Dir.

## Verification

| Platform | Status |
|---|---|
| macOS | full on-device run incl. numeric state-machine test (load/stop/seek+play byte-exact) |
| Windows | agent-verified: frame queue (897 unique frames, stall behavior) + auto-poster PASS |
| Linux | agent-verified: auto-poster PASS + NV12 visual check |
| Web | manual: no black on start/scrub/restart |
| iOS | on-device (iPhone 16): live playback, poster invariant (load/stop/seek+play), mid-frame load |
| Android | N/A (VideoPlayer is a pre-existing stub, unchanged) |

Known minor: on iOS, seek+play can show the frame 1 frame before the seek
target for a single frame (not black, not stale).
