### PR TITLE
fix(win): console tools stay console even when linking GUI-header addons

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -146,6 +146,15 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TC_ALL_SOURCES})
 
 add_library(TrussC STATIC ${TC_ALL_SOURCES})
 
+# PRIVATE (not PUBLIC): the core lib's own TUs must not emit TrussC.h's
+# /subsystem:windows pragma — a library .drectve overrides the command-line
+# /SUBSYSTEM and would flip console tools to the GUI subsystem. The app's own
+# TUs never get this define, so GUI apps still pin /subsystem:windows. Addons
+# get the same treatment in use_addon.cmake.
+if(WIN32)
+    target_compile_definitions(TrussC PRIVATE TRUSSC_LIBRARY_TU)
+endif()
+
 add_library(tc::TrussC ALIAS TrussC)
 
 # Bake the git-derived version into tc::getVersion() (tcVersion.h).

--- a/core/cmake/use_addon.cmake
+++ b/core/cmake/use_addon.cmake
@@ -51,6 +51,19 @@ macro(_tc_load_addon _ADDON_NAME)
             _tc_auto_addon(${_ADDON_NAME} "${_ADDON_PATH}")
         endif()
 
+        # Keep TrussC.h's /subsystem:windows pragma out of addon library objects
+        # (see the guard in TrussC.h): a single such .drectve in a linked static
+        # lib overrides the command-line /SUBSYSTEM and flips a console tool to
+        # the GUI subsystem. This is the one chokepoint every addon passes through
+        # regardless of how its target was created (own CMakeLists or auto). Skip
+        # header-only INTERFACE addons — they compile no TUs of their own.
+        if(WIN32 AND TARGET ${_ADDON_NAME})
+            get_target_property(_TC_ADDON_TYPE ${_ADDON_NAME} TYPE)
+            if(NOT _TC_ADDON_TYPE STREQUAL "INTERFACE_LIBRARY")
+                target_compile_definitions(${_ADDON_NAME} PRIVATE TRUSSC_LIBRARY_TU)
+            endif()
+        endif()
+
         list(APPEND _TC_LOADED_ADDONS ${_ADDON_NAME})
         set(_TC_LOADED_ADDONS "${_TC_LOADED_ADDONS}" CACHE INTERNAL "List of loaded TrussC addons")
     endif()

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -5,8 +5,17 @@
 // =============================================================================
 
 // Windows: Hide console window (in Release builds)
-// Define TRUSSC_SHOW_CONSOLE to always show console
-#if defined(_WIN32) && !defined(_DEBUG) && !defined(TRUSSC_SHOW_CONSOLE)
+// Define TRUSSC_SHOW_CONSOLE to always show console.
+//
+// This must fire ONLY in the app's own translation units, never in a library
+// (core TrussC or an addon static lib). A library object that emits the
+// /subsystem:windows directive forces the GUI subsystem onto the final image via
+// its .drectve, which overrides the command-line /SUBSYSTEM — so a single
+// GUI-header-including library (core, or e.g. a networking addon) would silently
+// turn a console tool into a GUI app that detaches from its launcher. The build
+// defines TRUSSC_LIBRARY_TU when compiling the TrussC lib and every addon; the
+// app's own main TU has neither define, so GUI apps still pin /subsystem:windows.
+#if defined(_WIN32) && !defined(_DEBUG) && !defined(TRUSSC_SHOW_CONSOLE) && !defined(TRUSSC_LIBRARY_TU)
 #pragma comment(linker, "/subsystem:\"windows\" /entry:\"mainCRTStartup\"")
 #endif
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,6 +97,39 @@ This ensures:
 - User projects work when you move just the project folder
 - No complex relative path calculations needed
 
+### Windows Subsystem: console tools vs GUI apps
+
+On Windows every executable is stamped with a **subsystem** that decides how it
+attaches to a launching terminal. A `WINDOWS` (GUI) image detaches immediately —
+`cmd` returns to the prompt, closing the console window doesn't kill it and sends
+no `CTRL_CLOSE` — while a `CONSOLE` image keeps its terminal (stdout is visible,
+`Ctrl+C` / window-close reach it).
+
+- **GUI apps (default).** In Release, `TrussC.h` emits
+  `#pragma comment(linker, "/subsystem:windows /entry:mainCRTStartup")` so a
+  double-clicked app never flashes a console. The pragma fires from the **app's
+  own** translation units.
+- **Console tools.** Define `TRUSSC_SHOW_CONSOLE` (in `local.cmake`, which
+  survives `trusscli update`) to suppress that pragma in the app's TUs, leaving
+  the default console subsystem — how `trusscli` itself builds.
+  ```cmake
+  # local.cmake
+  if(WIN32)
+      target_compile_definitions(${PROJECT_NAME} PRIVATE TRUSSC_SHOW_CONSOLE)
+  endif()
+  ```
+
+**Why libraries must not carry the pragma.** A `#pragma comment(linker, ...)` in
+a *library* object (core TrussC or an addon) rides into the final link via that
+object's `.drectve` section, and for `/subsystem` a `.drectve` directive
+**overrides the command-line `/SUBSYSTEM`**. So a single GUI-header-including
+addon (e.g. `tcxWebSocket`) would silently turn a console tool back into a GUI
+app. To prevent that the build defines `TRUSSC_LIBRARY_TU` (PRIVATE) on the core
+lib and on every addon target, and the pragma is gated on
+`!defined(TRUSSC_LIBRARY_TU)`. Net effect: the subsystem is decided **only by the
+app's own TUs** — GUI by default, console when the app defines
+`TRUSSC_SHOW_CONSOLE` — no matter which addons it links.
+
 ---
 
 ## 4. API Design

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1346,6 +1346,17 @@ int main(int argc, char** argv) {
 ```
 If you want an app that runs without a window (update loop only, no `draw()`), use `runHeadlessApp<App>()` (see *Can I make a console / headless app?*). Exit from `main` with a `return` code, or from inside an app via `exitApp()` (immediate) / `requestExitApp()` (cancellable).
 
+### Windows: my console tool detaches from cmd / keeps running after I close the console — how do I make it a real console app?
+
+That happens because the exe was linked as the Windows **GUI** subsystem — the TrussC default, so a double-clicked GUI app never flashes a console. A GUI image returns to the `cmd` prompt immediately, ignores `Ctrl+C`, and gets no `CTRL_CLOSE` when its console window closes (so a supervisor loop keeps running in the background). For a CLI/console tool you want the **console** subsystem instead: define `TRUSSC_SHOW_CONSOLE` in `local.cmake` (it survives `trusscli update`, unlike the generated `CMakeLists.txt`):
+```cmake
+# local.cmake
+if(WIN32)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE TRUSSC_SHOW_CONSOLE)
+endif()
+```
+That is the whole procedure — no linker flags, no per-addon steps. In particular you do **not** need to do anything about addons: the core lib and every addon are compiled with `TRUSSC_LIBRARY_TU`, so their objects never inject `/subsystem:windows`, and your tool links as console even when it uses GUI-header-including addons (e.g. `tcxWebSocket`). Verify with `dumpbin /headers app.exe | findstr subsystem` — you want `Windows CUI` (console), not `Windows GUI`. Mechanism: ARCHITECTURE.md §3.5 "Windows Subsystem".
+
 ## "I want to X" — which API?
 
 ### "I want to save / load / communicate" → which API?


### PR DESCRIPTION
## Problem
On Windows a TrussC console tool (e.g. anchorbolt) could link as the **GUI** subsystem instead of console, so it detached from `cmd` (returned to the prompt immediately), ignored `Ctrl+C`, and kept running after its console window closed — while still printing nothing to the terminal.

## Root cause
`TrussC.h` emits `#pragma comment(linker, "/subsystem:windows /entry:mainCRTStartup")` in every TU that includes it (Release, no `TRUSSC_SHOW_CONSOLE`). In a **static-library** object (core TrussC, or an addon like `tcxWebSocket` that includes `<TrussC.h>`) that directive rides into the final link via the object's `.drectve` section — and for `/subsystem` a `.drectve` directive **overrides the command-line `/SUBSYSTEM`**. So one GUI-header-including addon flipped the whole image to GUI, and no command-line flag or `local.cmake` workaround could win.

## Fix
- Gate the pragma on `!defined(TRUSSC_LIBRARY_TU)`.
- Define `TRUSSC_LIBRARY_TU` (PRIVATE) on the core `TrussC` lib and on **every** addon target — applied at the `_tc_load_addon` chokepoint, so it covers both own-`CMakeLists.txt` addons (via `add_subdirectory`) and auto addons.

The app's own TUs never get the define, so **GUI apps still pin `/subsystem:windows` from their `main` TU**. The subsystem is now decided solely by the app: GUI by default, console when it defines `TRUSSC_SHOW_CONSOLE`.

## Verification (Windows, MSVC)
| Build | subsystem | |
|---|---|---|
| anchorbolt (console tool, links tcxWebSocket) | `3` Windows CUI | ✅ fixed |
| a GUI graphics app | `2` Windows GUI | ✅ no regression |

## Docs
- `ARCHITECTURE.md` §3.5 — new "Windows Subsystem: console tools vs GUI apps".
- `FOR_AI_ASSISTANT.md` — console-app creation procedure (define `TRUSSC_SHOW_CONSOLE` in `local.cmake`; addons are handled automatically).

Files: `core/include/TrussC.h`, `core/CMakeLists.txt`, `core/cmake/use_addon.cmake`, `docs/ARCHITECTURE.md`, `docs/FOR_AI_ASSISTANT.md`.