### PR TITLE
fix: VideoPlayer (mac) freezes on videos with non-square SAR

### DIFF
--- a/core/platform/mac/tcVideoPlayer_mac.mm
+++ b/core/platform/mac/tcVideoPlayer_mac.mm
@@ -53,6 +53,7 @@ NS_INLINE CGImageRef tcv_copy_cgimage_at_time(AVAssetImageGenerator* gen,
 @property (nonatomic, assign) BOOL isFinished;
 @property (nonatomic, assign) BOOL hasNewFrame;
 @property (nonatomic, assign) BOOL loop;
+@property (nonatomic, assign) BOOL sizeMismatchWarned;   // warn once per load
 
 // Pixel buffer for C++ side
 @property (nonatomic, assign) unsigned char* pixelBuffer;
@@ -106,6 +107,7 @@ NS_INLINE CGImageRef tcv_copy_cgimage_at_time(AVAssetImageGenerator* gen,
         _isFinished = NO;
         _hasNewFrame = NO;
         _loop = NO;
+        _sizeMismatchWarned = NO;
 
         _pixelBuffer = nullptr;
         _pixelBufferSize = 0;
@@ -311,6 +313,7 @@ NS_INLINE CGImageRef tcv_copy_cgimage_at_time(AVAssetImageGenerator* gen,
     _isReady = NO;
     _isFinished = NO;
     _hasNewFrame = NO;
+    _sizeMismatchWarned = NO;
 }
 
 - (void)playerDidFinishPlaying:(NSNotification*)notification {
@@ -346,13 +349,26 @@ NS_INLINE CGImageRef tcv_copy_cgimage_at_time(AVAssetImageGenerator* gen,
             size_t bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
             unsigned char* baseAddress = (unsigned char*)CVPixelBufferGetBaseAddress(pixelBuffer);
 
-            // Convert BGRA to RGBA
-            if (_pixelBuffer && width == (size_t)_videoWidth && height == (size_t)_videoHeight) {
-                for (size_t y = 0; y < height; y++) {
+            // Convert BGRA to RGBA. The decoder's buffer can be slightly larger
+            // than the track's naturalSize (e.g. a non-square SAR makes
+            // naturalSize 1919 while the coded frame is 1920): copy the
+            // overlapping region instead of dropping the frame, which used to
+            // freeze playback silently on such files.
+            if (_pixelBuffer) {
+                if ((width != (size_t)_videoWidth || height != (size_t)_videoHeight)
+                        && !_sizeMismatchWarned) {
+                    _sizeMismatchWarned = YES;
+                    NSLog(@"TCVideoPlayer: decoded frame %zux%zu differs from track naturalSize "
+                          @"%ldx%ld (non-square SAR?); copying the overlapping region",
+                          width, height, (long)_videoWidth, (long)_videoHeight);
+                }
+                size_t copyW = MIN(width, (size_t)_videoWidth);
+                size_t copyH = MIN(height, (size_t)_videoHeight);
+                for (size_t y = 0; y < copyH; y++) {
                     unsigned char* srcRow = baseAddress + y * bytesPerRow;
-                    unsigned char* dstRow = _pixelBuffer + y * width * 4;
+                    unsigned char* dstRow = _pixelBuffer + y * (size_t)_videoWidth * 4;
 
-                    for (size_t x = 0; x < width; x++) {
+                    for (size_t x = 0; x < copyW; x++) {
                         // BGRA -> RGBA
                         dstRow[x * 4 + 0] = srcRow[x * 4 + 2];  // R <- B
                         dstRow[x * 4 + 1] = srcRow[x * 4 + 1];  // G <- G


### PR DESCRIPTION
## What
On macOS, a video whose H.264 stream carries a non-square sample aspect ratio (e.g. SAR 2024:2025 from a videotoolbox transcode) kept playing time-wise but the picture froze on the first frame: AVFoundation's `naturalSize` (coded width × SAR ≈ 1919) disagreed with the decoder's actual buffer width (1920), and `update()` silently dropped every frame on its exact-size guard.

- Copy the overlapping region (min of reported / decoded size) instead of dropping the frame
- Log a one-time warning naming both sizes, so this failure is never silent again

Windows (Media Foundation re-resolves the actual frame size on every copy) and Linux (ffmpeg works at coded size) never had the mismatch — this is mac-only.

## Verification
- videoPlayerExample + a SAR 2024:2025 file: picture was static before (frame diff ≈ 0.1, only the time HUD moving), plays after the fix (full-frame diff), warning logged exactly once
- Regression: a normal square-pixel video (640×360) plays as before, no warning