### PR TITLE
fix: temporary-mesh deferred draws drew nothing; texture draws ignored setBlendMode

### DIFF
--- a/core/include/tc/3d/tcMeshPbrPipeline.h
+++ b/core/include/tc/3d/tcMeshPbrPipeline.h
@@ -15,13 +15,14 @@
 //   5. tc/gpu/shaders/meshPbr.glsl.h (generated sokol-shdc output)
 //   6. tcMeshPbrPipeline.h        (this file; defines Mesh::drawGpuPbr())
 //
-// v1 limitations:
-//   - Swapchain target only. Drawing PBR mesh inside an Fbo pass will trigger
-//     a sokol_gfx pipeline format mismatch. Phase 4 will add per-target cache.
-//   - Swapchain PBR draws are deferred into the per-layer flush
-//     (flushDeferredShaderDraws) so they composite with sokol_gl 2D in
-//     submission order — a 2D background drawn before a PBR mesh now stays
-//     behind it. FBO-pass PBR draws remain immediate.
+// Draw submission:
+//   - Pipelines are cached per (color format, sample count), so both the
+//     swapchain and Fbo passes are supported render targets.
+//   - ALL PBR draws are deferred: swapchain draws into the per-layer flush
+//     (flushDeferredShaderDraws), FBO-pass draws into fboPbrDraws (flushed at
+//     Fbo::end()), so they composite with sokol_gl 2D in submission order.
+//     Captured sg_buffer handles stay valid because Mesh defers buffer
+//     destruction to end of frame (internal::pendingGpuBufferDestroys).
 //
 // =============================================================================
 

--- a/core/include/tc/app/tcGlobal.cpp
+++ b/core/include/tc/app/tcGlobal.cpp
@@ -298,6 +298,11 @@ void present() {
     sg_end_pass();
     internal::currentWindowContext().inSwapchainPass = false;
     sg_commit();
+
+    // Now that every deferred draw (swapchain layers above, FBO passes at
+    // their Fbo::end()) has been submitted, it is safe to destroy GPU buffers
+    // released by meshes during this frame (temporary Mesh draws, re-uploads).
+    internal::drainPendingGpuBufferDestroys();
 }
 
 bool isInSwapchainPass() {

--- a/core/include/tc/gpu/tcTexture.h
+++ b/core/include/tc/gpu/tcTexture.h
@@ -902,9 +902,16 @@ private:
 
     void drawInternal(float x, float y, float w, float h,
                       float u0, float v0, float u1, float v1) const {
-        // Blend pipeline for the active target (behavior preserved: FBO uses Fill2D
-        // even for premultiplied sources, as before).
-        if (internal::currentWindowContext().inFboPass) {
+        // Blend pipeline for the active target. An explicit non-Alpha blend mode
+        // set via setBlendMode() takes priority — texture draws (including
+        // Fbo::draw) must honor it, e.g. compositing an Fbo with Subtract.
+        // Under the default Alpha mode, behavior is preserved: premultiplied
+        // sources use the premult pipeline on the swapchain, FBO passes use
+        // Fill2D even for premultiplied sources, as before.
+        BlendMode blend = internal::currentWindowContext().currentBlendMode;
+        if (blend != BlendMode::Alpha) {
+            internal::loadPipeline(internal::active2D(blend));
+        } else if (internal::currentWindowContext().inFboPass) {
             internal::loadPipeline(internal::activeFill2D());
         } else if (premultipliedAlpha_) {
             internal::loadPipeline(internal::activePremult());

--- a/core/include/tc/graphics/tcMesh.h
+++ b/core/include/tc/graphics/tcMesh.h
@@ -8,6 +8,30 @@
 
 namespace trussc {
 
+namespace internal {
+
+// GPU buffers whose owning Mesh is gone but that may still be referenced by a
+// deferred PBR / point draw command recorded this frame (swapchain draws are
+// replayed in flushDeferredShaderDraws, FBO-pass draws in Fbo::end()). Without
+// this, a temporary Mesh — e.g. drawBox() creating createBox(...).draw() —
+// destroys its sg_buffers at end of statement and the deferred replay binds
+// dead handles, silently drawing nothing. Destruction is deferred here and
+// drained once per frame in present(), after all deferred draws have executed.
+inline std::vector<sg_buffer> pendingGpuBufferDestroys;
+
+inline void deferGpuBufferDestroy(sg_buffer buf) {
+    if (buf.id != 0) pendingGpuBufferDestroys.push_back(buf);
+}
+
+inline void drainPendingGpuBufferDestroys() {
+    for (sg_buffer buf : pendingGpuBufferDestroys) {
+        sg_destroy_buffer(buf);
+    }
+    pendingGpuBufferDestroys.clear();
+}
+
+} // namespace internal
+
 // Primitive mode
 enum class PrimitiveMode {
     Triangles,
@@ -1115,7 +1139,7 @@ public:
             }
         }
 
-        if (pbuf_.id != 0) { sg_destroy_buffer(pbuf_); pbuf_ = {}; }
+        if (pbuf_.id != 0) { internal::deferGpuBufferDestroy(pbuf_); pbuf_ = {}; }
         sg_buffer_desc pbd = {};
         pbd.data.ptr  = pointPacked_.data();
         pbd.data.size = pointPacked_.size() * sizeof(float);
@@ -1137,16 +1161,18 @@ public:
 
 private:
     void releaseGpuBuffers() const {
+        // Deferred destroy: a deferred draw command recorded this frame may
+        // still hold these handles (see internal::pendingGpuBufferDestroys).
         if (vbuf_.id != 0) {
-            sg_destroy_buffer(vbuf_);
+            internal::deferGpuBufferDestroy(vbuf_);
             vbuf_ = {};
         }
         if (ibuf_.id != 0) {
-            sg_destroy_buffer(ibuf_);
+            internal::deferGpuBufferDestroy(ibuf_);
             ibuf_ = {};
         }
         if (pbuf_.id != 0) {
-            sg_destroy_buffer(pbuf_);
+            internal::deferGpuBufferDestroy(pbuf_);
             pbuf_ = {};
         }
         gpuVertexCount_ = 0;


### PR DESCRIPTION
## Summary

Two rendering fixes in core:

1. **Defer mesh GPU buffer destroys until deferred draws have flushed** — Since the swapchain PBR deferral (`a89dc4ff`), draw commands capture `sg_buffer` handles and replay at flush time. A temporary `Mesh` (e.g. `drawBox()` / `drawSphere()` / `drawCone()`, which create `createBox(...).draw()` per frame) destroyed its buffers at end of statement, so the replay bound dead handles and silently drew nothing. `releaseGpuBuffers()` now defers destruction to `internal::pendingGpuBufferDestroys`, drained in `present()` after `sg_commit()`.

2. **Honor the current blend mode in `Texture::drawInternal()`** — Texture draws (including `Fbo::draw()`) unconditionally loaded the Fill2D (Alpha) pipeline, so an explicit `setBlendMode()` (e.g. compositing an Fbo with `Subtract`) was silently ignored — this had never worked. Non-Alpha modes now resolve via `active2D(mode)` (per-target, works inside Fbo passes too); the default Alpha path is unchanged, including the premultiplied special case.

## Verified (macOS / Metal)

- Repro app: white-on-black Fbo composited with `clear(1)` + `Subtract` → correctly inverted; plain-shape Subtract control unchanged
- Workshop `8-3d` (immediate `drawBox`/`drawSphere` + Material): all lit meshes render again
- Workshop `9-fft`: bass-hit invert flash works (confirmed by eye with live audio)
- Regression: `3DPrimitivesExample` (member meshes + lighting) identical before/after
- Regression: `fboBlendModeExample` — Add blend correct on both swapchain and Fbo sides

Windows / Linux not manually tested (shared code paths; relying on CI).