### PR TITLE
feat: recording audio on Windows and Linux (AAC track in screen recording)

### DIFF
--- a/core/include/tc/sound/tcAudioRecorder.h
+++ b/core/include/tc/sound/tcAudioRecorder.h
@@ -91,6 +91,10 @@ public:
         }
 
         fs::path resolved = getDataPath(path);
+        if (resolved.has_parent_path()) {   // same convenience as VideoWriter
+            std::error_code ec;
+            fs::create_directories(resolved.parent_path(), ec);
+        }
         file_.open(resolved, std::ios::binary | std::ios::trunc);
         if (!file_) {
             logError("AudioRecorder") << "start: cannot open " << resolved.string();

--- a/core/include/tc/video/tcVideoRecorder.h
+++ b/core/include/tc/video/tcVideoRecorder.h
@@ -99,8 +99,8 @@ struct VideoRecordSettings {
                                 // many seconds of output; 0 = unlimited (call
                                 // stop() manually). Ignored by VideoWriter.
 
-    // Record the engine's master mix into the file as an AAC track (macOS only
-    // for now; other platforms warn and record video-only). ScreenRecorder also
+    // Record the engine's master mix into the file as an AAC track (macOS and
+    // Windows; other platforms warn and record video-only). ScreenRecorder also
     // switches the video PTS clock from wall time to the AUDIO DEVICE clock, so
     // A/V stay in sync no matter how unstable the frame rate is.
     bool audio = false;

--- a/core/include/tc/video/tcVideoRecorder.h
+++ b/core/include/tc/video/tcVideoRecorder.h
@@ -99,8 +99,10 @@ struct VideoRecordSettings {
                                 // many seconds of output; 0 = unlimited (call
                                 // stop() manually). Ignored by VideoWriter.
 
-    // Record the engine's master mix into the file as an AAC track (macOS and
-    // Windows; other platforms warn and record video-only). ScreenRecorder also
+    // Record the engine's master mix into the file as an AAC track (macOS,
+    // Windows and Linux; other platforms warn and record video-only, and Linux
+    // needs a GStreamer AAC encoder installed: gst-libav or gst-plugins-bad).
+    // ScreenRecorder also
     // switches the video PTS clock from wall time to the AUDIO DEVICE clock, so
     // A/V stay in sync no matter how unstable the frame rate is.
     bool audio = false;

--- a/core/platform/linux/tcVideoRecorder_linux.cpp
+++ b/core/platform/linux/tcVideoRecorder_linux.cpp
@@ -44,10 +44,14 @@ namespace trussc {
 namespace internal {
 struct VideoWriterPlatformData {
     GstElement* pipeline = nullptr;
-    GstElement* appsrc   = nullptr;  // borrowed (owned by pipeline)
+    GstElement* appsrc   = nullptr;  // video source (we hold a ref)
+    GstElement* audiosrc = nullptr;  // audio source (we hold a ref); null = video-only
     int    width  = 0;
     int    height = 0;
     double fps    = 30.0;
+    bool   hasAudio = false;
+    int    audioRate = 0;
+    int    audioChannels = 0;
     bool   failed = false;
 };
 }  // namespace internal
@@ -246,11 +250,6 @@ void configureKeyframeInterval(GstElement* enc, int frames) {
 // ---------------------------------------------------------------------------
 bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
                                float fps, const VideoRecordSettings& settings) {
-    if (settings.audio) {
-        logWarning("VideoWriter")
-            << "audio recording is not supported on this platform yet - "
-               "recording video only";
-    }
     // Resolve the codec to an encoder plan. H.264 and HEVC are supported via
     // GStreamer; ProRes is AVFoundation-only (macOS), so reject it clearly
     // rather than silently writing a different format than requested.
@@ -267,6 +266,35 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
     if (!gstInitialized) {
         gst_init(nullptr, nullptr);
         gstInitialized = true;
+    }
+
+    // Audio track: pick the first AAC encoder available on this system. All of
+    // these are software encoders that initialize reliably when installed, so
+    // (unlike the video encoders) a presence check is enough — no probe
+    // pipeline needed. Missing encoder or unusable format degrades to
+    // video-only with a warning, mirroring the mac/win backends.
+    const char* aacEnc = nullptr;
+    if (settings.audio) {
+        if (settings.audioSampleRate > 0 && settings.audioChannels > 0) {
+            static const char* kAacEncoders[] = {
+                "fdkaacenc",   // gst-plugins-bad + libfdk-aac: best quality
+                "voaacenc",    // gst-plugins-bad + vo-aacenc
+                "avenc_aac",   // gst-libav: broadly installed
+                "faac",        // gst-plugins-bad + libfaac
+            };
+            for (const char* cand : kAacEncoders) {
+                if (elementAvailable(cand)) { aacEnc = cand; break; }
+            }
+            if (!aacEnc) {
+                logWarning("VideoWriter")
+                    << "no GStreamer AAC encoder found (install gst-libav or "
+                       "gst-plugins-bad) - recording video only";
+            }
+        } else {
+            logWarning("VideoWriter")
+                << "audio requested but sample rate / channel count are unset "
+                   "- recording video only";
+        }
     }
 
     // Auto-select the most efficient encoder that actually works here: the
@@ -291,6 +319,15 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
     desc += opt->segment;
     if (haveParse) { desc += " ! "; desc += plan.parse; }
     desc += " ! mp4mux name=mux ! filesink name=sink";
+    // Audio branch: a second appsrc feeding interleaved float samples through
+    // audioconvert into the AAC encoder, muxed into the same mp4.
+    if (aacEnc) {
+        desc += " appsrc name=asrc ! queue ! audioconvert ! ";
+        desc += aacEnc;
+        desc += " name=aenc";
+        if (elementAvailable("aacparse")) desc += " ! aacparse";
+        desc += " ! mux.";
+    }
 
     GError* err = nullptr;
     GstElement* pipeline = gst_parse_launch(desc.c_str(), &err);
@@ -349,11 +386,47 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
                  "block",        TRUE,
                  nullptr);
 
+    // Audio appsrc: interleaved float32 at the engine's rate/channels;
+    // audioconvert adapts to whatever the AAC encoder negotiates.
+    GstElement* audiosrc = nullptr;
+    if (aacEnc) {
+        audiosrc = gst_bin_get_by_name(GST_BIN(pipeline), "asrc");
+        if (audiosrc) {
+            GstCaps* acaps = gst_caps_new_simple(
+                "audio/x-raw",
+                "format",   G_TYPE_STRING, "F32LE",
+                "layout",   G_TYPE_STRING, "interleaved",
+                "rate",     G_TYPE_INT, settings.audioSampleRate,
+                "channels", G_TYPE_INT, settings.audioChannels,
+                nullptr);
+            gst_app_src_set_caps(GST_APP_SRC(audiosrc), acaps);
+            gst_caps_unref(acaps);
+            g_object_set(audiosrc,
+                         "format",       GST_FORMAT_TIME,
+                         "is-live",      FALSE,
+                         "do-timestamp", FALSE,
+                         "block",        TRUE,
+                         nullptr);
+        }
+        // AAC bitrate (bits/sec on all candidate encoders), best-effort.
+        GstElement* aenc = gst_bin_get_by_name(GST_BIN(pipeline), "aenc");
+        if (aenc) {
+            if (settings.audioBitrate > 0 &&
+                g_object_class_find_property(G_OBJECT_GET_CLASS(aenc),
+                                             "bitrate")) {
+                g_object_set(aenc, "bitrate", (gint)settings.audioBitrate,
+                             nullptr);
+            }
+            gst_object_unref(aenc);
+        }
+    }
+
     if (gst_element_set_state(pipeline, GST_STATE_PLAYING) ==
         GST_STATE_CHANGE_FAILURE) {
         logError("VideoWriter")
             << "could not start pipeline (encoder: " << opt->encName << ")";
         gst_object_unref(appsrc);
+        if (audiosrc) gst_object_unref(audiosrc);
         gst_object_unref(sink);
         gst_object_unref(pipeline);
         return false;
@@ -363,22 +436,57 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
     auto* pd = new VideoWriterPlatformData();
     pd->pipeline = pipeline;
     pd->appsrc   = appsrc;  // keep our ref; released in closePlatform()
+    pd->audiosrc = audiosrc;
     pd->width    = w;
     pd->height   = h;
     pd->fps      = (fps > 0) ? fps : 30.0;
+    if (audiosrc) {
+        pd->hasAudio      = true;
+        pd->audioRate     = settings.audioSampleRate;
+        pd->audioChannels = settings.audioChannels;
+    }
     platform_ = pd;
 
     logNotice("VideoWriter")
         << "GStreamer " << plan.label << " encoder: " << opt->encName
-        << (opt->hardware ? " (hardware)" : " (software)");
+        << (opt->hardware ? " (hardware)" : " (software)")
+        << (pd->hasAudio ? std::string(" + AAC audio (") + aacEnc + ")"
+                         : std::string());
     return true;
 }
 
 // ---------------------------------------------------------------------------
-// appendPlatform - push one RGBA8 (top-down) frame into the pipeline
+// appendAudioPlatform - push interleaved float samples into the audio branch
 // ---------------------------------------------------------------------------
-// Audio track is macOS-only for now; the header degrades to video-only.
-bool VideoWriter::appendAudioPlatform(const float*, int, double) { return false; }
+bool VideoWriter::appendAudioPlatform(const float* interleaved, int frames,
+                                      double timeSec) {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd || !pd->audiosrc || !pd->hasAudio || pd->failed) return false;
+    if (!interleaved || frames <= 0) return false;
+
+    const gsize size = (gsize)frames * pd->audioChannels * sizeof(float);
+    GstBuffer* buf = gst_buffer_new_allocate(nullptr, size, nullptr);
+    if (!buf) {
+        logError("VideoWriter") << "could not allocate audio buffer";
+        pd->failed = true;
+        return false;
+    }
+    gst_buffer_fill(buf, 0, interleaved, size);
+
+    GST_BUFFER_PTS(buf) = (GstClockTime)(timeSec * GST_SECOND);
+    GST_BUFFER_DURATION(buf) =
+        (GstClockTime)((double)frames / pd->audioRate * GST_SECOND);
+
+    GstFlowReturn ret =
+        gst_app_src_push_buffer(GST_APP_SRC(pd->audiosrc), buf);  // takes ownership
+    if (ret != GST_FLOW_OK) {
+        logError("VideoWriter")
+            << "audio appsrc rejected buffer: " << gst_flow_get_name(ret);
+        pd->failed = true;
+        return false;
+    }
+    return true;
+}
 
 bool VideoWriter::appendPlatform(const unsigned char* rgba, double timeSec) {
     VideoWriterPlatformData* pd = platform_;
@@ -420,8 +528,12 @@ void VideoWriter::closePlatform() {
     if (!pd) return;
 
     if (pd->pipeline && pd->appsrc && !pd->failed) {
-        // Signal EOS so mp4mux writes its moov atom, then wait for the EOS (or
-        // ERROR) to travel the pipeline - otherwise the file is left truncated.
+        // Signal EOS on every source so mp4mux writes its moov atom (the muxer
+        // waits for EOS on ALL its pads), then wait for the EOS (or ERROR) to
+        // travel the pipeline - otherwise the file is left truncated.
+        if (pd->audiosrc) {
+            gst_app_src_end_of_stream(GST_APP_SRC(pd->audiosrc));
+        }
         if (gst_app_src_end_of_stream(GST_APP_SRC(pd->appsrc)) == GST_FLOW_OK) {
             GstBus* bus = gst_element_get_bus(pd->pipeline);
             if (bus) {
@@ -452,6 +564,7 @@ void VideoWriter::closePlatform() {
         gst_element_set_state(pd->pipeline, GST_STATE_NULL);
     }
     if (pd->appsrc)   gst_object_unref(pd->appsrc);
+    if (pd->audiosrc) gst_object_unref(pd->audiosrc);
     if (pd->pipeline) gst_object_unref(pd->pipeline);
 
     delete pd;

--- a/core/platform/linux/tcVideoRecorder_linux.cpp
+++ b/core/platform/linux/tcVideoRecorder_linux.cpp
@@ -318,7 +318,13 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
     std::string desc = "appsrc name=src ! queue ! videoconvert ! ";
     desc += opt->segment;
     if (haveParse) { desc += " ! "; desc += plan.parse; }
-    desc += " ! mp4mux name=mux ! filesink name=sink";
+    // The queue between encoder and muxer is load-bearing when audio is muxed:
+    // mp4mux blocks video consumption for its interleave window (~250ms) while
+    // waiting for audio, audio only arrives from the main thread, and the main
+    // thread is blocked pushing video into an appsrc that holds barely one raw
+    // frame -> permanent deadlock. A post-encode queue absorbs the window in
+    // the cheap compressed domain and breaks the cycle.
+    desc += " ! queue ! mp4mux name=mux ! filesink name=sink";
     // Audio branch: a second appsrc feeding interleaved float samples through
     // audioconvert into the AAC encoder, muxed into the same mp4.
     if (aacEnc) {

--- a/core/platform/win/tcVideoRecorder_win.cpp
+++ b/core/platform/win/tcVideoRecorder_win.cpp
@@ -54,7 +54,9 @@
 #include "TrussC.h"
 
 #include <cmath>
+#include <cstring>
 #include <string>
+#include <vector>
 
 #pragma comment(lib, "mf.lib")
 #pragma comment(lib, "mfplat.lib")
@@ -76,6 +78,15 @@ struct VideoWriterPlatformData {
     bool  mfStarted = false;   // this instance called MFStartup
     bool  usedHardware = false;
     bool  failed = false;
+
+    // Audio track (AAC). hasAudio stays false when settings.audio is off, the
+    // engine format is outside the MF AAC encoder's input constraints, or the
+    // audio stream could not be negotiated (video-only degradation).
+    bool  hasAudio = false;
+    DWORD audioStream = 0;
+    int   audioRate = 0;
+    int   audioChannels = 0;
+    std::vector<short> s16;    // float -> PCM16 conversion scratch
 };
 }  // namespace internal
 using internal::VideoWriterPlatformData;
@@ -96,13 +107,66 @@ void fpsToRatio(double fps, UINT32& num, UINT32& den) {
     }
 }
 
+// Audio track parameters, validated by openPlatform(). rate/channels must be
+// within the MF AAC encoder's input constraints (PCM16, 44.1/48 kHz, 1-2 ch);
+// bytesPerSec one of the encoder's discrete CBR steps (12000/16000/20000/24000).
+struct AudioParams {
+    bool wanted = false;
+    int  rate = 0;
+    int  channels = 0;
+    UINT32 bytesPerSec = 24000;
+};
+
+// Add the AAC output + PCM16 input audio streams to the sink writer. Called
+// before BeginWriting(); a failure fails the whole open (streams cannot be
+// removed from a sink writer), and the caller retries without audio.
+HRESULT configureAudioStream(IMFSinkWriter* writer, const AudioParams& ap,
+                             DWORD& audioStreamIndex) {
+    // --- Output media type: AAC-LC ---
+    IMFMediaType* outType = nullptr;
+    HRESULT hr = MFCreateMediaType(&outType);
+    if (SUCCEEDED(hr)) hr = outType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
+    if (SUCCEEDED(hr)) hr = outType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_AAC);
+    if (SUCCEEDED(hr)) hr = outType->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND,
+                                               (UINT32)ap.rate);
+    if (SUCCEEDED(hr)) hr = outType->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS,
+                                               (UINT32)ap.channels);
+    if (SUCCEEDED(hr)) hr = outType->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, 16);
+    if (SUCCEEDED(hr)) hr = outType->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND,
+                                               ap.bytesPerSec);
+    if (SUCCEEDED(hr)) hr = writer->AddStream(outType, &audioStreamIndex);
+    if (outType) outType->Release();
+    if (FAILED(hr)) return hr;
+
+    // --- Input media type: interleaved PCM16 ---
+    const UINT32 blockAlign = (UINT32)ap.channels * 2;
+    IMFMediaType* inType = nullptr;
+    hr = MFCreateMediaType(&inType);
+    if (SUCCEEDED(hr)) hr = inType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
+    if (SUCCEEDED(hr)) hr = inType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM);
+    if (SUCCEEDED(hr)) hr = inType->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND,
+                                              (UINT32)ap.rate);
+    if (SUCCEEDED(hr)) hr = inType->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS,
+                                              (UINT32)ap.channels);
+    if (SUCCEEDED(hr)) hr = inType->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, 16);
+    if (SUCCEEDED(hr)) hr = inType->SetUINT32(MF_MT_AUDIO_BLOCK_ALIGNMENT, blockAlign);
+    if (SUCCEEDED(hr)) hr = inType->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND,
+                                              (UINT32)ap.rate * blockAlign);
+    if (SUCCEEDED(hr)) hr = inType->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, 1);
+    if (SUCCEEDED(hr)) hr = writer->SetInputMediaType(audioStreamIndex, inType,
+                                                      nullptr);
+    if (inType) inType->Release();
+    return hr;
+}
+
 // Add the compressed output + RGB32 input streams and begin writing. Returns
 // the stream index. Failure here (notably for a hardware encoder that can't
 // negotiate on this machine) is what drives the software fallback in open().
 HRESULT configureWriter(IMFSinkWriter* writer, int w, int h,
                         UINT32 fpsNum, UINT32 fpsDen, int br,
                         VideoCodec codec, int keyframeInterval,
-                        DWORD& streamIndex) {
+                        DWORD& streamIndex,
+                        const AudioParams& audio, DWORD& audioStreamIndex) {
     // --- Output media type: H.264 or HEVC (both mux into .mp4) ---
     const GUID subtype = (codec == VideoCodec::HEVC) ? MFVideoFormat_HEVC
                                                      : MFVideoFormat_H264;
@@ -144,6 +208,12 @@ HRESULT configureWriter(IMFSinkWriter* writer, int w, int h,
     if (inType) inType->Release();
     if (FAILED(hr)) return hr;
 
+    // Audio track, if requested (must be added before BeginWriting).
+    if (audio.wanted) {
+        hr = configureAudioStream(writer, audio, audioStreamIndex);
+        if (FAILED(hr)) return hr;
+    }
+
     // Activates and negotiates the encoder MFT synchronously: a hardware
     // encoder that exists but can't run here fails at this point.
     return writer->BeginWriting();
@@ -178,10 +248,12 @@ bool streamUsesHardwareEncoder(IMFSinkWriter* writer, DWORD streamIndex) {
 HRESULT openWriter(const std::wstring& wpath, int w, int h,
                    UINT32 fpsNum, UINT32 fpsDen, int br,
                    VideoCodec codec, int keyframeInterval, bool hwEnabled,
+                   const AudioParams& audio,
                    IMFSinkWriter** outWriter, DWORD* outStream,
-                   bool* outHardware) {
+                   DWORD* outAudioStream, bool* outHardware) {
     *outWriter = nullptr;
     *outStream = 0;
+    *outAudioStream = 0;
     *outHardware = false;
 
     // SinkWriter creation flags: allow/forbid hardware MFTs, and don't throttle
@@ -203,16 +275,19 @@ HRESULT openWriter(const std::wstring& wpath, int w, int h,
     }
 
     DWORD streamIndex = 0;
+    DWORD audioStreamIndex = 0;
     hr = configureWriter(writer, w, h, fpsNum, fpsDen, br,
-                         codec, keyframeInterval, streamIndex);
+                         codec, keyframeInterval, streamIndex,
+                         audio, audioStreamIndex);
     if (FAILED(hr)) {
         writer->Release();
         return hr;
     }
 
-    *outWriter   = writer;
-    *outStream   = streamIndex;
-    *outHardware = streamUsesHardwareEncoder(writer, streamIndex);
+    *outWriter      = writer;
+    *outStream      = streamIndex;
+    *outAudioStream = audioStreamIndex;
+    *outHardware    = streamUsesHardwareEncoder(writer, streamIndex);
     return S_OK;
 }
 
@@ -223,10 +298,31 @@ HRESULT openWriter(const std::wstring& wpath, int w, int h,
 // ---------------------------------------------------------------------------
 bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
                                float fps, const VideoRecordSettings& settings) {
+    // Audio track: the MF AAC encoder only accepts PCM16 at 44.1/48 kHz, 1-2
+    // channels. Outside those constraints we warn and record video-only
+    // (mirrors the mac backend's degradation behavior).
+    AudioParams audio;
     if (settings.audio) {
-        logWarning("VideoWriter")
-            << "audio recording is not supported on this platform yet - "
-               "recording video only";
+        const int aRate = settings.audioSampleRate;
+        const int aCh   = settings.audioChannels;
+        if ((aRate == 44100 || aRate == 48000) && aCh >= 1 && aCh <= 2) {
+            audio.wanted   = true;
+            audio.rate     = aRate;
+            audio.channels = aCh;
+            // The encoder supports discrete CBR steps only:
+            // 12000/16000/20000/24000 bytes/sec (96/128/160/192 kbit).
+            const UINT32 steps[] = {12000, 16000, 20000, 24000};
+            const int want = settings.audioBitrate / 8;
+            audio.bytesPerSec = steps[0];
+            for (UINT32 s : steps) {
+                if ((int)s <= want) audio.bytesPerSec = s;
+            }
+        } else {
+            logWarning("VideoWriter")
+                << "audio format " << aRate << " Hz / " << aCh
+                << " ch not supported by the AAC encoder "
+                   "(needs 44100/48000 Hz, 1-2 ch) - recording video only";
+        }
     }
     // This backend encodes H.264 and HEVC (both into .mp4). ProRes is a macOS-
     // only mastering codec; reject it clearly rather than silently substituting.
@@ -270,6 +366,7 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
 
     IMFSinkWriter* writer = nullptr;
     DWORD streamIndex = 0;
+    DWORD audioStreamIndex = 0;
     bool  isHw = false;
 
     const VideoCodec codec = settings.codec;
@@ -279,10 +376,11 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
     // file each attempt (the writer otherwise locks/appends).
     DeleteFileW(wpath.c_str());
     hr = openWriter(wpath, w, h, fpsNum, fpsDen, br, codec, kf,
-                    /*hwEnabled*/ true, &writer, &streamIndex, &isHw);
+                    /*hwEnabled*/ true, audio,
+                    &writer, &streamIndex, &audioStreamIndex, &isHw);
 
-    // Software fallback: only the hardware path can fail here, so a failed open
-    // means "hardware encoder unusable on this machine" -> retry pure software.
+    // Software fallback: a failed open normally means "hardware encoder
+    // unusable on this machine" -> retry pure software.
     if (FAILED(hr) || !writer) {
         logWarning("VideoWriter")
             << "hardware " << videoCodecName(codec)
@@ -290,7 +388,28 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
             << std::hex << (unsigned)hr << "); falling back to software";
         DeleteFileW(wpath.c_str());
         hr = openWriter(wpath, w, h, fpsNum, fpsDen, br, codec, kf,
-                        /*hwEnabled*/ false, &writer, &streamIndex, &isHw);
+                        /*hwEnabled*/ false, audio,
+                        &writer, &streamIndex, &audioStreamIndex, &isHw);
+    }
+
+    // Last resort with audio requested: the AAC stream itself may be what
+    // failed (sink writer streams can't be removed, so a failed audio setup
+    // fails the whole open). Degrade to video-only rather than not recording.
+    if ((FAILED(hr) || !writer) && audio.wanted) {
+        logWarning("VideoWriter")
+            << "could not set up the AAC audio track (hr=0x"
+            << std::hex << (unsigned)hr << ") - recording video only";
+        audio.wanted = false;
+        DeleteFileW(wpath.c_str());
+        hr = openWriter(wpath, w, h, fpsNum, fpsDen, br, codec, kf,
+                        /*hwEnabled*/ true, audio,
+                        &writer, &streamIndex, &audioStreamIndex, &isHw);
+        if (FAILED(hr) || !writer) {
+            DeleteFileW(wpath.c_str());
+            hr = openWriter(wpath, w, h, fpsNum, fpsDen, br, codec, kf,
+                            /*hwEnabled*/ false, audio,
+                            &writer, &streamIndex, &audioStreamIndex, &isHw);
+        }
     }
 
     if (FAILED(hr) || !writer) {
@@ -305,19 +424,89 @@ bool VideoWriter::openPlatform(const std::string& fullPath, int w, int h,
     pd->writer       = writer;
     pd->streamIndex  = streamIndex;
     pd->usedHardware = isHw;
+    if (audio.wanted) {
+        pd->hasAudio      = true;
+        pd->audioStream   = audioStreamIndex;
+        pd->audioRate     = audio.rate;
+        pd->audioChannels = audio.channels;
+    }
     platform_ = pd;
 
     logNotice("VideoWriter")
         << "Media Foundation " << videoCodecName(codec) << " encoder: "
-        << (isHw ? "hardware" : "software");
+        << (isHw ? "hardware" : "software")
+        << (pd->hasAudio ? " + AAC audio" : "");
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// appendAudioPlatform - append interleaved float samples to the AAC track
+// ---------------------------------------------------------------------------
+// Called on the recorder's writer thread, interleaved with video WriteSample
+// calls on the same thread; the sink writer handles the muxing (throttling is
+// disabled at creation, so neither stream ever blocks waiting for the other).
+bool VideoWriter::appendAudioPlatform(const float* interleaved, int frames,
+                                      double timeSec) {
+    VideoWriterPlatformData* pd = platform_;
+    if (!pd || !pd->writer || pd->failed || !pd->hasAudio) return false;
+    if (!interleaved || frames <= 0) return false;
+
+    // float [-1,1] -> interleaved PCM16, clamped.
+    const int samples = frames * pd->audioChannels;
+    pd->s16.resize((size_t)samples);
+    for (int i = 0; i < samples; ++i) {
+        float v = interleaved[i];
+        if (v > 1.0f) v = 1.0f;
+        else if (v < -1.0f) v = -1.0f;
+        pd->s16[(size_t)i] = (short)(v * 32767.0f);
+    }
+
+    const DWORD byteCount = (DWORD)samples * sizeof(short);
+    IMFMediaBuffer* buffer = nullptr;
+    HRESULT hr = MFCreateMemoryBuffer(byteCount, &buffer);
+    if (FAILED(hr) || !buffer) {
+        logError("VideoWriter") << "MFCreateMemoryBuffer (audio) failed";
+        pd->failed = true;
+        return false;
+    }
+
+    BYTE* dst = nullptr;
+    hr = buffer->Lock(&dst, nullptr, nullptr);
+    if (FAILED(hr)) {
+        buffer->Release();
+        pd->failed = true;
+        return false;
+    }
+    memcpy(dst, pd->s16.data(), byteCount);
+    buffer->Unlock();
+    buffer->SetCurrentLength(byteCount);
+
+    IMFSample* sample = nullptr;
+    hr = MFCreateSample(&sample);
+    if (SUCCEEDED(hr)) hr = sample->AddBuffer(buffer);
+    if (SUCCEEDED(hr)) {
+        // MF time units are 100-nanosecond ticks (1e7 per second).
+        sample->SetSampleTime((LONGLONG)(timeSec * 1.0e7 + 0.5));
+        sample->SetSampleDuration(
+            (LONGLONG)((double)frames / pd->audioRate * 1.0e7 + 0.5));
+        hr = pd->writer->WriteSample(pd->audioStream, sample);
+    }
+
+    if (sample) sample->Release();
+    buffer->Release();
+
+    if (FAILED(hr)) {
+        logError("VideoWriter") << "WriteSample (audio) failed (hr=0x"
+                                  << std::hex << (unsigned)hr << ")";
+        pd->failed = true;
+        return false;
+    }
     return true;
 }
 
 // ---------------------------------------------------------------------------
 // appendPlatform - encode one RGBA8 (top-down) frame
 // ---------------------------------------------------------------------------
-// Audio track is macOS-only for now; the header degrades to video-only.
-bool VideoWriter::appendAudioPlatform(const float*, int, double) { return false; }
 
 bool VideoWriter::appendPlatform(const unsigned char* rgba, double timeSec) {
     VideoWriterPlatformData* pd = platform_;

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1154,7 +1154,7 @@ Pass the length in seconds: `startRecording("out.mp4", 3.0f)` records exactly 3 
 
 ### Can the screen recording include the app's audio? (VideoRecordSettings.audio)
 
-Yes — set `audio = true` and the recording gains an AAC track of the engine's master mix (macOS for now; Windows/Linux warn and record video-only):
+Yes — set `audio = true` and the recording gains an AAC track of the engine's master mix (macOS and Windows; Linux warns and records video-only):
 
 ```cpp
 VideoRecordSettings s;

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -1154,7 +1154,7 @@ Pass the length in seconds: `startRecording("out.mp4", 3.0f)` records exactly 3 
 
 ### Can the screen recording include the app's audio? (VideoRecordSettings.audio)
 
-Yes — set `audio = true` and the recording gains an AAC track of the engine's master mix (macOS and Windows; Linux warns and records video-only):
+Yes — set `audio = true` and the recording gains an AAC track of the engine's master mix (macOS / Windows / Linux; Linux needs a GStreamer AAC encoder — gst-libav or gst-plugins-bad — and warns + records video-only without one):
 
 ```cpp
 VideoRecordSettings s;

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10793,9 +10793,9 @@ related = ["startRecording", "VideoCodec", "ScreenRecorder"]
 ["VideoRecordSettings::audio"]
 category = "video"
 keywords = ["sound", "aac", "track", "master mix", "record audio"]
-description.en = "Record the AudioEngine's master mix into the file as an AAC track (macOS and Windows; other platforms warn and record video only). ScreenRecorder also switches the video PTS to the audio device clock, so A/V stay in sync however unstable the frame rate is"
-description.ja = "AudioEngineのマスターミックスをAACトラックとしてファイルに録音する（macOSとWindows。他プラットフォームは警告して映像のみ）。ScreenRecorder は映像PTSもオーディオデバイスクロックに切り替えるため、フレームレートが不安定でもA/Vがズレない"
-description.ko = "AudioEngine의 마스터 믹스를 AAC 트랙으로 파일에 녹음(macOS와 Windows, 다른 플랫폼은 경고 후 영상만 녹화). ScreenRecorder는 영상 PTS도 오디오 디바이스 클럭으로 전환하므로 프레임레이트가 불안정해도 A/V가 어긋나지 않음"
+description.en = "Record the AudioEngine's master mix into the file as an AAC track (macOS/Windows/Linux; other platforms warn and record video only; Linux needs a GStreamer AAC encoder such as gst-libav or gst-plugins-bad). ScreenRecorder also switches the video PTS to the audio device clock, so A/V stay in sync however unstable the frame rate is"
+description.ja = "AudioEngineのマスターミックスをAACトラックとしてファイルに録音する（macOS/Windows/Linux。他プラットフォームは警告して映像のみ。LinuxはGStreamerのAACエンコーダ（gst-libavかgst-plugins-bad）が必要）。ScreenRecorder は映像PTSもオーディオデバイスクロックに切り替えるため、フレームレートが不安定でもA/Vがズレない"
+description.ko = "AudioEngine의 마스터 믹스를 AAC 트랙으로 파일에 녹음(macOS/Windows/Linux, 다른 플랫폼은 경고 후 영상만 녹화, Linux는 GStreamer AAC 인코더(gst-libav 또는 gst-plugins-bad) 필요). ScreenRecorder는 영상 PTS도 오디오 디바이스 클럭으로 전환하므로 프레임레이트가 불안정해도 A/V가 어긋나지 않음"
 related = ["AudioRecorder", "AudioEngine"]
 
 ["VideoRecordSettings::audioBitrate"]

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -10793,9 +10793,9 @@ related = ["startRecording", "VideoCodec", "ScreenRecorder"]
 ["VideoRecordSettings::audio"]
 category = "video"
 keywords = ["sound", "aac", "track", "master mix", "record audio"]
-description.en = "Record the AudioEngine's master mix into the file as an AAC track (macOS only for now; other platforms warn and record video only). ScreenRecorder also switches the video PTS to the audio device clock, so A/V stay in sync however unstable the frame rate is"
-description.ja = "AudioEngineのマスターミックスをAACトラックとしてファイルに録音する（現状macOSのみ。他プラットフォームは警告して映像のみ）。ScreenRecorder は映像PTSもオーディオデバイスクロックに切り替えるため、フレームレートが不安定でもA/Vがズレない"
-description.ko = "AudioEngine의 마스터 믹스를 AAC 트랙으로 파일에 녹음(현재 macOS 전용, 다른 플랫폼은 경고 후 영상만 녹화). ScreenRecorder는 영상 PTS도 오디오 디바이스 클럭으로 전환하므로 프레임레이트가 불안정해도 A/V가 어긋나지 않음"
+description.en = "Record the AudioEngine's master mix into the file as an AAC track (macOS and Windows; other platforms warn and record video only). ScreenRecorder also switches the video PTS to the audio device clock, so A/V stay in sync however unstable the frame rate is"
+description.ja = "AudioEngineのマスターミックスをAACトラックとしてファイルに録音する（macOSとWindows。他プラットフォームは警告して映像のみ）。ScreenRecorder は映像PTSもオーディオデバイスクロックに切り替えるため、フレームレートが不安定でもA/Vがズレない"
+description.ko = "AudioEngine의 마스터 믹스를 AAC 트랙으로 파일에 녹음(macOS와 Windows, 다른 플랫폼은 경고 후 영상만 녹화). ScreenRecorder는 영상 PTS도 오디오 디바이스 클럭으로 전환하므로 프레임레이트가 불안정해도 A/V가 어긋나지 않음"
 related = ["AudioRecorder", "AudioEngine"]
 
 ["VideoRecordSettings::audioBitrate"]


### PR DESCRIPTION
Extends `VideoRecordSettings.audio` (added in #181, macOS-only) to Windows and Linux. All three desktop platforms now record the AudioEngine's master mix as an AAC track with audio-clock-driven video PTS.

## Windows (Media Foundation)
- Adds an AAC-LC audio stream to the existing `IMFSinkWriter` (PCM16 input; 44.1/48 kHz, 1–2 ch; bitrate clamped to the encoder's discrete CBR steps 96–192 kbit).
- Out-of-constraint formats or a failed stream negotiation degrade to video-only with a warning (4-step retry: hw+audio → sw+audio → hw → sw).
- Verified on Windows 11 hardware: HW H.264 + AAC path, A/V sync within 3–13 ms (±1 frame) across all 5 beep/bounce events, clean finalize.

## Linux (GStreamer)
- Adds an audio branch `appsrc (F32LE interleaved) → audioconvert → AAC encoder → mp4mux`; encoder is the first available of `fdkaacenc / voaacenc / avenc_aac / faac`, warning + video-only without one. EOS is signalled on both sources so mp4mux finalizes.
- Includes a load-bearing `queue` between video encoder and muxer: mp4mux's ~250 ms interleave window + an appsrc holding less than one raw frame + audio being fed from the (blocked) main thread otherwise deadlocks the app. Found and verified on Linux hardware (nvh264enc + voaacenc).
- Verified on Linux: clean 5 s recording, H.264 + AAC 48 kHz stereo, no EOS timeout. Known constant A/V offset of ~-19 ms (encoder priming, no drift) — noted as acceptable.

## Misc
- `AudioRecorder::start()` now creates the output's parent directory, matching `VideoWriter` (flagged during Windows verification).
- Docs (`api-reference.toml`, `FOR_AI_ASSISTANT.md`, header comments) updated to "macOS / Windows / Linux".
