### PR TITLE
add: drawSuperellipse / appendSuperellipse (superellipse primitives)

### DIFF
--- a/addons/tcxLua/src/generated/trussc_generated.cpp
+++ b/addons/tcxLua/src/generated/trussc_generated.cpp
@@ -470,6 +470,12 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua) 
         [](trussc::Vec3 pos, trussc::Vec2 size, float radius) { return trussc::drawRectSquircle(pos, size, radius); },
         [](float x, float y, float w, float h, float radius) { return trussc::drawRectSquircle(x, y, w, h, radius); }
     ));
+    lua->set_function("drawSuperellipse", sol::overload(
+        [](trussc::Vec3 pos, trussc::Vec2 size) { return trussc::drawSuperellipse(pos, size); },
+        [](trussc::Vec3 pos, trussc::Vec2 size, float n) { return trussc::drawSuperellipse(pos, size, n); },
+        [](float x, float y, float w, float h) { return trussc::drawSuperellipse(x, y, w, h); },
+        [](float x, float y, float w, float h, float n) { return trussc::drawSuperellipse(x, y, w, h, n); }
+    ));
     lua->set_function("drawCircle", sol::overload(
         [](trussc::Vec3 center, float radius) { return trussc::drawCircle(center, radius); },
         [](float cx, float cy, float radius) { return trussc::drawCircle(cx, cy, radius); }
@@ -619,6 +625,12 @@ void tcxLua::setTrussCGeneratedBindings(const std::shared_ptr<sol::state>& lua) 
     lua->set_function("appendArc", sol::overload(
         [](float cx, float cy, float radius, float angleBegin, float angleEnd) { return trussc::appendArc(cx, cy, radius, angleBegin, angleEnd); },
         [](const trussc::Vec2 & center, float radius, float angleBegin, float angleEnd) { return trussc::appendArc(center, radius, angleBegin, angleEnd); }
+    ));
+    lua->set_function("appendSuperellipse", sol::overload(
+        [](float x, float y, float w, float h) { return trussc::appendSuperellipse(x, y, w, h); },
+        [](float x, float y, float w, float h, float n) { return trussc::appendSuperellipse(x, y, w, h, n); },
+        [](const trussc::Vec2 & pos, const trussc::Vec2 & size) { return trussc::appendSuperellipse(pos, size); },
+        [](const trussc::Vec2 & pos, const trussc::Vec2 & size, float n) { return trussc::appendSuperellipse(pos, size, n); }
     ));
     lua->set_function("appendCurve", sol::overload(
         [](const std::vector<Vec3> & points) { return trussc::appendCurve(points); },

--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -901,6 +901,17 @@ inline void drawRectSquircle(float x, float y, float w, float h, float radius) {
     getDefaultContext().drawRectSquircle(x, y, w, h, radius);
 }
 
+// Superellipse inscribed in the rect (pos, size) — drop-in alternative to
+// drawRectRounded. n morphs the shape (2=ellipse, 4=squircle, higher->rect);
+// default n=5 approximates the Apple app-icon silhouette.
+inline void drawSuperellipse(Vec3 pos, Vec2 size, float n = 5.0f) {
+    getDefaultContext().drawSuperellipse(pos, size, n);
+}
+
+inline void drawSuperellipse(float x, float y, float w, float h, float n = 5.0f) {
+    getDefaultContext().drawSuperellipse(x, y, w, h, n);
+}
+
 // Circle
 inline void drawCircle(Vec3 center, float radius) {
     getDefaultContext().drawCircle(center, radius);

--- a/core/include/tc/graphics/tcRenderContext.cpp
+++ b/core/include/tc/graphics/tcRenderContext.cpp
@@ -167,6 +167,65 @@ void internal::RenderContext::drawRectSquircle(Vec3 pos, Vec2 size, float radius
 }
 
 // ---------------------------------------------------------------------------
+// Superellipse (Lamé curve): |x/rx|^n + |y/ry|^n = 1, inscribed in (pos, size).
+// Parametric form: (rx * sign(cos t) * |cos t|^(2/n),
+//                   ry * sign(sin t) * |sin t|^(2/n))
+// n=2 is an ellipse, n=4 a squircle, n->inf approaches the bounding rect,
+// n=1 a diamond, n<1 concave (astroid-like). The shape is star-convex from
+// its center for any n>0, so the center-fan fill below is always valid —
+// including concave n<1 shapes that a first-vertex fan (endShape) would
+// render incorrectly.
+// ---------------------------------------------------------------------------
+void internal::RenderContext::drawSuperellipse(Vec3 pos, Vec2 size, float n) {
+    if (n <= 0) return;
+
+    float x = pos.x, y = pos.y, cz = pos.z;
+    float w = size.x, h = size.y;
+
+    // Normalize negative dimensions; see drawRectRounded for rationale.
+    if (w < 0) { x += w; w = -w; }
+    if (h < 0) { y += h; h = -h; }
+
+    float rx = w * 0.5f, ry = h * 0.5f;
+    float cx = x + rx, cy = y + ry;
+
+    // Same conservative heuristic as drawEllipse: segment count from the
+    // larger radius. Uniform-angle sampling naturally lands vertices on the
+    // corner diagonals, which is where large-n curvature concentrates.
+    int segments = decideCircleSegments(std::max(rx, ry));
+    if (segments == 0) return;
+
+    float expo = 2.0f / n;
+    auto point = [&](float angle) -> Vec2 {
+        float c = std::cos(angle), s = std::sin(angle);
+        return Vec2(cx + std::copysign(std::pow(std::abs(c), expo), c) * rx,
+                    cy + std::copysign(std::pow(std::abs(s), expo), s) * ry);
+    };
+
+    auto& writer = internal::getActiveWriter();
+
+    if (fillEnabled_) {
+        writer.begin(PrimitiveType::TriangleStrip);
+        writer.color(currentR_, currentG_, currentB_, currentA_);
+        for (int i = 0; i <= segments; i++) {
+            Vec2 p = point((float)i / segments * TAU);
+            writer.vertex(cx, cy, cz);
+            writer.vertex(p.x, p.y, cz);
+        }
+        writer.end();
+    }
+    if (strokeEnabled_) {
+        writer.begin(PrimitiveType::LineStrip);
+        writer.color(currentR_, currentG_, currentB_, currentA_);
+        for (int i = 0; i <= segments; i++) {
+            Vec2 p = point((float)i / segments * TAU);
+            writer.vertex(p.x, p.y, cz);
+        }
+        writer.end();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Bitmap string billboard (project a world position through the current camera
 // context and draw the glyphs screen-aligned on top of the scene).
 //

--- a/core/include/tc/graphics/tcRenderContext.h
+++ b/core/include/tc/graphics/tcRenderContext.h
@@ -454,6 +454,20 @@ public:
         drawRectSquircle(Vec3(x, y, 0), Vec2(w, h), radius);
     }
 
+    // -------------------------------------------------------------------------
+    // Superellipse (Lamé curve): |x/rx|^n + |y/ry|^n = 1, inscribed in the
+    // rect (pos, size) — drop-in alternative to drawRectRounded. The exponent
+    // n morphs the shape: 2 = ellipse, 4 = squircle, higher -> closer to the
+    // rect, 1 = diamond, <1 = concave (star-like). Default n=5 approximates
+    // the Apple app-icon silhouette. Aspect ratio comes from size.
+    // (Implementation in tcRenderContext.cpp)
+    // -------------------------------------------------------------------------
+    void drawSuperellipse(Vec3 pos, Vec2 size, float n = 5.0f);
+
+    void drawSuperellipse(float x, float y, float w, float h, float n = 5.0f) {
+        drawSuperellipse(Vec3(x, y, 0), Vec2(w, h), n);
+    }
+
     // Main implementation (Vec3)
     void drawCircle(Vec3 center, float radius) {
         int segments = decideCircleSegments(radius);

--- a/core/include/tc/graphics/tcShape.h
+++ b/core/include/tc/graphics/tcShape.h
@@ -213,6 +213,36 @@ inline void appendArc(const Vec2& center, float radius,
     appendArc(center.x, center.y, radius, angleBegin, angleEnd);
 }
 
+// Append the full closed outline of a superellipse (Lamé curve) inscribed in
+// the rect (x, y, w, h) — same bounding-box convention as drawSuperellipse.
+// Emits the start point twice (loop closure); the duplicate is benign.
+// Note: endShape() fills with a first-vertex fan, which is only correct for
+// convex outlines — fine for n >= 1; for concave n < 1 shapes use
+// drawSuperellipse (center fan) or fill via Path.
+inline void appendSuperellipse(float x, float y, float w, float h,
+                               float n = 5.0f) {
+    if (n <= 0.0f) return;
+    if (w < 0) { x += w; w = -w; }
+    if (h < 0) { y += h; h = -h; }
+    float rx = w * 0.5f, ry = h * 0.5f;
+    float cx = x + rx, cy = y + ry;
+    auto& ctx = getDefaultContext();
+    int segs = ctx.decideArcSegments(std::max(rx, ry), TAU);
+    if (segs < 8) segs = 8;
+    float expo = 2.0f / n;
+    for (int i = 0; i <= segs; i++) {
+        float a = TAU * ((float)i / (float)segs);
+        float c = std::cos(a), s = std::sin(a);
+        vertex(cx + std::copysign(std::pow(std::abs(c), expo), c) * rx,
+               cy + std::copysign(std::pow(std::abs(s), expo), s) * ry);
+    }
+}
+
+inline void appendSuperellipse(const Vec2& pos, const Vec2& size,
+                               float n = 5.0f) {
+    appendSuperellipse(pos.x, pos.y, size.x, size.y, n);
+}
+
 // Helper — tessellate one Catmull-Rom segment (with p0/p3 as tangent
 // influences, p1->p2 as the visible piece) into the active vertex buffer.
 namespace internal {

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -94,6 +94,9 @@ setIndependentFps(60, EVENT_DRIVEN);   // call redraw() on every visible change
 ```cpp
 drawRect(x, y, w, h)
 drawRectRounded(x, y, w, h, radius)
+drawRectSquircle(x, y, w, h, radius)   // iOS-style curvature-continuous corners
+drawSuperellipse(x, y, w, h, n = 5)    // Lamé curve inscribed in the rect; default n=5 ≈ Apple icon.
+                                       // n: 2=ellipse, 4=squircle, higher→rect, 1=diamond, <1=star
 drawCircle(x, y, radius)
 drawEllipse(x, y, rx, ry)
 drawArc(x, y, radius, angleBegin, angleEnd)   // Angles in radians, TAU = 2*PI
@@ -137,9 +140,10 @@ beginShape();
 vertex(0, 0);
 appendArc(cx, cy, r, angleBegin, angleEnd);   // Arc vertices
 appendCurve(controlPoints, false);            // Catmull-Rom segment (>=4 points)
+appendSuperellipse(x, y, w, h, n);            // Full superellipse outline (bounding-box, like drawSuperellipse)
 endShape(true);                               // close the outline
 ```
-`appendArc` and `appendCurve` also work inside `beginStroke` / `beginLines`.
+`appendArc`, `appendCurve` and `appendSuperellipse` also work inside `beginStroke` / `beginLines`.
 
 ### Path (accumulator class)
 `Path` collects vertices over multiple calls and can be drawn later,
@@ -1473,6 +1477,7 @@ float srgbToLinear(float x)  // Convert a single sRGB channel value to linear RG
 ```cpp
 void appendArc(float cx, float cy, float radius, float angleBegin, float angleEnd) [+1]  // Append arc vertices to the current shape (use between beginShape/endShape)
 void appendCurve(const std::vector<Vec3> & points) [+1]  // Append Catmull-Rom curve vertices to the current shape (use between beginShape/endShape; needs >=4 points, closed=true wraps around)
+void appendSuperellipse(float x, float y, float w, float h, float n = 5.0) [+1]  // Append the closed outline of a superellipse inscribed in a rect to the current shape (use between beginShape/endShape)
 void beginLines()  // Begin batch line drawing. Add vertex pairs with vertex(), then call endLines(). Each pair of vertices draws one independent line segment. Use setColor() between vertices for per-line colors.
 void beginShape()  // Begin drawing a shape
 void beginStroke()  // Begin drawing a stroke (uses StrokeMesh internally)
@@ -1492,6 +1497,7 @@ void drawRectRounded(Vec3 pos, Vec2 size, float radius) [+1]  // Draw rounded re
 void drawRectSquircle(Vec3 pos, Vec2 size, float radius) [+1]  // Draw squircle rectangle (curvature-continuous corners, iOS-style)
 void drawSphere(float radius, int resolution = 16) [+2]  // Draw 3D sphere (respects fill/noFill)
 void drawStroke(float x1, float y1, float x2, float y2) [+1]  // Draw a single stroke segment (thick line with cap/join)
+void drawSuperellipse(Vec3 pos, Vec2 size, float n = 5.0) [+1]  // Draw a superellipse (Lamé curve) inscribed in a rect — Apple-icon-like by default (n=5)
 void drawTriangle(Vec3 p1, Vec3 p2, Vec3 p3) [+1]  // Draw triangle
 void endLines()  // End batch line drawing and render all accumulated line segments
 void endShape(bool close = false)  // End drawing a shape
@@ -1535,7 +1541,7 @@ void pushStyle()  // Push current style (color, fill, stroke, blend) onto stack
 void resetBlendMode()  // Reset blend mode to Alpha (default)
 void resetScissor()  // Reset (disable) scissor clipping
 void resetStyle()  // Reset style to default values (white color, fill enabled, stroke disabled)
-void setBlendMode(BlendMode mode)  // Set blend mode. BlendMode::Alpha (default), Add, Multiply, Screen, Subtract, Disabled
+void setBlendMode(BlendMode mode)  // Set blend mode. BlendMode::Alpha (default), Add, Multiply, Screen, Subtract, Disabled. Works on the screen and inside Fbo passes alike; the mode persists until changed (it also carries into a subsequent Fbo::begin)
 void setCircleResolution(int res) ⚠️deprecated  // Deprecated alias for setCurveResolution()
 void setCurveResolution(int n)  // Set fixed curve segment count (switches off adaptive tolerance mode)
 void setCurveTolerance(float pixels)  // Set adaptive curve tessellation tolerance in pixels (smaller = smoother, scale-aware)
@@ -1822,6 +1828,7 @@ void closeLogFile()  // Close the current log file
 bool compress(const void * src, std::size_t nbytes, std::vector<std::uint8_t> & out, Codec codec) [+1]  // Compress a byte buffer with the given codec (Codec::None or Codec::LZ4). The vector overload resizes out and returns true on success; the raw (dst pointer) overload returns the number of bytes written, or -1 on failure (no resizing).
 std::size_t compressBound(std::size_t nbytes, Codec codec)  // Worst-case compressed size, for sizing a destination buffer
 bool decompress(const void * src, std::size_t nbytes, std::vector<std::uint8_t> & out, std::size_t decompressedSize, Codec codec) [+1]  // Decompress a byte buffer; decompressedSize is the known original byte count. The vector overload resizes out and returns true on success (false / cleared out on mismatch or failure); the raw (dst pointer) overload returns the number of bytes written, or -1 on failure.
+std::vector<unsigned char> fromBase64(const std::string & encoded)  // Decode a Base64 string back into raw bytes
 Logger & getLogger()  // Access the global logger instance
 std::thread::id getMainThreadId()  // Get the main thread ID. Records the current thread's ID on the first call, so it must first be called from the main thread.
 const char * getVersion()  // TrussC version string from git describe (e.g. "v0.6.2" or "v0.6.2-14-gabc123")
@@ -2176,6 +2183,22 @@ void AudioEngine::shutdown()  // Stop and close the audio device.
 ### AudioOutBuffer — Argument type for the AudioEngine::audioOut event. Holds the interleaved mutable output buffer for a single audio callback. Listeners should ADD their contribution to data (voices are already mixed in); do not call engine APIs from here.
 
 ```cpp
+```
+
+### AudioRecordSettings — Settings for AudioRecorder::start(): sample format (S16/F32) and an optional channel map
+
+```cpp
+```
+
+### AudioRecorder — Records the engine's master output (everything the speakers get, Sounds and audioOut synthesis alike) to a WAV file. Taps audioOut at Monitor priority; file IO runs on a background thread, the audio thread never blocks
+
+```cpp
+uint64_t AudioRecorder::getDroppedFrames() const  // Frames lost to ring-buffer overflow (0 in normal operation; nonzero means the writer thread fell behind)
+fs::path AudioRecorder::getPath() const  // Resolved path of the file being written
+double AudioRecorder::getRecordedSeconds() const  // Seconds actually written to the file so far
+bool AudioRecorder::isRecording() const  // True while recording
+bool AudioRecorder::start(const fs::path & path, const AudioRecordSettings & settings = {std::vector<std::vector<int>>()})  // Start recording the master mix into a WAV file (relative paths resolve via getDataPath). The audio engine must already be initialized; returns false otherwise or when the file cannot be opened
+void AudioRecorder::stop()  // Stop and finalize the file (patches the WAV header sizes). Safe to call when not recording; also runs automatically on destruction
 ```
 
 ### AudioSettings — Configuration passed to AudioEngine::init() to override engine defaults (sample rate, channels, buffer size, polyphony, device). Empty deviceName selects the system default playback device.
@@ -3995,6 +4018,7 @@ bool VideoWriter::isOpen() const  // Check if the encoder is open and accepting 
 unsigned char * VideoWriter::lockFrame(int & strideOut) [macos]  // Lock and return the encoder's frame buffer for zero-copy fills; strideOut receives the row stride. Pair with submitFrame
 bool VideoWriter::open(const fs::path & path, int width, int height, const VideoRecordSettings & settings = {})  // Open the encoder at the given size (path resolved via getDataPath)
 bool VideoWriter::submitFrame(double timeSec) [macos]  // Append the previously locked frame at the given presentation time (seconds)
+bool VideoWriter::writeAudio(const float * interleaved, int frames, double timeSec)  // Append interleaved float32 samples to the audio track at an explicit PTS (seconds, same timeline as addFrameAt). Only meaningful when opened with settings.audio = true and audioSampleRate/audioChannels set; returns false otherwise
 ```
 
 ### Window — A secondary application window (macOS only for now). Owns its own Node tree, events, mouse state and render context; ticks at its display's refresh rate. GPU resources are shared with every other window
@@ -4045,6 +4069,7 @@ std::string Xml::toString(const std::string & indent = std::string("  ")) const 
 ## Enums
 
 ```cpp
+enum AudioRecordSettings::SampleFormat { S16, F32 }  // WAV sample format: S16 = 16-bit PCM (default), F32 = 32-bit IEEE float (headroom survives, no clipping in the file)
 enum AxisMode { None, Fill, Content }  // Layout axis sizing: None (fixed), Fill (expand to the parent), Content (fit children).
 enum Beep { ping, success, complete, coin, error, warning, cancel, click, typing, notify, sweep }  // Built-in system beep sounds (ping, success, error, …) for beep().
 enum BlendMode { Alpha, Add, Multiply, Screen, Subtract, Disabled }  // Color blend mode: Alpha, Add, Multiply, Screen, Subtract, Disabled.

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -11476,6 +11476,32 @@ description.ja = "現在の図形にCatmull-Rom曲線の頂点を追加（beginS
 description.ko = "현재 도형에 Catmull-Rom 곡선 정점을 추가 (beginShape/endShape 사이에서 사용, 4점 이상 필요, closed=true는 닫힌 곡선)"
 related = ["drawCurve"]
 
+["appendSuperellipse"]
+category = "graphics_shapes"
+keywords = ["superellipse", "lame curve", "squircle", "shape", "outline"]
+description.en = "Append the closed outline of a superellipse inscribed in a rect to the current shape (use between beginShape/endShape)"
+description.ja = "矩形に内接するスーパー楕円の閉じた輪郭を現在の図形に追加（beginShape/endShape間で使用）"
+description.ko = "사각형에 내접하는 초타원의 닫힌 윤곽을 현재 도형에 추가 (beginShape/endShape 사이에서 사용)"
+details.en = '''
+Same bounding-box convention and exponent parameter as
+[`drawSuperellipse`](#drawSuperellipse). Note that `endShape()` fills with a
+first-vertex fan, which is only correct for convex outlines (`n >= 1`); for
+concave `n < 1` shapes use [`drawSuperellipse`](#drawSuperellipse) directly.
+'''
+details.ja = '''
+[`drawSuperellipse`](#drawSuperellipse) と同じバウンディングボックス指定・指数
+パラメータを取る。`endShape()` の塗りは先頭頂点からのファンなので凸形状
+（`n >= 1`）でのみ正しい。凹になる `n < 1` は
+[`drawSuperellipse`](#drawSuperellipse) を直接使うこと。
+'''
+details.ko = '''
+[`drawSuperellipse`](#drawSuperellipse)와 같은 바운딩 박스 지정과 지수
+매개변수를 사용한다. `endShape()`의 채우기는 첫 정점 기준 팬이므로 볼록한
+윤곽(`n >= 1`)에서만 올바르다. 오목한 `n < 1` 형태는
+[`drawSuperellipse`](#drawSuperellipse)를 직접 사용할 것.
+'''
+related = ["drawSuperellipse", "appendArc", "beginShape"]
+
 ["appendToFile"]
 category = "file"
 keywords = ["write", "add", "concat"]
@@ -12249,7 +12275,7 @@ of = ["ofDrawRectRounded"]
 description.en = "Draw rounded rectangle (circular arc corners)"
 description.ja = "角丸矩形を描画（円弧コーナー）"
 description.ko = "둥근 모서리 사각형 그리기 (원호 모서리)"
-related = ["drawRectSquircle"]
+related = ["drawRectSquircle", "drawSuperellipse"]
 
 ["drawRectSquircle"]
 category = "graphics_shapes"
@@ -12257,6 +12283,7 @@ keywords = ["rounded", "ios", "superellipse", "smooth corner"]
 description.en = "Draw squircle rectangle (curvature-continuous corners, iOS-style)"
 description.ja = "スクワークル矩形を描画（曲率連続コーナー、iOS風）"
 description.ko = "스쿼클 사각형 그리기 (곡률 연속 모서리, iOS 스타일)"
+related = ["drawRectRounded", "drawSuperellipse"]
 
 ["drawSphere"]
 category = "graphics_shapes"
@@ -12274,6 +12301,43 @@ description.en = "Draw a single stroke segment (thick line with cap/join)"
 description.ja = "単一のストロークを描画（太線、端点/結合スタイル対応）"
 description.ko = "단일 stroke 세그먼트를 그림 (캡/조인이 있는 굵은 선)"
 related = ["setStrokeWeight", "setStrokeCap", "setStrokeJoin", "drawLine"]
+
+["drawSuperellipse"]
+category = "graphics_shapes"
+keywords = ["superellipse", "lame curve", "apple icon", "squircle", "rounded", "piet hein"]
+description.en = "Draw a superellipse (Lamé curve) inscribed in a rect — Apple-icon-like by default (n=5)"
+description.ja = "矩形に内接するスーパー楕円（ラメ曲線）を描画 — デフォルト（n=5）はAppleアイコン風"
+description.ko = "사각형에 내접하는 초타원(라메 곡선) 그리기 — 기본값(n=5)은 Apple 아이콘 스타일"
+details.en = '''
+Draws the Lamé curve `|x/rx|^n + |y/ry|^n = 1` filling the rect `(x, y, w, h)` —
+a drop-in alternative to [`drawRectRounded`](#drawRectRounded). The exponent `n`
+morphs the shape: `2` = ellipse, `4` = squircle, higher values approach the
+bounding rect; `1` = diamond, `< 1` = concave star-like shapes (filled correctly
+via a center fan). The default `n = 5` approximates the Apple app-icon
+silhouette; Piet Hein's classic superellipse uses `n = 2.5`. Aspect ratio comes
+from `w`/`h`. Unlike [`drawRectSquircle`](#drawRectSquircle) (which rounds the
+corners of a rect with straight edges in between), the whole outline is one
+continuous superellipse.
+'''
+details.ja = '''
+矩形 `(x, y, w, h)` を満たすラメ曲線 `|x/rx|^n + |y/ry|^n = 1` を描画する。
+[`drawRectRounded`](#drawRectRounded) の代わりにそのまま使える。指数 `n` で形が
+変わる: `2` = 楕円、`4` = スクワークル、大きいほど矩形に近づく。`1` = ひし形、
+`1` 未満は凹んだ星形（中心ファンで正しく塗られる）。デフォルトの `n = 5` は
+Apple のアプリアイコンに近いシルエット。Piet Hein の古典的スーパー楕円は
+`n = 2.5`。縦横比は `w`/`h` で決まる。[`drawRectSquircle`](#drawRectSquircle)
+（角だけ丸めて辺は直線）と違い、輪郭全体が1本の連続したスーパー楕円になる。
+'''
+details.ko = '''
+사각형 `(x, y, w, h)`를 채우는 라메 곡선 `|x/rx|^n + |y/ry|^n = 1`을 그린다.
+[`drawRectRounded`](#drawRectRounded) 대신 바로 사용할 수 있다. 지수 `n`으로
+형태가 변한다: `2` = 타원, `4` = 스쿼클, 클수록 사각형에 가까워진다. `1` =
+마름모, `1` 미만은 오목한 별 모양(중심 팬으로 올바르게 채워진다). 기본값
+`n = 5`는 Apple 앱 아이콘에 가까운 실루엣이며, Piet Hein의 고전적 초타원은
+`n = 2.5`. 종횡비는 `w`/`h`로 결정된다. [`drawRectSquircle`](#drawRectSquircle)
+(모서리만 둥글고 변은 직선)과 달리 윤곽 전체가 하나의 연속된 초타원이다.
+'''
+related = ["drawRectRounded", "drawRectSquircle", "drawEllipse", "appendSuperellipse"]
 
 ["drawTriangle"]
 category = "graphics_shapes"

--- a/examples/graphics/roundedRectExample/src/tcApp.cpp
+++ b/examples/graphics/roundedRectExample/src/tcApp.cpp
@@ -1,9 +1,10 @@
 // =============================================================================
 // roundedRectExample
-// Compares three rectangle drawing methods:
+// Compares four rectangle drawing methods:
 //   - drawRect: sharp corners
 //   - drawRectRounded: circular arc corners
 //   - drawRectSquircle: curvature-continuous corners (iOS-style)
+//   - drawSuperellipse: Lamé curve inscribed in the rect (Apple-icon-like)
 // =============================================================================
 
 #include "tcApp.h"
@@ -18,26 +19,45 @@ void tcApp::setup() {
 void tcApp::draw() {
     clear(0.15f, 0.15f, 0.2f);
 
-    float w = 200, h = 200, r = 40;
-    float y = 200;
+    float w = 180, h = 180, r = 36;
+    float y = 120;
 
     // 1. Normal
     setColor(1.0f);
-    drawBitmapString("drawRect", 100, y - 20);
+    drawBitmapString("drawRect", 60, y - 20);
     setColor(0.9f, 0.3f, 0.3f);
-    drawRect(100, y, w, h);
+    drawRect(60, y, w, h);
 
     // 2. Rounded (circular arc)
     setColor(1.0f);
-    drawBitmapString("drawRectRounded", 380, y - 20);
+    drawBitmapString("drawRectRounded", 280, y - 20);
     setColor(0.3f, 0.9f, 0.3f);
-    drawRectRounded(380, y, w, h, r);
+    drawRectRounded(280, y, w, h, r);
 
     // 3. Squircle (iOS-style)
     setColor(1.0f);
-    drawBitmapString("drawRectSquircle", 660, y - 20);
+    drawBitmapString("drawRectSquircle", 500, y - 20);
     setColor(0.3f, 0.5f, 0.9f);
-    drawRectSquircle(660, y, w, h, r);
+    drawRectSquircle(500, y, w, h, r);
+
+    // 4. Superellipse (Apple-icon-like, default n=5)
+    setColor(1.0f);
+    drawBitmapString("drawSuperellipse", 720, y - 20);
+    setColor(0.9f, 0.7f, 0.2f);
+    drawSuperellipse(720, y, w, h);
+
+    // Exponent morph: n from concave star to near-rect
+    float ns[] = {0.7f, 1.0f, 2.0f, 2.5f, 4.0f, 5.0f, 10.0f};
+    float sw = 100, sy = 420;
+    setColor(1.0f);
+    drawBitmapString("drawSuperellipse(x, y, w, h, n) with varying n", 60, sy - 20);
+    for (int i = 0; i < 7; i++) {
+        float sx = 60 + i * (sw + 25);
+        setColor(0.9f, 0.7f, 0.2f);
+        drawSuperellipse(sx, sy, sw, sw, ns[i]);
+        setColor(1.0f);
+        drawBitmapString("n=" + toString(ns[i], 1), sx + 30, sy + sw + 24);
+    }
 }
 
 void tcApp::keyPressed(int key) {


### PR DESCRIPTION
## Summary
Adds superellipse (Lamé curve) drawing primitives — a drop-in alternative to `drawRectRounded` with a freely chosen exponent and aspect ratio.

```cpp
drawSuperellipse(x, y, w, h);          // default n=5 ≈ Apple app-icon silhouette
drawSuperellipse(x, y, w, h, 2.5f);    // Piet Hein's classic superellipse
appendSuperellipse(x, y, w, h, n);     // outline into beginShape/beginStroke/beginLines
```

- Draws `|x/rx|^n + |y/ry|^n = 1` inscribed in the rect `(x, y, w, h)` — same bounding-box convention as the `drawRect` family. `n`: 2 = ellipse, 4 = squircle, higher → rect, 1 = diamond, <1 = concave star.
- Fill uses a center fan, so concave `n < 1` shapes render correctly (a first-vertex fan would not).
- `appendSuperellipse` follows the `appendArc` / `appendCurve` pattern.

## Docs / bindings
- `api-reference.toml` entries (En/Ja/Ko) with cross-links from `drawRect` / `drawRectRounded` / `drawRectSquircle`; `check.js --strict` green.
- `FOR_AI_ASSISTANT.md` cheatsheet + regenerated API index.
- tcxLua bindings regenerated; bindcheck 428/428 functions, 31 call checks, 0 failures.

## Verification
- macOS: extended `roundedRectExample` (all four rect styles + exponent morph row `n = 0.7 … 10`), verified via MCP screenshots — fill, stroke-only, and `appendSuperellipse` paths all inspected visually.
- Linux/Windows: no platform-specific code (pure `std::` math + existing VertexWriter); relying on CI matrix.
