### PR TITLE
fix: hot reload crash after the recording-audio merge (AudioEngine dso lifetime + guest unmapping)

### DIFF
--- a/core/include/TrussC.h
+++ b/core/include/TrussC.h
@@ -2018,6 +2018,10 @@ namespace mcp {
     void registerDebuggerTools();
 }
 
+// Defined in tc/sound/tcSound.h (included later in this header); declared here
+// so the cleanup callback below can stop the audio device on exit.
+inline void shutdownAudio();
+
 namespace internal {
 
     inline void _setup_cb() {
@@ -2273,6 +2277,14 @@ namespace internal {
         console::stop();
 
         if (appCleanupFunc) appCleanupFunc();
+
+        // Stop the audio device explicitly: the AudioEngine singleton is
+        // intentionally leaked (see AudioEngine::getInstance()), so no
+        // exit-time destructor will do this. Runs after appCleanupFunc so
+        // the app's exit() can still use audio; shutdown() is a no-op when
+        // the engine was never initialized.
+        trussc::shutdownAudio();
+
         cleanup();
     }
 

--- a/core/include/tc/app/tcHotReloadHost.h
+++ b/core/include/tc/app/tcHotReloadHost.h
@@ -138,17 +138,23 @@ struct GuestLibrary {
 
     void unload() {
         destroy();
+        // Intentionally NOT dlclose()d / FreeLibrary()d: the old guest's code
+        // can still be referenced from host-owned state even after its App is
+        // destroyed -- shared_ptr control blocks it allocated (e.g. the COW
+        // listener list inside Event<T> after this App's listeners were
+        // removed), std::function invokers, vtables/typeinfo. Unmapping the
+        // image turns any such leftover into a jump into unmapped memory
+        // (observed: SEGV in Event::listenImpl releasing the previous list
+        // snapshot on the first reload). Leaking ~one guest image per reload
+        // is the standard hot-reload trade-off and is bounded by dev usage.
         if (handle) {
-#ifdef _WIN32
-            FreeLibrary(handle);
-#else
-            dlclose(handle);
-#endif
             handle = nullptr;
-            // Remove the per-load temp copy. On Linux this is safe even if
-            // dlclose didn't fully unload: unlink just drops the directory
-            // entry — the mmap'd pages stay alive until the OS releases them.
+#ifndef _WIN32
+            // POSIX: unlinking the mapped temp copy is safe (drops the
+            // directory entry only). Windows can't delete a loaded DLL, so
+            // temp copies remain until the next run cleans them up.
             try { fs::remove(loadedPath); } catch (...) {}
+#endif
         }
         createApp = nullptr;
         destroyApp = nullptr;

--- a/core/include/tc/sound/tcSound.h
+++ b/core/include/tc/sound/tcSound.h
@@ -689,8 +689,15 @@ public:
     static constexpr int DEFAULT_BUFFER_SIZE = 0;  // 0 = let miniaudio choose
 
     static AudioEngine& getInstance() {
-        static AudioEngine instance;
-        return instance;
+        // Intentionally leaked. A plain function-local static registers its
+        // destructor against the __dso_handle of the image whose code runs the
+        // first call — under hot reload that is the guest dylib, so dlclose()
+        // of an old guest destroys the engine the host is still using (the
+        // next listen() then dies on the destroyed Event mutex). The heap
+        // instance has no exit-time destructor; the framework cleanup path
+        // calls shutdown() explicitly for a clean device stop on normal exit.
+        static AudioEngine* instance = new AudioEngine();
+        return *instance;
     }
 
     // Initialize and shutdown (implementation in tcAudio_impl.cpp).

--- a/examples/sound/audioRecorderExample/src/main.cpp
+++ b/examples/sound/audioRecorderExample/src/main.cpp
@@ -7,7 +7,7 @@
 int main() {
     WindowSettings settings;
     settings.setSize(960, 600);
-    settings.setTitle("audioSynthExample - TrussC");
+    settings.setTitle("audioRecorderExample - TrussC");
 
     return TC_RUN_APP(tcApp, settings);
 }


### PR DESCRIPTION
`TC_HOT_RELOAD` apps started crashing after the recording-audio merge (#181): on macOS the first reload aborted with `recursive_mutex lock failed`, on Linux the app appeared to reload fine but SIGSEGV'd on exit. Root cause found with a minimal repro (`clear()` edit → reload) and lldb.

## Root cause

The audio auto-subscribe added to the `App` constructor made guest code the **first** caller of `AudioEngine::getInstance()`. That exposed two independent hazards:

1. **dso-bound singleton destructor.** A function-local static registers its exit destructor against the `__dso_handle` of the image whose code runs the first call — under hot reload that's the guest dylib. `dlclose()` of an old guest therefore destroyed the engine the host was still using; the next `listen()` died on the destroyed `Event` mutex.
2. **Stale guest code reachable from host state.** Even after the old guest's `App` is destroyed, host-owned state can still reference its code: `shared_ptr` control blocks it allocated (e.g. `Event<T>`'s COW listener-list snapshot after `removeListener`), `std::function` invokers, vtables. Unmapping the image turns any such leftover into a jump into unmapped memory (observed as SEGV in `Event::listenImpl` on the first reload).

Platform note: glibc's `dlclose` often keeps the image mapped (unique/weak symbols), which is why Linux survived reloads and crashed at exit instead — same regression, different timing.

## Fix

- `AudioEngine::getInstance()` is now an intentionally **leaked heap singleton** (no exit-time destructor to mis-register), and the framework cleanup callback calls `shutdownAudio()` explicitly so normal exit still stops the device cleanly.
- The hot reload host **no longer `dlclose()`s / `FreeLibrary()`s old guest images** — the standard hot-reload trade-off (~one guest image leaked per reload, dev-time only). POSIX temp copies are still unlinked; Windows `.tmp.dll`s remain as before.
- Drive-by: `audioRecorderExample` window title fixed (leftover from `audioSynthExample`).

## Verification

- **macOS**: repro crashed 100% on the 1st reload before; survives 5 consecutive reloads after. `audioRecorderExample` records and shuts down cleanly (`AudioEngine: shutdown` on exit).
- **Windows** (Win11 / MSVC / D3D11): recording examples exit cleanly; hot reload host/guest split works end-to-end — 3 consecutive reloads (~1.35 s each), no crash.
- **Linux** (GL / GStreamer): dev HEAD reproduced the exit-time SEGV (exit 139); with the fix, 5 consecutive reloads, screen-verified updates, clean exit 0.
