### PR TITLE
fix: shadow map sampled v-flipped on top-left-origin backends

### DIFF
--- a/core/include/tc/3d/tcMeshPbrPipeline.h
+++ b/core/include/tc/3d/tcMeshPbrPipeline.h
@@ -354,9 +354,20 @@ public:
         // submission time (issue #192). The array texture VIEW is shared, but
         // each light's layer is rendered exactly once per frame before the
         // material draws that use it, so the layer content matches the matrix.
+        // Slot data refreshes every frame that runs a shadow pass. Draws
+        // submitted before the first shadow pass of a frame may still use the
+        // previous frame's slots (intentional, one frame old at most). If the
+        // slots are older than that, the app stopped calling beginShadowPass()
+        // entirely -- expose zero slots instead of ghost shadows from a stale
+        // map (the per-frame slot reset only runs inside beginShadowPass()).
+        int liveSlotCount = (shadowSlotFrame_ + 1 >= getFrameCount()) ? shadowSlotCount_ : 0;
         fsp.shadowMapParams[0] = static_cast<float>(shadowTexResolution_);
-        fsp.shadowMapParams[1] = static_cast<float>(shadowSlotCount_);
-        for (int s = 0; s < shadowSlotCount_; s++) {
+        fsp.shadowMapParams[1] = static_cast<float>(liveSlotCount);
+        // z flags a top-left-origin backend (Metal / D3D11 / WebGPU): the
+        // shader must v-flip its shadow UV to sample the offscreen map
+        // correctly (GL convention otherwise).
+        fsp.shadowMapParams[2] = sg_query_features().origin_top_left ? 1.0f : 0.0f;
+        for (int s = 0; s < liveSlotCount; s++) {
             Mat4 svpT = shadowSlotViewProj_[s].transposed();
             std::memcpy(fsp.shadowViewProj[s], svpT.m, sizeof(fsp.shadowViewProj[s]));
             fsp.shadowSlotParams[s][0] = static_cast<float>(shadowSlotLightIndex_[s]);

--- a/core/shaders/meshPbr.glsl
+++ b/core/shaders/meshPbr.glsl
@@ -67,7 +67,7 @@ layout(binding=1) uniform fs_params {
     vec4 texFlags;                        // x=hasBaseColorTex, y=hasMetRoughTex, z=hasEmissiveTex, w=hasOcclusionTex
     mat4 shadowViewProj[MAX_SHADOW_LIGHTS];   // per-slot light VP for shadow depth comparison
     vec4 shadowSlotParams[MAX_SHADOW_LIGHTS]; // x=lightIndex (-1=unused), y=bias, z=strength, w=unused
-    vec4 shadowMapParams;                     // x=mapSize, y=numShadowSlots, zw=unused
+    vec4 shadowMapParams;                     // x=mapSize, y=numShadowSlots, z=originTopLeft, w=unused
 };
 
 // IBL resources. Bound only when iblParams.x > 0.5.
@@ -161,6 +161,16 @@ float calcShadow(int slot, vec3 worldPos) {
     vec4 clip = shadowViewProj[slot] * vec4(worldPos, 1.0);
     vec3 ndc = clip.xyz / clip.w;
     vec2 shadowUV = ndc.xy * 0.5 + 0.5;
+
+    // The shadow map is an offscreen render target. On top-left-origin
+    // backends (Metal / D3D11 / WebGPU) its rows are stored flipped relative
+    // to the GL convention assumed by the NDC->UV mapping above, so sampling
+    // without a flip reads the mirror image: shadows land offset and half the
+    // receiver plane self-shadows along a straight line (the v=0.5 axis).
+    // shadowMapParams.z carries sg_query_features().origin_top_left.
+    if (shadowMapParams.z > 0.5) {
+        shadowUV.y = 1.0 - shadowUV.y;
+    }
 
     // Outside shadow frustum = fully lit
     if (shadowUV.x < 0.0 || shadowUV.x > 1.0 ||


### PR DESCRIPTION
## Problem

Shadow maps introduced in #197 rendered incorrectly on **Metal / D3D11 / WebGPU**:

- Shadows landed offset from their casters (mirrored across the light axis)
- Half of the receiver plane went dark with a straight cutoff line across
  the lit area (bias-independent, FOV-independent)
- Additionally, on all backends: shadows persisted as "ghosts" forever once
  an app stopped calling beginShadowPass() (e.g. toggling all shadows off)

GL-family backends (GLCORE / GLES3 / WebGL2) were unaffected by the first
issue, which is why the cross-platform verification for #197 passed on
Linux / RasPi.

## Root cause

`calcShadow()` mapped NDC to shadow UV with the GL convention
(`v = ndc.y * 0.5 + 0.5`). Offscreen render targets store rows top-down on
top-left-origin backends, so sampling read the map mirrored vertically:
shadows appeared displaced, and the receiver plane on one side of the
light's v=0.5 axis (a world-space straight line through the light axis —
hence the FOV/bias-independent cutoff) self-shadowed against mirrored depths.

The ghost-shadow issue: the per-frame shadow slot reset only runs inside
`beginShadowPass()`, so when no shadow pass ran at all, the previous slot
count and stale map contents stayed live indefinitely.

## Fix

- Pass `sg_query_features().origin_top_left` to the PBR shader via
  `shadowMapParams.z`; `calcShadow()` v-flips its UV when set.
  GL path is unchanged (flag = 0).
- Expose zero shadow slots when no shadow pass has run for more than one
  frame. The intentional one-frame retention (draws submitted before the
  first shadow pass of a frame reuse the previous frame's slots) is kept.

## Verification (runtime, per backend)

| Backend | Origin | Expectation | Result |
|---|---|---|---|
| Metal (macOS) | top-left | fixed | ✅ correct shadows, no cutoff, toggle-off clears |
| D3D11 (Windows) | top-left | fixed | ✅ incl. direct before/after comparison vs dev |
| WebGPU (wasm) | top-left | fixed | ✅ |
| WebGL2 (wasm) | bottom-left | no change | ✅ no regression, toggle-off clears |
| GLCORE (Linux) | bottom-left | no change | ✅ a–e all MATCH, stale-slot expiry works |

Verified with examples/3d/multiShadowExample: shadow direction vs light
position, smooth spot footprint (no straight cutoff), per-light toggles,
and all-shadows-off leaving no ghost shadows. GLES3 (RasPi) not re-run
this round — same no-op GL path as GLCORE.

## Notes

- The multiShadowExample screenshot currently on trussc.org was captured
  on macOS before this fix and shows the broken shadows — it needs an
  update.sh re-run after this merges.
