### PR TITLE
fix(docs): opaque enum forward declarations no longer strip enumerators

### DIFF
--- a/docs/reference/generate.js
+++ b/docs/reference/generate.js
@@ -80,6 +80,26 @@ for (const id in structure) {
         documented: !!(p.description && p.description.en),
     };
 }
+// --- refuse enums that lost their enumerators --------------------------------
+// An enum reaching the output with zero members is almost always an OPAQUE
+// FORWARD DECLARATION (`enum class StrokeCap;`, needed when a header is included
+// before the real definition) winning structure.js's "first id wins" dedupe.
+// Downstream this silently DELETES the enum from the Lua bindings and the web
+// data (an enum with no members has nothing to bind), so fail loudly here.
+// There is no legitimately empty public enum in TrussC; if one is ever added,
+// mark it `hide = true` in api-reference.toml or relax this gate deliberately.
+const emptyEnums = Object.values(joined).filter(e => e.kind === 'enum' && !e.hidden && !(e.members && e.members.length));
+if (emptyEnums.length) {
+    console.error(
+        `generate: REFUSING to write reference data — ${emptyEnums.length} enum(s) have ZERO enumerators:\n` +
+        emptyEnums.map(e => '  ' + e.id).join('\n') + '\n' +
+        'Cause: an opaque forward declaration (`enum class Foo;`) in an earlier-included header\n' +
+        '       beat the real definition in structure.js\'s "first id wins" dedupe.\n' +
+        'Fix: structure.js drops opaque enum decls when the enum is also seen complete — if this\n' +
+        '     fires, the definition never reached the AST (check the enum is inside namespace trussc\n' +
+        '     and its header is reachable from TrussC.h).');
+    process.exit(1);
+}
 fs.writeFileSync(OUT_JSON, JSON.stringify(joined, null, 0));
 
 // --- human/AI markdown index, grouped by category (prose) then owner ---

--- a/docs/reference/structure.js
+++ b/docs/reference/structure.js
@@ -294,7 +294,17 @@ function parseSig(sig) {
 
 // --- 4. build the structure map (overloads merged into one entry) -----------
 const syms = enumerate(splitTopLevel(astText));
-const pub = syms.filter(s => isTc(s.file) && !isHidden(s) && !noise(s) && symbolId(s));
+let pub = syms.filter(s => isTc(s.file) && !isHidden(s) && !noise(s) && symbolId(s));
+// drop OPAQUE enum declarations (`enum class StrokeCap;`) when the same enum is
+// also seen complete. An opaque decl carries no enumerators, and it can live in a
+// header included EARLIER than the definition (tcWindowContext.h needs StrokeCap
+// as a member type before tcRenderContext.h defines it) — so the "first id wins"
+// dedupe below would let it beat the definition and publish an enum with zero
+// members. Symmetric with walkRecord's completeDefinition guard, but exact: a
+// legitimately empty `enum class Foo {};` has no complete-with-members sibling
+// and is kept as-is.
+const enumsWithMembers = new Set(pub.filter(s => s.kind === 'enum' && s.members && s.members.length).map(symbolId));
+pub = pub.filter(s => !(s.kind === 'enum' && !(s.members && s.members.length) && enumsWithMembers.has(symbolId(s))));
 const structure = Object.create(null);                          // null proto: ids like "toString"/"constructor" are safe keys
 for (const s of pub) {
     const id = symbolId(s);


### PR DESCRIPTION
## Summary

An opaque `enum class Foo;` in a header included **earlier** than the real definition won `structure.js`'s "first id wins" dedupe and contributed a symbol with **zero enumerators**. Records already guarded against exactly this (`walkRecord`'s `completeDefinition` check); enums did not.

v0.7.4 added `enum class StrokeCap;` to `tcWindowContext.h` (needed because `WindowContext` holds the per-window stroke accumulator and is included before the real definition). That erased `Butt`/`Round`/`Square` from the generated API data:

- `reference-data.json`'s `StrokeCap` entry lost all 3 enumerators.
- Regenerating the Lua bindings would have **dropped the `StrokeCap` usertype entirely** from all 16 shards — breaking `StrokeCap.Butt` for Lua / TrussSketch users.
- The web reference / editor completion data lost the type.

`check.js --strict` passed throughout, so nothing caught it.

## Fix

- **`structure.js`**: post-pass that drops an enum declaration with no enumerators **only when another declaration of the same symbol id carries them**. A legitimately empty `enum class Foo {};` is untouched. (Chosen over a walk-time "skip childless EnumDecl", which would also drop genuinely empty enums.)
- **`generate.js`**: refuses to write reference data when any enum reaches the output with zero enumerators, so this class of regression **fails CI** instead of silently shipping. Placed in `generate.js` rather than `check.js` because `check.js`'s default path consumes `structure.js --ids` (names only, no members) and structurally cannot see enumerators, while `generate.js` is the single choke point every consumer (luagen, luagen-types, all three web emitters) reads from. Verified the guard fires by feeding it a doctored structure JSON.

Audited the other symbol kinds for the same hazard: records/class templates are already guarded (29 forward decls, all correctly skipped); typedefs/vars carry no payload beyond name; functions *accumulate* signatures rather than clobber. Confirmed empirically — after the fix there are zero duplicate symbol ids among `type`/`enum`/`typedef`/`var` (the only duplicates are genuine function overloads).

## Shipped v0.7.4 is unaffected

Regenerating the bindings after this fix reproduces the committed v0.7.4 ones **byte-for-byte** (`git diff --stat addons/tcxLua/src/generated/` is empty), which proves the shipped bindings are correct and that regeneration is now faithful.

## Verification

- `generate.js`: clean full run from a fresh clang AST. `StrokeCap.members` = 3 (`Butt` 0, `Round` 1, `Square` 2). Enums with zero members: **0** (was 1). Deep diff of the whole `reference-data.json` vs the pre-fix snapshot: `StrokeCap` is the **only** changed entry, 0 ids added or removed.
- `check.js --strict`: pass (0 orphan, 0 undocumented / 2467).
- Lua: regenerated both generators; diff vs committed is empty. `bindcheck --regen`: 431/431 functions, 157/157 usertypes, 0 missing, 0 call failures. Landmine demo: regenerating against the *pre-fix* data made `StrokeCap` vanish from all 16 shards.
- Web data: `StrokeCap` present with all three values in `trusssketch-api.js`, `trusssketch-ref.js` and `trussc-api.js` (with En/Ja/Ko value descriptions). Name-set diff before vs after shows **zero** additions or removals across types / enums / constants / macros / functions in all three files; the only textual change is the v0.7.4 version string.