### PR TITLE
fix: MCP key injection now matches the real key event path

### DIFF
--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -612,6 +612,67 @@ inline void registerInspectionTools() {
 }
 
 // ---------------------------------------------------------------------------
+// Key injection helpers (shared by tc_key_press / tc_key_release)
+//
+// These mirror the real SAPP_EVENTTYPE_KEY_DOWN / KEY_UP path in TrussC.h
+// step for step, including the ordering: notify listeners, update the
+// held-key set, then call the app/Node-tree callback. Modifier flags are
+// DERIVED from the held-key set, the way sokol gets ev->modifiers from the
+// keys the OS reports as down — so an injected modifier hold (tc_key_press
+// with the modifier keycode) shows up on every event that follows it, and
+// e.shift agrees with what isShiftPressed() reports.
+// ---------------------------------------------------------------------------
+namespace detail {
+
+// Modifier flags for the event carrying `key`, as of AFTER this event's own
+// state change — which is what the OS reports: a Shift key-down already has
+// the Shift flag set, its key-up already has it cleared. Every other key is
+// read straight from the held-key set.
+inline void fillKeyModifiers(KeyEventArgs& args, int key, bool down) {
+    auto heldAfter = [key, down](int code) {
+        return code == key ? down : isKeyPressed(code);
+    };
+    args.shift = heldAfter(SAPP_KEYCODE_LEFT_SHIFT)   || heldAfter(SAPP_KEYCODE_RIGHT_SHIFT);
+    args.ctrl  = heldAfter(SAPP_KEYCODE_LEFT_CONTROL) || heldAfter(SAPP_KEYCODE_RIGHT_CONTROL);
+    args.alt   = heldAfter(SAPP_KEYCODE_LEFT_ALT)     || heldAfter(SAPP_KEYCODE_RIGHT_ALT);
+    args.super = heldAfter(SAPP_KEYCODE_LEFT_SUPER)   || heldAfter(SAPP_KEYCODE_RIGHT_SUPER);
+}
+
+inline void injectKeyDown(int key) {
+    KeyEventArgs args;
+    args.key = key;
+    fillKeyModifiers(args, key, true);
+    events().keyPressed.notify(args);
+
+    ::trussc::internal::currentWindowContext().keysPressed.insert(key);
+
+    if (::trussc::internal::appKeyPressedFunc)
+        ::trussc::internal::appKeyPressedFunc(args);
+}
+
+inline void injectKeyUp(int key) {
+    KeyEventArgs args;
+    args.key = key;
+    fillKeyModifiers(args, key, false);
+    events().keyReleased.notify(args);
+
+    ::trussc::internal::currentWindowContext().keysPressed.erase(key);
+
+    if (::trussc::internal::appKeyReleasedFunc)
+        ::trussc::internal::appKeyReleasedFunc(args);
+}
+
+// Currently held keycodes, for the tool reply (handy when scripting chords).
+inline json heldKeysJson() {
+    std::vector<int> held(::trussc::internal::currentWindowContext().keysPressed.begin(),
+                          ::trussc::internal::currentWindowContext().keysPressed.end());
+    std::sort(held.begin(), held.end());
+    return json(held);
+}
+
+} // namespace detail
+
+// ---------------------------------------------------------------------------
 // Control Tools (opt-in via mcp::registerControlTools())
 //
 // The always-on standard set is strictly read-only; everything that lets the
@@ -765,26 +826,78 @@ inline void registerControlTools() {
 
     // --- Key Tools ---
 
-    tool("tc_key_press", "Press a key")
-        .arg<int>("key", "Key code (sokol_app keycode)")
-        .bind<int>([](int key) {
-            KeyEventArgs args;
-            args.key = key;
-            events().keyPressed.notify(args);
-            if (::trussc::internal::appKeyPressedFunc)
-                ::trussc::internal::appKeyPressedFunc(args);
-            return json{{"status", "ok"}};
+    // The modifier flags are shorthand for pressing/releasing the modifier
+    // KEY ITSELF (the LEFT_* keycode), like a real keyboard does — so both
+    // e.shift on the callback and isShiftPressed() in update() see it. Hold a
+    // modifier across several keys by pressing its keycode explicitly
+    // (tc_key_press 340), then plain presses inherit it.
+    tool("tc_key_press",
+         "Press a key (updates the held-key set that isKeyPressed() reads). "
+         "A modifier flag also presses that modifier's own key first (shift -> keycode 340, "
+         "ctrl -> 341, alt -> 342, super -> 343) and reports it in modifiersPressed; "
+         "pair it with the same flag on tc_key_release, or hold a modifier across several "
+         "keys by pressing/releasing its keycode explicitly")
+        .arg<int>("key", "Key code (sokol_app keycode; letters are uppercase ASCII: 'A'=65..'Z'=90)")
+        .arg<bool>("shift", "Hold Shift for this press", false)
+        .arg<bool>("ctrl", "Hold Ctrl for this press", false)
+        .arg<bool>("alt", "Hold Alt for this press", false)
+        .arg<bool>("super", "Hold Super/Command for this press", false)
+        .bind([](const json& a) -> json {
+            const int key = a.at("key").get<int>();
+
+            // Press the requested modifiers first (skip any already held —
+            // whichever side, so an explicit RIGHT_SHIFT hold is respected).
+            json pressedMods = json::array();
+            auto holdMod = [&](const char* flag, bool alreadyHeld, int code) {
+                if (a.value(flag, false) && !alreadyHeld) {
+                    detail::injectKeyDown(code);
+                    pressedMods.push_back(code);
+                }
+            };
+            holdMod("shift", isShiftPressed(),   SAPP_KEYCODE_LEFT_SHIFT);
+            holdMod("ctrl",  isControlPressed(), SAPP_KEYCODE_LEFT_CONTROL);
+            holdMod("alt",   isAltPressed(),     SAPP_KEYCODE_LEFT_ALT);
+            holdMod("super", isSuperPressed(),   SAPP_KEYCODE_LEFT_SUPER);
+
+            detail::injectKeyDown(key);
+
+            return json{{"status", "ok"},
+                        {"modifiersPressed", pressedMods},
+                        {"heldKeys", detail::heldKeysJson()}};
         });
 
-    tool("tc_key_release", "Release a key")
-        .arg<int>("key", "Key code (sokol_app keycode)")
-        .bind<int>([](int key) {
-            KeyEventArgs args;
-            args.key = key;
-            events().keyReleased.notify(args);
-            if (::trussc::internal::appKeyReleasedFunc)
-                ::trussc::internal::appKeyReleasedFunc(args);
-            return json{{"status", "ok"}};
+    tool("tc_key_release",
+         "Release a key (updates the held-key set that isKeyPressed() reads). "
+         "A modifier flag also releases that modifier's own key afterwards "
+         "(shift -> keycode 340, ctrl -> 341, alt -> 342, super -> 343), "
+         "mirroring tc_key_press")
+        .arg<int>("key", "Key code (sokol_app keycode; letters are uppercase ASCII: 'A'=65..'Z'=90)")
+        .arg<bool>("shift", "Also release Shift after this key", false)
+        .arg<bool>("ctrl", "Also release Ctrl after this key", false)
+        .arg<bool>("alt", "Also release Alt after this key", false)
+        .arg<bool>("super", "Also release Super/Command after this key", false)
+        .bind([](const json& a) -> json {
+            const int key = a.at("key").get<int>();
+
+            // The key goes up first — while the modifiers are still held, so
+            // this event still carries them (as it does on a real keyboard).
+            detail::injectKeyUp(key);
+
+            json releasedMods = json::array();
+            auto dropMod = [&](const char* flag, int code) {
+                if (a.value(flag, false) && isKeyPressed(code)) {
+                    detail::injectKeyUp(code);
+                    releasedMods.push_back(code);
+                }
+            };
+            dropMod("shift", SAPP_KEYCODE_LEFT_SHIFT);
+            dropMod("ctrl",  SAPP_KEYCODE_LEFT_CONTROL);
+            dropMod("alt",   SAPP_KEYCODE_LEFT_ALT);
+            dropMod("super", SAPP_KEYCODE_LEFT_SUPER);
+
+            return json{{"status", "ok"},
+                        {"modifiersReleased", releasedMods},
+                        {"heldKeys", detail::heldKeysJson()}};
         });
 
     // --- Node Tools ---

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -92,10 +92,30 @@ works, deprecated until v1.0.0.)
 | `tc_mouse_release` | `x`, `y`, `button` | Release — end of a drag gesture |
 | `tc_mouse_click` | `x`, `y`, `button`, `shift`/`ctrl`/`alt`/`super` (optional) | Click mouse button (0:left, 1:right), optionally with modifier keys held — e.g. `super: true` Cmd+clicks |
 | `tc_mouse_scroll` | `dx`, `dy` | Scroll mouse wheel |
-| `tc_key_press` | `key` | Press a key (sokol_app keycode) |
-| `tc_key_release` | `key` | Release a key |
+| `tc_key_press` | `key`, `shift`/`ctrl`/`alt`/`super` (optional) | Press a key (sokol_app keycode; letters are uppercase ASCII, `'A'`=65). A modifier flag presses that modifier's own key first, so both `e.shift` and `isShiftPressed()` see it |
+| `tc_key_release` | `key`, `shift`/`ctrl`/`alt`/`super` (optional) | Release a key; a modifier flag releases that modifier's own key afterwards |
 | `tc_select_node` | `id` | Select a node by instance id (0 clears); drives the same selection an inspector shows |
 | `tc_set_node_members` | `id`, `members`, `mod` (optional) | Set reflected members from a JSON object (same encoding as `tc_get_node_tree`; enums accept label string or int). Pass `mod` (a Mod's short type name, e.g. `"LayoutMod"`) to target a mod attached to the node instead of the node itself. Reports `applied` / `skipped` (type mismatch) / `readOnly` / `unknown` keys |
+
+Injected key events go through the same two channels a real key does: the
+`keyPressed` / `keyReleased` callbacks **and** the held-key set that
+`isKeyPressed()` / `isShiftPressed()` read — so an app that polls in `update()`
+reacts to injection just like it does to the keyboard. `tc_key_press` /
+`tc_key_release` reply with the resulting `heldKeys`, which is the quickest way
+to see the state an app is actually looking at.
+
+The modifier flags are shorthand for pressing that modifier's **own key**
+(`shift` → keycode 340, `ctrl` → 341, `alt` → 342, `super` → 343), the way a
+real keyboard does it — pair the same flag on press and release. To hold a
+modifier across several keys, press and release its keycode explicitly; the
+presses in between inherit it:
+
+```
+tc_key_press   {"key": 340}          # Shift down
+tc_key_press   {"key": 65}           # 'A' arrives with shift = true
+tc_key_release {"key": 65}
+tc_key_release {"key": 340}          # Shift up
+```
 
 The node tools make a scene **round-trippable for agents**: arrange things in a
 GUI (e.g. with the `tcxNodeInspector` addon's gizmo), then `tc_get_node_tree` to


### PR DESCRIPTION
## Problem

`tc_key_press` / `tc_key_release` only fired the `keyPressed` / `keyReleased`
callbacks. They never touched the held-key set behind `isKeyPressed()`, and never
filled the modifier flags on `KeyEventArgs`. Two things silently did nothing when
driving an app over MCP:

- Apps that poll `isKeyPressed()` / `isShiftPressed()` in `update()` were completely
  deaf to injected keys — no error, just nothing.
- Apps that branch on `e.shift` could not be driven at all. Pressing the modifier
  keycode separately produced an independent event; it did not affect the next press.

The mouse tools already anchor `currentWindowContext().mouseX/mouseY`, so the
keyboard was the odd one out.

## Fix

Both tools now go through shared inject helpers that mirror the real
`SAPP_EVENTTYPE_KEY_DOWN` / `KEY_UP` path step for step: derive modifiers → notify
listeners → update `keysPressed` → call the app/Node-tree callback.

The optional `shift` / `ctrl` / `alt` / `super` flags are shorthand for pressing or
releasing the modifier's **own key** (340/341/342/343), the way a real keyboard does
it. That keeps `e.shift` and `isShiftPressed()` from ever disagreeing, and keeps
ownership of the state symmetric — whoever presses releases. Holding a modifier
across several keys is still expressed by pressing/releasing its keycode explicitly;
the presses in between inherit it, because the flags are derived from the set.

Both tools reply with the resulting `heldKeys` so a caller can see the state the app
is actually reading.

## Verification

A small app calling `mcp::registerControlTools()`, logging both paths — `e.key`/
`e.shift` in the callback and `isKeyPressed()`/`isShiftPressed()` polled in
`update()` — driven over MCP HTTP:

- `tc_key_press {key:84, shift:true}` → callback `key=84 shift=1`, poll `T=1 shift=1`
- `tc_key_release {key:84, shift:true}` → poll back to `T=0 shift=0`, `heldKeys: []`
- Hold 340 → press/release 65 → press/release 84 → release 340: shift stays 1
  throughout, state ends clean
- Modifier flag while that modifier is already held: no duplicate press

Also checked against a real OS key event (`[down] key=343 … super=1`): a modifier's
own key-down carries its own flag, which is what the derivation reproduces.

## Scope

Core MCP tools + `docs/AI_AUTOMATION.md` only. No example or app-side key handling
touched.