### PR TITLE
fix(release): align Windows TRUSSC_DIR path with new core layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
         run: |
           cmake -B build `
             -DCMAKE_BUILD_TYPE=Release `
-            -DTRUSSC_DIR="${{ github.workspace }}/TrussC/trussc"
+            -DTRUSSC_DIR="${{ github.workspace }}/TrussC/core"
 
       - name: Build
         run: cmake --build build --config Release


### PR DESCRIPTION
## Summary

The Windows job in `.github/workflows/release.yml` still pointed at the old `TrussC/trussc` directory, while the macOS and Linux jobs, and every CMakeLists.txt template inside the same file, already use `TrussC/core`. This one leftover made the Windows leg of `release.yml` fail with `TRUSSC_DIR` not resolving. This PR is a **single-line change** that brings the Windows leg in line with the rest.

## Diff (only change in this PR)

```diff
             cmake -B build `
               -DCMAKE_BUILD_TYPE=Release `
-              -DTRUSSC_DIR=\"\${{ github.workspace }}/TrussC/trussc\"
+              -DTRUSSC_DIR=\"\${{ github.workspace }}/TrussC/core\"
```

Reference lines that already used `core` (unchanged, cited as justification):
- Line 115 (`macos:` job) — `-DTRUSSC_DIR=\"\${GITHUB_WORKSPACE}/TrussC/core\"`
- Line 336 (`linux:` job) — `-DTRUSSC_DIR=\"\${GITHUB_WORKSPACE}/TrussC/core\"`
- Lines 82 / 235 / 313 (auto-generated CMakeLists.txt templates) — `TRUSSC_DIR .../../core`

## Verification

### 1. `build.yml` on the synced fork — all platforms green

Fork was force-synced to `TrussC-org/TrussC@main` and then this one-line fix was pushed on top. The fork's own `build.yml` was triggered by that push and every job passed:

- Run: https://github.com/nariakiiwatani/TrussC/actions/runs/31095802760
- Result: **all jobs success** — ios / android / web / macOS / linux / **windows** / reference-check / changes / ci-ok

### 2. `release.yml` validated inline in a real downstream project (mac & win green)

We validated the fixed `release.yml` end-to-end from a private downstream application. The workflow file was copied verbatim into that private project (only the trigger and `inputs`→`env` mapping were adapted; the checkout / clone / configure / build / package steps are byte-identical to `release.yml`) and released via a tag push. Both jobs finished green:

- macOS job: success ✅
- **Windows job: success ✅** — CMake resolved `TRUSSC_DIR` against `TrussC/core` and built the application, which is the direct proof that this fix works in a real downstream project.

(Run URLs on the private side are omitted; the fork-side `build.yml` run linked above is fully public and independently reproduces the Windows result.)

## Scope

Single file, single line. No behavioral change on macOS or Linux. Only unblocks the Windows leg of `release.yml`.
