### PR TITLE
Font: fix the atlas lifetime and minified quality, add two opt-in sharpness knobs

### DIFF
--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -282,6 +282,10 @@ private:
         descent_ = descent * scale_;
         lineGap_ = lineGap * scale_;
 
+        // Kept so the draw path can fall back to them. See getRawAscent().
+        rawAscent_  = ascent_;
+        rawLineGap_ = lineGap_;
+
         // Vertical grid fit.
         //
         // A glyph outline has its baseline at font-unit y = 0, so the baseline
@@ -508,6 +512,26 @@ public:
     float getLineHeight() const { return ascent_ - descent_ + lineGap_; }
     float getAscent() const { return ascent_; }
     float getDescent() const { return descent_; }
+
+    // The font's own metrics, before grid fit (identical to the above when grid
+    // fit is off).
+    //
+    // Grid fit rounds a placement value in MODEL space, so it only lands the
+    // baseline on the pixel grid while one model unit is one device pixel.
+    // Under a non-integer scale it does the opposite of its job: a fitted
+    // ascent of, say, 13 puts every baseline at 6.5 device pixels when drawn at
+    // scale 0.5 -- the worst possible phase, on every line, in every frame,
+    // instead of the uniformly distributed phase an unfitted ascent gives. That
+    // is not a rounding-error-level effect; measured on Helvetica at scale 0.5
+    // it costs up to 13% of the energy concentration it wins back at 1:1.
+    //
+    // So the draw path asks for these whenever the transform is not 1:1. The
+    // public Font::getAscent()/getLineHeight() keep reporting the fitted values,
+    // because those describe the font as laid out, and a metric that changed
+    // with whatever transform happened to be current would be much worse to
+    // build a layout on.
+    float getRawAscent() const { return rawAscent_; }
+    float getRawLineHeight() const { return rawAscent_ - descent_ + rawLineGap_; }
     float getSpaceAdvance() const { return spaceAdvance_; }
     int getFontSize() const { return fontSize_; }
 
@@ -564,6 +588,8 @@ private:
     stbtt_fontinfo fontInfo_ = {};
     int fontSize_ = 0;
     float scale_ = 0;
+    float rawAscent_ = 0;    // pre-grid-fit; see getRawAscent()
+    float rawLineGap_ = 0;
     float ascent_ = 0;
     float descent_ = 0;
     float lineGap_ = 0;
@@ -1593,8 +1619,9 @@ protected:
         };
 
         float offsetY = 0;
-        float totalTextH = getLineHeight() * lineWidths.size();
-        float ascent = atlasManager_->getAscent() * s;
+        const float lineH = placementLineHeight();
+        float totalTextH = lineH * lineWidths.size();
+        float ascent = placementAscent();
         switch (v) {
             case Direction::Top:      offsetY = 0; break;
             case Direction::Baseline: offsetY = -ascent; break;
@@ -1612,7 +1639,7 @@ protected:
             if (cp == '\n') {
                 currentLine++;
                 cursorX = x + lineOffsetX(currentLine);
-                cursorY += getLineHeight();
+                cursorY += lineH;
                 continue;
             }
             if (cp == '\t') {
@@ -1733,8 +1760,8 @@ protected:
 
         const float s   = 1.0f / dpiScale_;
         const float em  = (float)logicalSize_;
-        const float asc = atlasManager_->getAscent() * s;
-        const float colSpacing = getLineHeight();
+        const float asc = placementAscent();
+        const float colSpacing = placementLineHeight();
         const float cellH = em;  // CJK vertical advance per cell
 
         // -------- Tokenize --------
@@ -2358,6 +2385,32 @@ public:
         return atlasManager_ ? atlasManager_->getDescent() / dpiScale_ : 0;
     }
 
+    // ---- Placement metrics (draw path) --------------------------------------
+    // Grid fit rounds in model space, so it only puts the baseline on the pixel
+    // grid while one model unit is one device pixel. Under any other transform
+    // it pins every baseline to a fixed bad phase instead of a uniformly
+    // distributed one, which measures worse than not fitting at all. So the
+    // draw path asks whether the fit actually lands before using it, and falls
+    // back to the font's own metrics when it does not. See
+    // FontAtlasManager::getRawAscent() for the numbers.
+    bool gridFitLands() const {
+        if (!atlasManager_ || !cacheKey_.gridFit) return false;
+        return std::fabs(getDefaultContext().getScale() - 1.0f) < 0.01f;
+    }
+
+    float placementAscent() const {
+        if (!atlasManager_) return 0;
+        return (gridFitLands() ? atlasManager_->getAscent()
+                               : atlasManager_->getRawAscent()) / dpiScale_;
+    }
+
+    float placementLineHeight() const {
+        if (lineHeight_ > 0) return lineHeight_;   // explicit setLineHeight wins
+        if (!atlasManager_) return 0;
+        return (gridFitLands() ? atlasManager_->getLineHeight()
+                               : atlasManager_->getRawLineHeight()) / dpiScale_;
+    }
+
     int getSize() const {
         return logicalSize_;
     }
@@ -2457,7 +2510,10 @@ private:
     float dpiScale_ = 1.0f;    // DPI scale at load time (physical/logical ratio)
     int oversample_ = defaultOversample_;   // desired; stamped into cacheKey_ on load
     bool mipmaps_ = true;                   // desired; stamped into cacheKey_ on load
-    bool gridFit_ = false;                  // desired; stamped into cacheKey_ on load
+    // On by default: it costs no memory and no draw-time work, is positive at
+    // 1:1 on every face and size measured, and stands down automatically under
+    // any other transform (see gridFitLands()).
+    bool gridFit_ = true;                   // desired; stamped into cacheKey_ on load
 
     // 4x4 already costs 16x the atlas; beyond that the prefilter gains nothing
     // a bigger font size would not give more cheaply.

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -898,6 +898,20 @@ public:
         cache_.erase(key);
     }
 
+    // Drop a cached atlas, but only when this cache holds the last reference.
+    // Called when a Font reloads at a different key: the cache owns a strong
+    // ref and nothing else ever evicts, so without this every size a Font
+    // visits stays resident for the process lifetime (a size slider walking
+    // 16..40 leaves 25 atlases behind). use_count() == 1 means "only the cache
+    // is holding it", so a Font still using this atlas is never freed from
+    // under it.
+    void releaseIfUnused(const FontCacheKey& key) {
+        auto it = cache_.find(key);
+        if (it != cache_.end() && it->second.use_count() == 1) {
+            cache_.erase(it);
+        }
+    }
+
     // Release all
     void clear() {
         cache_.clear();
@@ -976,6 +990,15 @@ public:
             }
         }
 
+        // What this Font was holding before, so a reload at a different key can
+        // hand the previous atlas back to the cache. Note this is deliberately
+        // NOT done in ~Font(): a Font constructed and destroyed every frame
+        // would then re-rasterize its whole atlas every frame, turning a merely
+        // wasteful pattern into a stall. Keeping unreferenced atlases cached is
+        // what a cache is for; only a *reload* has a known-dead predecessor.
+        const internal::FontCacheKey previousKey = cacheKey_;
+        const bool hadAtlas = (atlasManager_ != nullptr);
+
         cacheKey_.fontPath = actualPath;
         cacheKey_.fontSize = physicalSize;
 
@@ -991,6 +1014,12 @@ public:
 #endif
         } else {
             atlasManager_ = internal::SharedFontCache::getInstance().getOrCreate(cacheKey_);
+        }
+
+        // The assignment above dropped this Font's reference to its previous
+        // atlas. If nothing else holds it, let the cache go too.
+        if (hadAtlas && !(previousKey == cacheKey_)) {
+            internal::SharedFontCache::getInstance().releaseIfUnused(previousKey);
         }
 
         if (!atlasManager_) {

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -841,29 +841,14 @@ private:
         // coarse mips bleed slightly between neighbours, but that range is
         // sub-pixel on screen and far preferable to shimmer.)
         std::vector<std::vector<uint8_t>> lowerMips;   // levels 1..N (level 0 = atlas.pixels_)
-        // PROVISIONAL: mipmaps are skipped while oversampling is on.
-        //
-        // The two are complementary, not conflicting -- oversampling wins at
-        // 1:1 and above, mipmaps own minification, which is precisely where
-        // oversampling makes aliasing worse (measured: phase-sweep shimmer on
-        // 16px text at scale(0.5) goes 1.21% -> 2.29% at oversample 2). What
-        // stops them combining today is LOD *selection*, not the mip content:
-        // an NxN atlas is N times denser than the screen, so a 1:1 draw sits at
-        // LOD log2(N) and the GPU reads a mip no better than an un-oversampled
-        // atlas -- the oversampling is paid for and then discarded.
-        //
-        // The fix is to pick the sampler from the effective scale
-        // (RenderContext::getScale(), already used this way for adaptive curve
-        // tessellation): max_lod = 0 at 1:1 and above, full mip chain below.
-        // Until that lands, silently doing both would cost the memory of both
-        // and deliver neither, so prefer the one the caller asked for last.
-        if (wantMipmaps_ && oversample_ > 1) {
-            logWarning("Font") << "mipmaps skipped while oversampling ("
-                               << oversample_ << "x) is on: mip selection would "
-                                  "discard the oversampling at 1:1. Pending "
-                                  "scale-aware sampler selection.";
-        }
-        if (wantMipmaps_ && oversample_ == 1) {
+        // Oversampling and mipmapping compose: oversampling owns 1:1 and above,
+        // the mip chain owns minification -- which is exactly where a denser
+        // atlas would otherwise make aliasing worse. pickSampler() keeps the
+        // GPU on mip 0 while the modelview is not minifying, so the mips below
+        // are only ever reached when they are the right answer. On an NxN
+        // atlas the chain also lands better than on a 1x one: drawing at 1/N
+        // scale reads mip log2(N), whose resolution matches the target exactly.
+        if (wantMipmaps_) {
             int numMips = 1;
             for (int mw = atlas.width_, mh = atlas.height_; mw > 1 || mh > 1; ) {
                 mw = std::max(1, mw / 2);
@@ -1046,27 +1031,49 @@ public:
         n = clampOversample(n);
         if (n == oversample_) return *this;      // nothing to rebuild
         oversample_ = n;
-
-        if (!atlasManager_) {                    // applied by the next load()
-            cacheKey_.oversample = n;
-            return *this;
-        }
-        if (isUrl(cacheKey_.fontPath)) {
-            // The bytes live in the async-fetch cache entry, not on disk, so we
-            // cannot re-rasterize from here. Record it for the next load().
-            logWarning("Font") << "setOversampling on a URL-loaded font takes "
-                                  "effect on the next load()";
-            return *this;
-        }
-
-        const internal::FontCacheKey previousKey = cacheKey_;
-        cacheKey_.oversample = n;
-        atlasManager_ = internal::SharedFontCache::getInstance().getOrCreate(cacheKey_);
-        internal::SharedFontCache::getInstance().releaseIfUnused(previousKey);
+        reresolveAtlas([n](internal::FontCacheKey& k) { k.oversample = n; },
+                       "setOversampling");
         return *this;
     }
     int getOversampling() const { return oversample_; }
 
+    // Build a mip chain for the atlas. Only reached when the text is actually
+    // minified (pickSampler pins mip 0 at 1:1 and above), so this is what stops
+    // small/distant text from shimmering without softening it anywhere else.
+    Font& setMipmaps(bool enabled) {
+        if (enabled == mipmaps_) return *this;
+        mipmaps_ = enabled;
+        reresolveAtlas([enabled](internal::FontCacheKey& k) { k.mipmaps = enabled; },
+                       "setMipmaps");
+        return *this;
+    }
+    bool getMipmaps() const { return mipmaps_; }
+
+    // Apply an atlas-option change to the cache key and swap in the atlas it
+    // now names. Called from the option setters so they are order-independent:
+    // a setter that only takes effect when it precedes load() is the kind of
+    // trap that leaves a feature quietly doing nothing.
+    template <class ApplyToKey>
+    void reresolveAtlas(ApplyToKey apply, const char* who) {
+        if (!atlasManager_) {                    // picked up by the next load()
+            apply(cacheKey_);
+            return;
+        }
+        if (isUrl(cacheKey_.fontPath)) {
+            // The bytes live in the async-fetch cache entry, not on disk, so we
+            // cannot re-rasterize from here. Record it for the next load().
+            logWarning("Font") << who << " on a URL-loaded font takes effect on "
+                                         "the next load()";
+            apply(cacheKey_);
+            return;
+        }
+        const internal::FontCacheKey previousKey = cacheKey_;
+        apply(cacheKey_);
+        atlasManager_ = internal::SharedFontCache::getInstance().getOrCreate(cacheKey_);
+        internal::SharedFontCache::getInstance().releaseIfUnused(previousKey);
+    }
+
+public:
     LoadResult load(const fs::path& nameOrPath, int size) {
         // Render glyphs at physical pixel size for sharp text on HiDPI displays.
         // All metrics/drawing are scaled back to logical coordinates.
@@ -1112,6 +1119,7 @@ public:
         cacheKey_.fontPath = actualPath;
         cacheKey_.fontSize = physicalSize;
         cacheKey_.oversample = oversample_;
+        cacheKey_.mipmaps = mipmaps_;
 
         if (isUrl(actualPath)) {
 #ifdef __EMSCRIPTEN__
@@ -1540,7 +1548,7 @@ protected:
             // the old font pipeline (dst_factor_alpha=ZERO destroyed dst alpha).
             internal::loadPipeline(internal::activeFill2D());
             sgl_enable_texture();
-            sgl_texture(atlas.getView(), sampler_);
+            sgl_texture(atlas.getView(), pickSampler(atlasManager_->getOversample()));
 
             Color col = getColor();
             sgl_c4f(col.r, col.g, col.b, col.a);
@@ -2333,8 +2341,9 @@ public:
         return atlasManager_ ? &atlasManager_->getAtlas(index) : nullptr;
     }
 
-    // Get shared sampler (for debug atlas rendering)
-    sg_sampler getSampler() { initResources(); return sampler_; }
+    // Get shared sampler (for debug atlas rendering). Returns the mip-0-pinned
+    // one: a debug view of the atlas wants to show the texels as stored.
+    sg_sampler getSampler() { initResources(); return samplerSharp_; }
 
     size_t getLoadedGlyphCount() const {
         return atlasManager_ ? atlasManager_->getLoadedGlyphCount() : 0;
@@ -2349,6 +2358,7 @@ private:
     internal::FontCacheKey cacheKey_;
     float dpiScale_ = 1.0f;    // DPI scale at load time (physical/logical ratio)
     int oversample_ = defaultOversample_;   // desired; stamped into cacheKey_ on load
+    bool mipmaps_ = false;                  // desired; stamped into cacheKey_ on load
 
     // 4x4 already costs 16x the atlas; beyond that the prefilter gains nothing
     // a bigger font size would not give more cheaply.
@@ -2359,18 +2369,62 @@ private:
     // Shared GPU resources. The TTF draw path loads the active per-target 2D
     // fill pipeline (internal::activeFill2D()) at draw time, so the font class
     // only needs its own sampler here.
-    static inline sg_sampler sampler_ = {};
+    static inline sg_sampler samplerSharp_ = {};    // max_lod 0 (1:1 and above)
+    static inline sg_sampler samplerMipped_ = {};   // full chain (minified)
     static inline bool resourcesInitialized_ = false;
+
+    // Minified text wants the mip chain; everything sharper wants the
+    // oversampled mip 0. The quantity that decides it is texels per screen
+    // pixel: the quad covers width*oversample texels and width/dpiScale *
+    // getScale() * dpiScale screen pixels, so the dpiScale cancels and it is
+    // just oversample/getScale().
+    //
+    // The threshold is 2, not 1, because a bilinear fetch reads a 2x2
+    // neighbourhood and copes with 2:1 on its own. Measured on 16px text
+    // (phase-sweep shimmer, un-oversampled atlas): at 2 texels/px mip 0 is
+    // actually BETTER (1.05% vs 1.16% — the mip chain only adds blur where
+    // nothing was broken), while at 4 it is not close (9.79% vs 2.95%) and it
+    // keeps growing from there (16 texels/px: 28.4% vs 13.6%).
+    //
+    // getScale() takes the same shortcuts the adaptive curve tessellator
+    // already accepts (tcRenderContext.h): column lengths approximate rotation
+    // and shear, and perspective is not considered. Choosing a mip level is a
+    // far more forgiving use of that estimate than choosing a segment count.
+    static sg_sampler pickSampler(int oversample) {
+        const float scale = getDefaultContext().getScale();
+        const float texelsPerPixel = (scale > 0.0f) ? (oversample / scale)
+                                                    : (float)oversample;
+        return (texelsPerPixel <= 2.0f) ? samplerSharp_ : samplerMipped_;
+    }
 
     void initResources() {
         if (resourcesInitialized_) return;
 
+        // Two samplers, picked per draw by the effective scale (see
+        // pickSampler). Trilinear on both: without mipmap_filter sokol defaults
+        // to NEAREST, which snaps to the nearest level and makes a 0.6x draw
+        // jump to the half-resolution mip and magnify it back up -- visibly
+        // soft, with a pop at the boundary. Texture already sets LINEAR here
+        // (tcTexture.h); the font path was the outlier.
         sg_sampler_desc smp_desc = {};
         smp_desc.min_filter = SG_FILTER_LINEAR;
         smp_desc.mag_filter = SG_FILTER_LINEAR;
+        smp_desc.mipmap_filter = SG_FILTER_LINEAR;
         smp_desc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
         smp_desc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
-        sampler_ = sg_make_sampler(&smp_desc);
+        samplerMipped_ = sg_make_sampler(&smp_desc);
+
+        // Pinned to mip 0. An NxN atlas is N times denser than the screen, so
+        // even a 1:1 draw computes LOD log2(N) and would read a mip that throws
+        // the oversampling away. Clamping the LOD is how the denser atlas gets
+        // to be denser. Harmless on a mip-less atlas -- there is only level 0.
+        //
+        // NOT 0.0f: sokol treats a zero max_lod as "unset" and substitutes
+        // FLT_MAX (_sg_sampler_desc_defaults), so asking for exactly mip 0
+        // silently asks for the whole chain. A small epsilon reads as an
+        // explicit value and still floors to level 0 under trilinear.
+        smp_desc.max_lod = 0.01f;
+        samplerSharp_ = sg_make_sampler(&smp_desc);
 
         resourcesInitialized_ = true;
     }

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -103,12 +103,14 @@ struct FontCacheKey {
     int fontSize;
     bool mipmaps = true;    // allowed to build a mip chain (built lazily on first minified draw)
     int oversample = 1;     // rasterize NxN finer, then box-prefilter back down
-    bool gridFit = false;   // nudge scale so the ascent lands on a whole pixel
+
+    // Grid fit is deliberately absent: it is a draw-time placement decision
+    // (see Font::fitY) and does not touch the atlas, so two fonts that differ
+    // only in gridFit can and should share one.
 
     bool operator==(const FontCacheKey& other) const {
         return fontPath == other.fontPath && fontSize == other.fontSize
-            && mipmaps == other.mipmaps && oversample == other.oversample
-            && gridFit == other.gridFit;
+            && mipmaps == other.mipmaps && oversample == other.oversample;
     }
 };
 
@@ -118,8 +120,7 @@ struct FontCacheKeyHash {
         size_t h2 = std::hash<int>()(key.fontSize);
         size_t h3 = std::hash<bool>()(key.mipmaps);
         size_t h4 = std::hash<int>()(key.oversample);
-        size_t h5 = std::hash<bool>()(key.gridFit);
-        return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3) ^ (h5 << 4);
+        return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3);
     }
 };
 
@@ -197,7 +198,7 @@ public:
     // -------------------------------------------------------------------------
     // Initialization
     // -------------------------------------------------------------------------
-    bool setup(const std::string& fontPath, int fontSize, bool gridFit = false) {
+    bool setup(const std::string& fontPath, int fontSize) {
         cleanup();
 
         // Load font file (fontPath is UTF-8 — convert so non-ASCII paths
@@ -216,16 +217,16 @@ public:
             return false;
         }
 
-        return initFromFontData(fontSize, gridFit);
+        return initFromFontData(fontSize);
     }
 
-    bool setupFromMemory(const uint8_t* data, size_t size, int fontSize, bool gridFit = false) {
+    bool setupFromMemory(const uint8_t* data, size_t size, int fontSize) {
         cleanup();
 
         fontData_.resize(size);
         std::memcpy(fontData_.data(), data, size);
 
-        return initFromFontData(fontSize, gridFit);
+        return initFromFontData(fontSize);
     }
 
     // Opt-in mipmapping. Must be set before glyphs are uploaded (the atlas
@@ -255,7 +256,7 @@ public:
     int getOversample() const { return oversample_; }
 
 private:
-    bool initFromFontData(int fontSize, bool gridFit, int fontIndex = 0) {
+    bool initFromFontData(int fontSize, int fontIndex = 0) {
         // Get font offset (required for .ttc files with multiple fonts)
         int offset = stbtt_GetFontOffsetForIndex(fontData_.data(), fontIndex);
         if (offset < 0) {
@@ -282,49 +283,9 @@ private:
         descent_ = descent * scale_;
         lineGap_ = lineGap * scale_;
 
-        // Kept so the draw path can fall back to them. See getRawAscent().
-        rawAscent_  = ascent_;
-        rawLineGap_ = lineGap_;
-
-        // Vertical grid fit.
-        //
-        // A glyph outline has its baseline at font-unit y = 0, so the baseline
-        // is a texel boundary in the atlas at ANY scale -- the rasterizer never
-        // splits it. What decides whether that survives to the screen is where
-        // the bitmap is placed: with the default Direction::Top the baseline
-        // lands at y + ascent, so a fractional ascent drags every glyph on the
-        // line off the pixel grid and the horizontal strokes smear no matter
-        // how good the atlas is.
-        //
-        // ascent_ is a PLACEMENT quantity: it is the offset from the top of the
-        // line box down to the baseline, and it never reaches the rasterizer
-        // (which works from scale_ via GetGlyphBitmapBox / MakeGlyphBitmap). So
-        // rounding it is enough, and nothing else moves -- glyph bitmaps,
-        // advances and line width are all bit-identical to the unfitted font.
-        // The only thing given up is that the text sits up to half a pixel off
-        // the ascent the font declares, which is invisible and costs no ink.
-        if (gridFit) {
-            const float fittedAscent = std::round(ascent_);
-            if (fittedAscent >= 1.0f) ascent_ = fittedAscent;
-        }
-
-        // Whole ascent alone only aligns the FIRST line: forEachGlyph advances
-        // by getLineHeight() per newline, and (ascent - descent + lineGap) *
-        // scale is fractional independently of the ascent. On Hiragino at 21px
-        // the line height is 31.5, so grid fitting the ascent produced perfect
-        // odd lines and worst-case (half-pixel) even ones — measurably worse
-        // overall than not fitting at all.
-        //
-        // Line height is a layout quantity too: rounding it moves the next
-        // baseline and nothing else, so every line inherits the first line's
-        // alignment.
-        if (gridFit) {
-            const float lh = ascent_ - descent_ + lineGap_;
-            const float lhRounded = std::round(lh);
-            if (lhRounded >= 1.0f) {
-                lineGap_ += (lhRounded - lh);
-            }
-        }
+        // Note: the metrics reported here are the font's own, always. Grid fit
+        // does not live at load time -- it is a draw-time decision made per
+        // baseline against the live transform. See Font::fitY().
 
         // Get space advance
         int spaceIndex = stbtt_FindGlyphIndex(&fontInfo_, ' ');
@@ -513,25 +474,6 @@ public:
     float getAscent() const { return ascent_; }
     float getDescent() const { return descent_; }
 
-    // The font's own metrics, before grid fit (identical to the above when grid
-    // fit is off).
-    //
-    // Grid fit rounds a placement value in MODEL space, so it only lands the
-    // baseline on the pixel grid while one model unit is one device pixel.
-    // Under a non-integer scale it does the opposite of its job: a fitted
-    // ascent of, say, 13 puts every baseline at 6.5 device pixels when drawn at
-    // scale 0.5 -- the worst possible phase, on every line, in every frame,
-    // instead of the uniformly distributed phase an unfitted ascent gives. That
-    // is not a rounding-error-level effect; measured on Helvetica at scale 0.5
-    // it costs up to 13% of the energy concentration it wins back at 1:1.
-    //
-    // So the draw path asks for these whenever the transform is not 1:1. The
-    // public Font::getAscent()/getLineHeight() keep reporting the fitted values,
-    // because those describe the font as laid out, and a metric that changed
-    // with whatever transform happened to be current would be much worse to
-    // build a layout on.
-    float getRawAscent() const { return rawAscent_; }
-    float getRawLineHeight() const { return rawAscent_ - descent_ + rawLineGap_; }
     float getSpaceAdvance() const { return spaceAdvance_; }
     int getFontSize() const { return fontSize_; }
 
@@ -588,8 +530,6 @@ private:
     stbtt_fontinfo fontInfo_ = {};
     int fontSize_ = 0;
     float scale_ = 0;
-    float rawAscent_ = 0;    // pre-grid-fit; see getRawAscent()
-    float rawLineGap_ = 0;
     float ascent_ = 0;
     float descent_ = 0;
     float lineGap_ = 0;
@@ -1019,7 +959,7 @@ public:
         }
 
         auto manager = std::make_shared<FontAtlasManager>();
-        if (!manager->setup(key.fontPath, key.fontSize, key.gridFit)) {
+        if (!manager->setup(key.fontPath, key.fontSize)) {
             return nullptr;
         }
         manager->setMipmaps(key.mipmaps);
@@ -1038,7 +978,7 @@ public:
         }
 
         auto manager = std::make_shared<FontAtlasManager>();
-        if (!manager->setupFromMemory(data, size, key.fontSize, key.gridFit)) {
+        if (!manager->setupFromMemory(data, size, key.fontSize)) {
             return nullptr;
         }
         manager->setMipmaps(key.mipmaps);
@@ -1138,31 +1078,31 @@ public:
     }
     int getOversampling() const { return oversample_; }
 
-    // Allow a mip chain for this atlas. On by default and built lazily: nothing
-    // is generated until a draw actually samples below the bilinear-safe rate,
-    // so apps that never minify text pay nothing. Turn it off to trade shimmer
-    // on small/distant text for ~33% less atlas memory and no rebuild cost.
-    // Nudge the rasterization scale (by up to a few percent) so the ascent is a
-    // whole number of pixels. With the default Direction::Top that puts the
-    // baseline -- and with it every glyph bitmap on the line -- on the pixel
-    // grid, which is what lets the atlas's own alignment reach the screen.
-    // Costs nothing: no extra memory, no draw-time work, and unlike rounding
-    // quads it cannot misfire under a transform, because nothing about it
-    // depends on the modelview.
+    // Round each baseline to a whole pixel at draw time. With the default
+    // Direction::Top the baseline lands at y + ascent, and a fractional ascent
+    // drags every glyph bitmap on the line off the pixel grid -- the horizontal
+    // strokes then smear no matter how good the atlas is. Snapping the baseline
+    // is what lets the atlas's own alignment reach the screen.
     //
-    // The trade is that the requested size is honoured approximately: ask for
-    // 16 and the glyphs may be rasterized at 15.6 or 16.4. Metrics stay
-    // self-consistent (getWidth/getLineHeight report the fitted values), so
-    // only layout pinned to hard-coded numbers would notice.
+    // Costs nothing: no extra memory, no reload, one round() per line. It also
+    // cannot misfire under a transform, because it stands down when the
+    // transform is not 1:1 (see fitY).
+    //
+    // The trade is that a line sits up to half a pixel off the baseline the
+    // font declares. Nothing else moves: glyph bitmaps, advances, line widths
+    // and the reported metrics are all identical to an unfitted font, so the
+    // text occupies the same box and drifts no further than that half pixel no
+    // matter how many lines it runs to.
     Font& setGridFit(bool enabled) {
-        if (enabled == gridFit_) return *this;
         gridFit_ = enabled;
-        reresolveAtlas([enabled](internal::FontCacheKey& k) { k.gridFit = enabled; },
-                       "setGridFit");
         return *this;
     }
     bool getGridFit() const { return gridFit_; }
 
+    // Allow a mip chain for this atlas. On by default and built lazily: nothing
+    // is generated until a draw actually samples below the bilinear-safe rate,
+    // so apps that never minify text pay nothing. Turn it off to trade shimmer
+    // on small/distant text for ~33% less atlas memory and no rebuild cost.
     Font& setMipmaps(bool enabled) {
         if (enabled == mipmaps_) return *this;
         mipmaps_ = enabled;
@@ -1243,7 +1183,6 @@ public:
         cacheKey_.fontSize = physicalSize;
         cacheKey_.oversample = oversample_;
         cacheKey_.mipmaps = mipmaps_;
-        cacheKey_.gridFit = gridFit_;
 
         if (isUrl(actualPath)) {
 #ifdef __EMSCRIPTEN__
@@ -1619,9 +1558,9 @@ protected:
         };
 
         float offsetY = 0;
-        const float lineH = placementLineHeight();
+        const float lineH = getLineHeight();
         float totalTextH = lineH * lineWidths.size();
-        float ascent = placementAscent();
+        float ascent = getAscent();
         switch (v) {
             case Direction::Top:      offsetY = 0; break;
             case Direction::Baseline: offsetY = -ascent; break;
@@ -1630,16 +1569,22 @@ protected:
             default: break;
         }
 
+        // Baseline of line n. Accumulated from the anchor, then snapped once --
+        // see fitY() for why stepping by a snapped line height is wrong.
+        auto baselineOf = [&](int lineIdx) -> float {
+            return y + fitY(offsetY + ascent + lineH * (float)lineIdx);
+        };
+
         int currentLine = 0;
         float cursorX = x + lineOffsetX(0);
-        float cursorY = y + offsetY + ascent;
+        float cursorY = baselineOf(0);
 
         for (size_t i = 0; i < text.size(); ) {
             uint32_t cp = decodeUTF8(text, i);
             if (cp == '\n') {
                 currentLine++;
                 cursorX = x + lineOffsetX(currentLine);
-                cursorY += lineH;
+                cursorY = baselineOf(currentLine);
                 continue;
             }
             if (cp == '\t') {
@@ -1760,8 +1705,8 @@ protected:
 
         const float s   = 1.0f / dpiScale_;
         const float em  = (float)logicalSize_;
-        const float asc = placementAscent();
-        const float colSpacing = placementLineHeight();
+        const float asc = getAscent();
+        const float colSpacing = getLineHeight();
         const float cellH = em;  // CJK vertical advance per cell
 
         // -------- Tokenize --------
@@ -1873,6 +1818,17 @@ protected:
         float  colX        = colX0;
         float  colCenterX  = colX - em / 2.f;
         float  colY        = colYStart(0);
+        float  colTop      = colY;   // anchor fitY() accumulates from
+
+        // Baseline for an upright glyph whose cell starts at cellTop. Snapped
+        // once, from the top of the column -- see fitY().
+        //
+        // Rotated glyphs are left alone: their baseline runs vertically after
+        // the rotation, so moving baselineY moves them ACROSS the column rather
+        // than along it, and grid fit has nothing to say about that axis.
+        auto uprightBaseline = [&](float cellTop) -> float {
+            return colTop + fitY(cellTop - colTop + asc);
+        };
 
         for (const auto& t : toks) {
             if (t.kind == VTokKind_::Newline) {
@@ -1880,6 +1836,7 @@ protected:
                 colX       -= colSpacing;
                 colCenterX  = colX - em / 2.f;
                 colY        = colYStart(colIdx);
+                colTop      = colY;
                 continue;
             }
 
@@ -1897,7 +1854,7 @@ protected:
                     const internal::GlyphInfo* g = atlasManager_->getOrLoadGlyph(useCp);
                     if (g && g->isValid()) {
                         float drawX = colCenterX - g->getAdvance() * s / 2.f;
-                        float baselineY = colY + asc;
+                        float baselineY = uprightBaseline(colY);
                         // Fallback offset for Tu without vertical form.
                         if (vo == internal::VertOrient::Tu && !hasVert) {
                             internal::VertOffset off = internal::getVerticalPunctOffset(cp);
@@ -1944,7 +1901,7 @@ protected:
                         const internal::GlyphInfo* g = atlasManager_->getOrLoadGlyph(cp);
                         if (g && g->isValid()) {
                             float drawX = colCenterX - g->getAdvance() * s / 2.f;
-                            float baselineY = colY + asc;
+                            float baselineY = uprightBaseline(colY);
                             visitor(PlacedGlyph{cp, drawX, baselineY, 0.f, 0.f, 0.f, 1.f});
                         }
                         colY += cellH;
@@ -1957,7 +1914,7 @@ protected:
                     const float scaledW = rw * xscale;
                     const float cellLeft = colCenterX - em / 2.f;
                     float cursorX = cellLeft + (em - scaledW) / 2.f;
-                    float baselineY = colY + asc;
+                    float baselineY = uprightBaseline(colY);
                     for (uint32_t cp : t.cps) {
                         const internal::GlyphInfo* g = atlasManager_->getOrLoadGlyph(cp);
                         if (!g || !g->isValid()) continue;
@@ -2390,34 +2347,36 @@ public:
     }
 
 protected:
-    // ---- Placement metrics (draw path) --------------------------------------
-    // Internal: these answer "where does this draw actually put the baseline",
-    // which is not the same question as getAscent()/getLineHeight() and is not
-    // something a caller should have to reason about.
-    //
-    // Grid fit rounds in model space, so it only puts the baseline on the pixel
-    // grid while one model unit is one device pixel. Under any other transform
-    // it pins every baseline to a fixed bad phase instead of a uniformly
-    // distributed one, which measures worse than not fitting at all. So the
-    // draw path asks whether the fit actually lands before using it, and falls
-    // back to the font's own metrics when it does not. See
-    // FontAtlasManager::getRawAscent() for the numbers.
+    // ---- Grid fit (draw path) -----------------------------------------------
+    // Whether snapping a baseline to a whole model unit actually puts it on the
+    // pixel grid. Rounding happens in MODEL space, so it only lands while one
+    // model unit is one device pixel. Under any other scale it does the
+    // opposite of its job: a snapped baseline at, say, y = 13 sits at 6.5
+    // device pixels when drawn at scale 0.5 -- the worst possible phase, on
+    // every line, in every frame, instead of the uniformly distributed phase an
+    // unsnapped baseline gives. That is not a rounding-error-level effect;
+    // measured on Helvetica at scale 0.5 it costs up to 13% of the energy
+    // concentration it wins back at 1:1. So grid fit stands down off 1:1.
     bool gridFitLands() const {
-        if (!atlasManager_ || !cacheKey_.gridFit) return false;
+        if (!gridFit_) return false;
         return std::fabs(getDefaultContext().getScale() - 1.0f) < 0.01f;
     }
 
-    float placementAscent() const {
-        if (!atlasManager_) return 0;
-        return (gridFitLands() ? atlasManager_->getAscent()
-                               : atlasManager_->getRawAscent()) / dpiScale_;
-    }
-
-    float placementLineHeight() const {
-        if (lineHeight_ > 0) return lineHeight_;   // explicit setLineHeight wins
-        if (!atlasManager_) return 0;
-        return (gridFitLands() ? atlasManager_->getLineHeight()
-                               : atlasManager_->getRawLineHeight()) / dpiScale_;
+    // Snap a baseline offset to the pixel grid.
+    //
+    // Callers must pass the offset ACCUMULATED from the anchor (ascent +
+    // n * lineHeight), not a per-line delta, and must round once. Rounding the
+    // line height instead and stepping by it would compound: at lineHeight
+    // 11.66 the block would run 0, 12, 24, 36 and end a whole pixel below where
+    // the text is supposed to be. Accumulating first gives 0, 12, 23, 35 --
+    // every baseline on the grid AND the block never more than half a pixel
+    // from its true height, however many lines it runs to.
+    //
+    // The offset is snapped rather than the final position so that a caller
+    // animating y still gets smooth sub-pixel motion instead of whole-pixel
+    // judder; what is fixed is the spacing within the block.
+    float fitY(float offsetFromAnchor) const {
+        return gridFitLands() ? std::round(offsetFromAnchor) : offsetFromAnchor;
     }
 
     // -------------------------------------------------------------------------
@@ -2514,10 +2473,11 @@ private:
     float dpiScale_ = 1.0f;    // DPI scale at load time (physical/logical ratio)
     int oversample_ = defaultOversample_;   // desired; stamped into cacheKey_ on load
     bool mipmaps_ = true;                   // desired; stamped into cacheKey_ on load
-    // On by default: it costs no memory and no draw-time work, is positive at
-    // 1:1 on every face and size measured, and stands down automatically under
-    // any other transform (see gridFitLands()).
-    bool gridFit_ = true;                   // desired; stamped into cacheKey_ on load
+    // On by default: it costs no memory and one round() per line, is positive
+    // at 1:1 on every face and size measured, and stands down automatically
+    // under any other transform (see gridFitLands()). Not part of cacheKey_ --
+    // it is a placement decision and never reaches the atlas.
+    bool gridFit_ = true;
 
     // 4x4 already costs 16x the atlas; beyond that the prefilter gains nothing
     // a bigger font size would not give more cheaply.

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -101,7 +101,7 @@ namespace internal {
 struct FontCacheKey {
     std::string fontPath;
     int fontSize;
-    bool mipmaps = false;   // opt-in: build a mip chain so minified glyphs don't shimmer
+    bool mipmaps = true;    // allowed to build a mip chain (built lazily on first minified draw)
     int oversample = 1;     // rasterize NxN finer, then box-prefilter back down
 
     bool operator==(const FontCacheKey& other) const {
@@ -228,6 +228,23 @@ public:
     // Opt-in mipmapping. Must be set before glyphs are uploaded (the atlas
     // texture is (re)built lazily in updateAtlasTexture, which reads this).
     void setMipmaps(bool enabled) { wantMipmaps_ = enabled; }
+
+    // Called from the draw path the first time this atlas is sampled below the
+    // bilinear-safe rate. Building the chain eagerly would tax every app that
+    // never minifies: the atlas texture is destroyed and recreated on every new
+    // glyph (see updateAtlasTexture), so a mip chain means re-walking ~1.33x
+    // the atlas on the CPU each time a fresh glyph shows up -- which for CJK is
+    // most frames during warm-up. Deferring it makes the cost land only on apps
+    // that actually draw small text, and only once.
+    void requestMipmaps() {
+        if (!wantMipmaps_ || mipsBuilt_) return;
+        mipsBuilt_ = true;
+        for (auto& atlas : atlases_) atlas.textureDirty_ = true;
+        // Fires at most once per atlas, and marks a real one-off cost (~33%
+        // more atlas texture, plus a rebuild), so it is worth saying out loud.
+        logNotice("Font") << "text drawn minified — building glyph atlas mipmaps";
+    }
+    bool hasMipmaps() const { return mipsBuilt_; }
 
     // Must be set before any glyph is rasterized (glyphs are lazy, so setting
     // it right after setup() is early enough). Clamped to at least 1.
@@ -510,7 +527,8 @@ private:
 
     // Atlases
     std::vector<AtlasState> atlases_;
-    bool wantMipmaps_ = false;   // opt-in mip chain (set via setMipmaps before upload)
+    bool wantMipmaps_ = true;    // mip chain allowed (opt out via Font::setMipmaps)
+    bool mipsBuilt_ = false;     // ...and actually needed, i.e. something minified
     int oversample_ = 1;         // NxN supersampling of the rasterized glyph
 
     // Glyph cache
@@ -848,7 +866,7 @@ private:
         // are only ever reached when they are the right answer. On an NxN
         // atlas the chain also lands better than on a 1x one: drawing at 1/N
         // scale reads mip log2(N), whose resolution matches the target exactly.
-        if (wantMipmaps_) {
+        if (wantMipmaps_ && mipsBuilt_) {
             int numMips = 1;
             for (int mw = atlas.width_, mh = atlas.height_; mw > 1 || mh > 1; ) {
                 mw = std::max(1, mw / 2);
@@ -1037,9 +1055,10 @@ public:
     }
     int getOversampling() const { return oversample_; }
 
-    // Build a mip chain for the atlas. Only reached when the text is actually
-    // minified (pickSampler pins mip 0 at 1:1 and above), so this is what stops
-    // small/distant text from shimmering without softening it anywhere else.
+    // Allow a mip chain for this atlas. On by default and built lazily: nothing
+    // is generated until a draw actually samples below the bilinear-safe rate,
+    // so apps that never minify text pay nothing. Turn it off to trade shimmer
+    // on small/distant text for ~33% less atlas memory and no rebuild cost.
     Font& setMipmaps(bool enabled) {
         if (enabled == mipmaps_) return *this;
         mipmaps_ = enabled;
@@ -1548,7 +1567,7 @@ protected:
             // the old font pipeline (dst_factor_alpha=ZERO destroyed dst alpha).
             internal::loadPipeline(internal::activeFill2D());
             sgl_enable_texture();
-            sgl_texture(atlas.getView(), pickSampler(atlasManager_->getOversample()));
+            sgl_texture(atlas.getView(), pickSampler());
 
             Color col = getColor();
             sgl_c4f(col.r, col.g, col.b, col.a);
@@ -2358,7 +2377,7 @@ private:
     internal::FontCacheKey cacheKey_;
     float dpiScale_ = 1.0f;    // DPI scale at load time (physical/logical ratio)
     int oversample_ = defaultOversample_;   // desired; stamped into cacheKey_ on load
-    bool mipmaps_ = false;                  // desired; stamped into cacheKey_ on load
+    bool mipmaps_ = true;                   // desired; stamped into cacheKey_ on load
 
     // 4x4 already costs 16x the atlas; beyond that the prefilter gains nothing
     // a bigger font size would not give more cheaply.
@@ -2390,11 +2409,16 @@ private:
     // already accepts (tcRenderContext.h): column lengths approximate rotation
     // and shear, and perspective is not considered. Choosing a mip level is a
     // far more forgiving use of that estimate than choosing a segment count.
-    static sg_sampler pickSampler(int oversample) {
+    sg_sampler pickSampler() const {
+        const int   oversample = atlasManager_->getOversample();
         const float scale = getDefaultContext().getScale();
         const float texelsPerPixel = (scale > 0.0f) ? (oversample / scale)
                                                     : (float)oversample;
-        return (texelsPerPixel <= 2.0f) ? samplerSharp_ : samplerMipped_;
+        if (texelsPerPixel <= 2.0f) return samplerSharp_;
+
+        // First draw below the bilinear-safe rate is what pays for the chain.
+        atlasManager_->requestMipmaps();
+        return samplerMipped_;
     }
 
     void initResources() {

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -103,10 +103,12 @@ struct FontCacheKey {
     int fontSize;
     bool mipmaps = true;    // allowed to build a mip chain (built lazily on first minified draw)
     int oversample = 1;     // rasterize NxN finer, then box-prefilter back down
+    bool gridFit = false;   // nudge scale so the ascent lands on a whole pixel
 
     bool operator==(const FontCacheKey& other) const {
         return fontPath == other.fontPath && fontSize == other.fontSize
-            && mipmaps == other.mipmaps && oversample == other.oversample;
+            && mipmaps == other.mipmaps && oversample == other.oversample
+            && gridFit == other.gridFit;
     }
 };
 
@@ -116,7 +118,8 @@ struct FontCacheKeyHash {
         size_t h2 = std::hash<int>()(key.fontSize);
         size_t h3 = std::hash<bool>()(key.mipmaps);
         size_t h4 = std::hash<int>()(key.oversample);
-        return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3);
+        size_t h5 = std::hash<bool>()(key.gridFit);
+        return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3) ^ (h5 << 4);
     }
 };
 
@@ -194,7 +197,7 @@ public:
     // -------------------------------------------------------------------------
     // Initialization
     // -------------------------------------------------------------------------
-    bool setup(const std::string& fontPath, int fontSize) {
+    bool setup(const std::string& fontPath, int fontSize, bool gridFit = false) {
         cleanup();
 
         // Load font file (fontPath is UTF-8 — convert so non-ASCII paths
@@ -213,16 +216,16 @@ public:
             return false;
         }
 
-        return initFromFontData(fontSize);
+        return initFromFontData(fontSize, gridFit);
     }
 
-    bool setupFromMemory(const uint8_t* data, size_t size, int fontSize) {
+    bool setupFromMemory(const uint8_t* data, size_t size, int fontSize, bool gridFit = false) {
         cleanup();
 
         fontData_.resize(size);
         std::memcpy(fontData_.data(), data, size);
 
-        return initFromFontData(fontSize);
+        return initFromFontData(fontSize, gridFit);
     }
 
     // Opt-in mipmapping. Must be set before glyphs are uploaded (the atlas
@@ -252,7 +255,7 @@ public:
     int getOversample() const { return oversample_; }
 
 private:
-    bool initFromFontData(int fontSize, int fontIndex = 0) {
+    bool initFromFontData(int fontSize, bool gridFit, int fontIndex = 0) {
         // Get font offset (required for .ttc files with multiple fonts)
         int offset = stbtt_GetFontOffsetForIndex(fontData_.data(), fontIndex);
         if (offset < 0) {
@@ -274,9 +277,50 @@ private:
         // Get font metrics
         int ascent, descent, lineGap;
         stbtt_GetFontVMetrics(&fontInfo_, &ascent, &descent, &lineGap);
+
         ascent_ = ascent * scale_;
         descent_ = descent * scale_;
         lineGap_ = lineGap * scale_;
+
+        // Vertical grid fit.
+        //
+        // A glyph outline has its baseline at font-unit y = 0, so the baseline
+        // is a texel boundary in the atlas at ANY scale -- the rasterizer never
+        // splits it. What decides whether that survives to the screen is where
+        // the bitmap is placed: with the default Direction::Top the baseline
+        // lands at y + ascent, so a fractional ascent drags every glyph on the
+        // line off the pixel grid and the horizontal strokes smear no matter
+        // how good the atlas is.
+        //
+        // ascent_ is a PLACEMENT quantity: it is the offset from the top of the
+        // line box down to the baseline, and it never reaches the rasterizer
+        // (which works from scale_ via GetGlyphBitmapBox / MakeGlyphBitmap). So
+        // rounding it is enough, and nothing else moves -- glyph bitmaps,
+        // advances and line width are all bit-identical to the unfitted font.
+        // The only thing given up is that the text sits up to half a pixel off
+        // the ascent the font declares, which is invisible and costs no ink.
+        if (gridFit) {
+            const float fittedAscent = std::round(ascent_);
+            if (fittedAscent >= 1.0f) ascent_ = fittedAscent;
+        }
+
+        // Whole ascent alone only aligns the FIRST line: forEachGlyph advances
+        // by getLineHeight() per newline, and (ascent - descent + lineGap) *
+        // scale is fractional independently of the ascent. On Hiragino at 21px
+        // the line height is 31.5, so grid fitting the ascent produced perfect
+        // odd lines and worst-case (half-pixel) even ones — measurably worse
+        // overall than not fitting at all.
+        //
+        // Line height is a layout quantity too: rounding it moves the next
+        // baseline and nothing else, so every line inherits the first line's
+        // alignment.
+        if (gridFit) {
+            const float lh = ascent_ - descent_ + lineGap_;
+            const float lhRounded = std::round(lh);
+            if (lhRounded >= 1.0f) {
+                lineGap_ += (lhRounded - lh);
+            }
+        }
 
         // Get space advance
         int spaceIndex = stbtt_FindGlyphIndex(&fontInfo_, ' ');
@@ -936,7 +980,7 @@ public:
         }
 
         auto manager = std::make_shared<FontAtlasManager>();
-        if (!manager->setup(key.fontPath, key.fontSize)) {
+        if (!manager->setup(key.fontPath, key.fontSize, key.gridFit)) {
             return nullptr;
         }
         manager->setMipmaps(key.mipmaps);
@@ -955,7 +999,7 @@ public:
         }
 
         auto manager = std::make_shared<FontAtlasManager>();
-        if (!manager->setupFromMemory(data, size, key.fontSize)) {
+        if (!manager->setupFromMemory(data, size, key.fontSize, key.gridFit)) {
             return nullptr;
         }
         manager->setMipmaps(key.mipmaps);
@@ -1059,6 +1103,27 @@ public:
     // is generated until a draw actually samples below the bilinear-safe rate,
     // so apps that never minify text pay nothing. Turn it off to trade shimmer
     // on small/distant text for ~33% less atlas memory and no rebuild cost.
+    // Nudge the rasterization scale (by up to a few percent) so the ascent is a
+    // whole number of pixels. With the default Direction::Top that puts the
+    // baseline -- and with it every glyph bitmap on the line -- on the pixel
+    // grid, which is what lets the atlas's own alignment reach the screen.
+    // Costs nothing: no extra memory, no draw-time work, and unlike rounding
+    // quads it cannot misfire under a transform, because nothing about it
+    // depends on the modelview.
+    //
+    // The trade is that the requested size is honoured approximately: ask for
+    // 16 and the glyphs may be rasterized at 15.6 or 16.4. Metrics stay
+    // self-consistent (getWidth/getLineHeight report the fitted values), so
+    // only layout pinned to hard-coded numbers would notice.
+    Font& setGridFit(bool enabled) {
+        if (enabled == gridFit_) return *this;
+        gridFit_ = enabled;
+        reresolveAtlas([enabled](internal::FontCacheKey& k) { k.gridFit = enabled; },
+                       "setGridFit");
+        return *this;
+    }
+    bool getGridFit() const { return gridFit_; }
+
     Font& setMipmaps(bool enabled) {
         if (enabled == mipmaps_) return *this;
         mipmaps_ = enabled;
@@ -1139,6 +1204,7 @@ public:
         cacheKey_.fontSize = physicalSize;
         cacheKey_.oversample = oversample_;
         cacheKey_.mipmaps = mipmaps_;
+        cacheKey_.gridFit = gridFit_;
 
         if (isUrl(actualPath)) {
 #ifdef __EMSCRIPTEN__
@@ -2378,6 +2444,7 @@ private:
     float dpiScale_ = 1.0f;    // DPI scale at load time (physical/logical ratio)
     int oversample_ = defaultOversample_;   // desired; stamped into cacheKey_ on load
     bool mipmaps_ = true;                   // desired; stamped into cacheKey_ on load
+    bool gridFit_ = false;                  // desired; stamped into cacheKey_ on load
 
     // 4x4 already costs 16x the atlas; beyond that the prefilter gains nothing
     // a bigger font size would not give more cheaply.

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -765,6 +765,19 @@ private:
         // Box prefiltering shifts the image by (os-1)/2 oversampled texels;
         // stb reports the compensating offset in final pixels via sub*, which
         // has to be folded into the glyph origin below.
+        //
+        // That leaves the origin at a non-integer position -- 1/(2*os) of a
+        // pixel, so a quarter pixel at os = 2 -- which means the atlas texel
+        // grid never quite lands on the screen pixel grid, however carefully
+        // grid fit places the baseline. Cancelling it (rasterize with the
+        // opposite shift, snap the box outward to whole pixels, render into the
+        // interior of a larger bitmap so the margin does not move the glyph)
+        // was built and measured: with the phase pinned and stepped 0.0..0.9 it
+        // was worth +0.5% mean concentration and roughly halved the spread
+        // across phases. Not enough to justify the code, which went through
+        // three separate sign/offset bugs on the way -- two of which no
+        // sharpness metric could see, because a glyph rendered crisply in the
+        // wrong place still scores as crisp. Left alone deliberately.
         float subX = 0.0f, subY = 0.0f;
         if (os > 1) {
             stbtt_MakeGlyphBitmapSubpixelPrefilter(&fontInfo_,

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -102,10 +102,11 @@ struct FontCacheKey {
     std::string fontPath;
     int fontSize;
     bool mipmaps = false;   // opt-in: build a mip chain so minified glyphs don't shimmer
+    int oversample = 1;     // rasterize NxN finer, then box-prefilter back down
 
     bool operator==(const FontCacheKey& other) const {
         return fontPath == other.fontPath && fontSize == other.fontSize
-            && mipmaps == other.mipmaps;
+            && mipmaps == other.mipmaps && oversample == other.oversample;
     }
 };
 
@@ -114,7 +115,8 @@ struct FontCacheKeyHash {
         size_t h1 = std::hash<std::string>()(key.fontPath);
         size_t h2 = std::hash<int>()(key.fontSize);
         size_t h3 = std::hash<bool>()(key.mipmaps);
-        return h1 ^ (h2 << 1) ^ (h3 << 2);
+        size_t h4 = std::hash<int>()(key.oversample);
+        return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3);
     }
 };
 
@@ -226,6 +228,11 @@ public:
     // Opt-in mipmapping. Must be set before glyphs are uploaded (the atlas
     // texture is (re)built lazily in updateAtlasTexture, which reads this).
     void setMipmaps(bool enabled) { wantMipmaps_ = enabled; }
+
+    // Must be set before any glyph is rasterized (glyphs are lazy, so setting
+    // it right after setup() is early enough). Clamped to at least 1.
+    void setOversample(int n) { oversample_ = (n < 1) ? 1 : n; }
+    int getOversample() const { return oversample_; }
 
 private:
     bool initFromFontData(int fontSize, int fontIndex = 0) {
@@ -504,6 +511,7 @@ private:
     // Atlases
     std::vector<AtlasState> atlases_;
     bool wantMipmaps_ = false;   // opt-in mip chain (set via setMipmaps before upload)
+    int oversample_ = 1;         // NxN supersampling of the rasterized glyph
 
     // Glyph cache
     std::unordered_map<uint32_t, GlyphInfo> glyphs_;
@@ -603,14 +611,23 @@ private:
         int advanceWidth, leftSideBearing;
         stbtt_GetGlyphHMetrics(&fontInfo_, glyphIndex, &advanceWidth, &leftSideBearing);
 
+        // Oversampling: rasterize at oversample_ times the target resolution and
+        // box-prefilter back down, so the bilinear fetch at draw time has real
+        // sub-pixel detail to interpolate instead of one hard-edged coverage
+        // sample. Unlike snapping the quad this survives rotation and scale --
+        // there is simply more information in the atlas, whatever the transform.
+        // Layout below is in OVERSAMPLED texels; the metrics handed back to the
+        // draw path are converted to final pixels at the end.
+        const int   os      = oversample_;
+        const float osScale = scale_ * (float)os;
+
         int x0, y0, x1, y1;
-        stbtt_GetGlyphBitmapBox(&fontInfo_, glyphIndex, scale_, scale_, &x0, &y0, &x1, &y1);
+        stbtt_GetGlyphBitmapBox(&fontInfo_, glyphIndex, osScale, osScale, &x0, &y0, &x1, &y1);
 
-        int glyphWidth = x1 - x0;
-        int glyphHeight = y1 - y0;
-
-        // Zero-width glyphs (like space)
-        if (glyphWidth <= 0 || glyphHeight <= 0) {
+        // Zero-width glyphs (like space). Tested on the raw box, before the
+        // prefilter margin below -- that margin is nonzero for os > 1 and would
+        // make an empty glyph look like it had area.
+        if ((x1 - x0) <= 0 || (y1 - y0) <= 0) {
             outInfo.atlasIndex_ = 0;
             outInfo.u0_ = outInfo.v0_ = outInfo.u1_ = outInfo.v1_ = 0;
             outInfo.xoff_ = 0;
@@ -621,6 +638,11 @@ private:
             outInfo.valid_ = true;
             return true;
         }
+
+        // The prefilter is a box of width `os`, which needs os-1 texels of extra
+        // room to run out into (stb's own packer reserves exactly the same).
+        int glyphWidth  = (x1 - x0) + (os - 1);
+        int glyphHeight = (y1 - y0) + (os - 1);
 
         int paddedWidth = glyphWidth + GLYPH_PADDING;
         int paddedHeight = glyphHeight + GLYPH_PADDING;
@@ -673,14 +695,33 @@ private:
         int destX = atlas.currentX_;
         int destY = atlas.currentY_;
 
-        // Render glyph (8bit grayscale)
-        std::vector<uint8_t> glyphBitmap(glyphWidth * glyphHeight);
-        stbtt_MakeGlyphBitmap(&fontInfo_,
-                              glyphBitmap.data(),
-                              glyphWidth, glyphHeight,
-                              glyphWidth,  // stride
-                              scale_, scale_,
-                              glyphIndex);
+        // Render glyph (8bit grayscale). Zero-filled because the prefilter runs
+        // out past the rasterized box into the os-1 margin and expects to read
+        // background there.
+        std::vector<uint8_t> glyphBitmap((size_t)glyphWidth * glyphHeight, 0);
+
+        // Box prefiltering shifts the image by (os-1)/2 oversampled texels;
+        // stb reports the compensating offset in final pixels via sub*, which
+        // has to be folded into the glyph origin below.
+        float subX = 0.0f, subY = 0.0f;
+        if (os > 1) {
+            stbtt_MakeGlyphBitmapSubpixelPrefilter(&fontInfo_,
+                                                   glyphBitmap.data(),
+                                                   glyphWidth, glyphHeight,
+                                                   glyphWidth,  // stride
+                                                   osScale, osScale,
+                                                   0.0f, 0.0f,  // no subpixel shift
+                                                   os, os,
+                                                   &subX, &subY,
+                                                   glyphIndex);
+        } else {
+            stbtt_MakeGlyphBitmap(&fontInfo_,
+                                  glyphBitmap.data(),
+                                  glyphWidth, glyphHeight,
+                                  glyphWidth,  // stride
+                                  scale_, scale_,
+                                  glyphIndex);
+        }
 
         // Copy to atlas (RGBA)
         for (int y = 0; y < glyphHeight; y++) {
@@ -701,10 +742,14 @@ private:
         outInfo.v0_ = (float)destY / atlas.height_;
         outInfo.u1_ = (float)(destX + glyphWidth) / atlas.width_;
         outInfo.v1_ = (float)(destY + glyphHeight) / atlas.height_;
-        outInfo.xoff_ = (float)x0;
-        outInfo.yoff_ = (float)y0;
-        outInfo.width_ = (float)glyphWidth;
-        outInfo.height_ = (float)glyphHeight;
+        // UVs above address oversampled TEXELS; everything the draw path uses is
+        // in FINAL pixels, so divide out the oversampling here. This is the only
+        // place the two spaces meet -- emitPlacedGlyphsToAtlas needs no changes.
+        const float inv = 1.0f / (float)os;
+        outInfo.xoff_ = (float)x0 * inv + subX;
+        outInfo.yoff_ = (float)y0 * inv + subY;
+        outInfo.width_ = (float)glyphWidth * inv;
+        outInfo.height_ = (float)glyphHeight * inv;
         outInfo.advance_ = advanceWidth * scale_;
         outInfo.valid_ = true;
 
@@ -796,7 +841,29 @@ private:
         // coarse mips bleed slightly between neighbours, but that range is
         // sub-pixel on screen and far preferable to shimmer.)
         std::vector<std::vector<uint8_t>> lowerMips;   // levels 1..N (level 0 = atlas.pixels_)
-        if (wantMipmaps_) {
+        // PROVISIONAL: mipmaps are skipped while oversampling is on.
+        //
+        // The two are complementary, not conflicting -- oversampling wins at
+        // 1:1 and above, mipmaps own minification, which is precisely where
+        // oversampling makes aliasing worse (measured: phase-sweep shimmer on
+        // 16px text at scale(0.5) goes 1.21% -> 2.29% at oversample 2). What
+        // stops them combining today is LOD *selection*, not the mip content:
+        // an NxN atlas is N times denser than the screen, so a 1:1 draw sits at
+        // LOD log2(N) and the GPU reads a mip no better than an un-oversampled
+        // atlas -- the oversampling is paid for and then discarded.
+        //
+        // The fix is to pick the sampler from the effective scale
+        // (RenderContext::getScale(), already used this way for adaptive curve
+        // tessellation): max_lod = 0 at 1:1 and above, full mip chain below.
+        // Until that lands, silently doing both would cost the memory of both
+        // and deliver neither, so prefer the one the caller asked for last.
+        if (wantMipmaps_ && oversample_ > 1) {
+            logWarning("Font") << "mipmaps skipped while oversampling ("
+                               << oversample_ << "x) is on: mip selection would "
+                                  "discard the oversampling at 1:1. Pending "
+                                  "scale-aware sampler selection.";
+        }
+        if (wantMipmaps_ && oversample_ == 1) {
             int numMips = 1;
             for (int mw = atlas.width_, mh = atlas.height_; mw > 1 || mh > 1; ) {
                 mw = std::max(1, mw / 2);
@@ -870,6 +937,7 @@ public:
             return nullptr;
         }
         manager->setMipmaps(key.mipmaps);
+        manager->setOversample(key.oversample);
 
         cache_[key] = manager;
         return manager;
@@ -888,6 +956,7 @@ public:
             return nullptr;
         }
         manager->setMipmaps(key.mipmaps);
+        manager->setOversample(key.oversample);
 
         cache_[key] = manager;
         return manager;
@@ -957,6 +1026,47 @@ public:
     //   - A system font name (PostScript or family name) — resolved via
     //     tc::systemFontPath when the path doesn't exist on disk. Lets users
     //     write `font.load("HiraginoSans-W3", 24)` cross-platform.
+    // -------------------------------------------------------------------------
+    // Oversampling (supersampled glyph rasterization)
+    // -------------------------------------------------------------------------
+    // Rasterize each glyph N times finer than the target size and box-prefilter
+    // it back down, so the bilinear fetch at draw time interpolates real detail.
+    // Costs N^2 atlas memory. Unlike rounding glyph positions onto the pixel
+    // grid, this keeps working under rotation and scale -- the atlas simply
+    // holds more information, whatever the transform does with it.
+    //
+    // Order-independent by design: calling it after load() re-resolves the
+    // atlas rather than silently doing nothing.
+    static void setDefaultOversampling(int n) {
+        defaultOversample_ = clampOversample(n);
+    }
+    static int getDefaultOversampling() { return defaultOversample_; }
+
+    Font& setOversampling(int n) {
+        n = clampOversample(n);
+        if (n == oversample_) return *this;      // nothing to rebuild
+        oversample_ = n;
+
+        if (!atlasManager_) {                    // applied by the next load()
+            cacheKey_.oversample = n;
+            return *this;
+        }
+        if (isUrl(cacheKey_.fontPath)) {
+            // The bytes live in the async-fetch cache entry, not on disk, so we
+            // cannot re-rasterize from here. Record it for the next load().
+            logWarning("Font") << "setOversampling on a URL-loaded font takes "
+                                  "effect on the next load()";
+            return *this;
+        }
+
+        const internal::FontCacheKey previousKey = cacheKey_;
+        cacheKey_.oversample = n;
+        atlasManager_ = internal::SharedFontCache::getInstance().getOrCreate(cacheKey_);
+        internal::SharedFontCache::getInstance().releaseIfUnused(previousKey);
+        return *this;
+    }
+    int getOversampling() const { return oversample_; }
+
     LoadResult load(const fs::path& nameOrPath, int size) {
         // Render glyphs at physical pixel size for sharp text on HiDPI displays.
         // All metrics/drawing are scaled back to logical coordinates.
@@ -1001,6 +1111,7 @@ public:
 
         cacheKey_.fontPath = actualPath;
         cacheKey_.fontSize = physicalSize;
+        cacheKey_.oversample = oversample_;
 
         if (isUrl(actualPath)) {
 #ifdef __EMSCRIPTEN__
@@ -2237,6 +2348,12 @@ private:
     std::shared_ptr<internal::FontAtlasManager> atlasManager_;
     internal::FontCacheKey cacheKey_;
     float dpiScale_ = 1.0f;    // DPI scale at load time (physical/logical ratio)
+    int oversample_ = defaultOversample_;   // desired; stamped into cacheKey_ on load
+
+    // 4x4 already costs 16x the atlas; beyond that the prefilter gains nothing
+    // a bigger font size would not give more cheaply.
+    static int clampOversample(int n) { return (n < 1) ? 1 : (n > 4 ? 4 : n); }
+    static inline int defaultOversample_ = 1;
     int logicalSize_ = 0;      // User-requested font size (logical pixels)
 
     // Shared GPU resources. The TTF draw path loads the active per-target 2D

--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -2385,7 +2385,16 @@ public:
         return atlasManager_ ? atlasManager_->getDescent() / dpiScale_ : 0;
     }
 
+    int getSize() const {
+        return logicalSize_;
+    }
+
+protected:
     // ---- Placement metrics (draw path) --------------------------------------
+    // Internal: these answer "where does this draw actually put the baseline",
+    // which is not the same question as getAscent()/getLineHeight() and is not
+    // something a caller should have to reason about.
+    //
     // Grid fit rounds in model space, so it only puts the baseline on the pixel
     // grid while one model unit is one device pixel. Under any other transform
     // it pins every baseline to a fixed bad phase instead of a uniformly
@@ -2411,11 +2420,6 @@ public:
                                : atlasManager_->getRawLineHeight()) / dpiScale_;
     }
 
-    int getSize() const {
-        return logicalSize_;
-    }
-
-protected:
     // -------------------------------------------------------------------------
     // Alignment offset calculation (available to subclasses)
     // -------------------------------------------------------------------------

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -315,6 +315,49 @@ Available macros: `TC_FONT_SANS`, `TC_FONT_SERIF`, `TC_FONT_MONO`,
 `TC_FONT_SANS_JA`, `TC_FONT_SERIF_JA`. Backends: CoreText (macOS/iOS),
 DirectWrite (Windows), fontconfig (Linux). Web falls back to a Noto CDN URL.
 
+### Why is my small text blurry, and how do I sharpen it?
+
+Two knobs, and they are deliberately not symmetric.
+
+**Grid fit — on by default, leave it on.** Each baseline is snapped to a
+whole pixel at draw time, so the horizontal strokes of every glyph land on
+the pixel grid instead of straddling it. It costs no memory and one
+rounding per line, and it measures +5 to +20% sharper on every face and
+size tested at 1:1. It stands down automatically when the transform is not
+1:1 (rounding in model space would land on a *fixed bad* phase under, say,
+`scale(0.5)`, which is worse than not rounding at all), so you can leave it
+on unconditionally.
+
+```cpp
+font.setGridFit(false);          // opt OUT — only if you need the exact declared baseline
+```
+
+The only thing it changes is that a line may sit up to half a pixel off the
+baseline the font declares. Glyph bitmaps, advances, line widths and the
+reported metrics are untouched, and because line offsets are accumulated
+before rounding (not stepped by a rounded line height), a 100-line block is
+still within half a pixel of its true height.
+
+**Oversampling — opt-in, and think before enabling.** Glyphs are rasterized
+N×N finer and box-prefiltered back down, which recovers the detail lost to
+the fractional pen position. The gain is real but the cost is N² *atlas
+area*:
+
+```cpp
+font.setOversampling(2);              // this font (1–4, default 1)
+Font::setDefaultOversampling(2);      // every font loaded afterwards
+```
+
+Worth it for small text — at 9–13 px it buys +15 to +20% for an atlas that
+was tiny to begin with. Rarely worth it above ~24 px, where the gain falls
+to a few percent and the atlas is already large. If you only draw big text,
+leave it at 1.
+
+Neither knob helps if the text is *minified* (drawn smaller than its loaded
+size) — for that, load the font at the size you actually draw it, or rely on
+mipmaps (`setMipmaps`, on by default, built lazily on the first minified
+draw).
+
 ### Color
 ```cpp
 clear();                              // Transparent black (0,0,0,0)

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -17405,9 +17405,9 @@ description.ko = "글리프 아틀라스가 밉맵을 생성해도 되는지 여
 
 ["Font::setGridFit"]
 keywords = ["grid fit", "hinting", "baseline", "pixel grid", "sharpness"]
-description.en = "Round the ascent and line height to whole pixels so every baseline lands on the pixel grid, sharpening horizontal strokes at no memory or draw cost (on by default; automatically stands down when the transform is not 1:1, where rounding in model space would hurt instead)."
-description.ja = "アセントと行の高さを整数ピクセルに丸めてベースラインをピクセル境界に乗せ、メモリも描画コストもかけずに横画を鮮明にする（既定で有効。1:1 でない変換下ではモデル空間での丸めが逆効果になるため自動的に無効化される）。"
-description.ko = "어센트와 줄 높이를 정수 픽셀로 반올림해 베이스라인을 픽셀 격자에 맞추고, 메모리와 렌더링 비용 없이 가로획을 또렷하게 만든다(기본 활성화. 1:1이 아닌 변환에서는 모델 공간 반올림이 역효과이므로 자동으로 해제된다)."
+description.en = "Snap every baseline to a whole pixel at draw time so horizontal strokes stay sharp, at no memory cost and one rounding per line (on by default; automatically stands down when the transform is not 1:1, where rounding in model space would hurt instead)."
+description.ja = "描画時に各行のベースラインを整数ピクセルにスナップして横画を鮮明に保つ。メモリコストはなく、行あたり丸め1回だけ（既定で有効。1:1 でない変換下ではモデル空間での丸めが逆効果になるため自動的に無効化される）。"
+description.ko = "그리기 시점에 각 줄의 베이스라인을 정수 픽셀에 맞춰 가로획을 또렷하게 유지한다. 메모리 비용은 없고 줄당 반올림 한 번뿐이다(기본 활성화. 1:1이 아닌 변환에서는 모델 공간 반올림이 역효과이므로 자동으로 해제된다)."
 
 ["Font::getGridFit"]
 keywords = ["grid fit", "hinting", "baseline"]
@@ -17420,12 +17420,7 @@ description.en = "Report whether grid fit actually lands on the pixel grid, i.e.
 description.ja = "グリッドフィットが実際にピクセル境界に乗るかどうかを返す。有効であり、かつ現在の変換で1モデル単位が1デバイスピクセルに対応する場合のみ真。"
 description.ko = "그리드 피팅이 실제로 픽셀 격자에 맞는지 여부를 반환한다. 활성화되어 있고 현재 변환이 1 모델 단위를 1 디바이스 픽셀로 매핑할 때만 참이다."
 
-["Font::placementAscent"]
-description.en = "Return the ascent the draw path should place the baseline with: the grid-fitted value when the fit lands, the font's own value otherwise."
-description.ja = "描画パスがベースラインの配置に使うべきアセントを返す。グリッドフィットが有効に働く場合は丸めた値、そうでなければフォント本来の値。"
-description.ko = "렌더링 경로가 베이스라인 배치에 사용해야 할 어센트를 반환한다. 그리드 피팅이 유효할 때는 반올림한 값을, 그렇지 않으면 폰트 본래의 값을 돌려준다."
-
-["Font::placementLineHeight"]
-description.en = "Return the line height the draw path should advance by: an explicit setLineHeight value if set, otherwise the grid-fitted or unfitted line height depending on whether the fit lands."
-description.ja = "描画パスが行送りに使うべき行の高さを返す。setLineHeight が明示指定されていればその値、なければグリッドフィットが有効に働くかどうかに応じて丸めた値か本来の値。"
-description.ko = "렌더링 경로가 줄 이동에 사용해야 할 줄 높이를 반환한다. setLineHeight가 명시되어 있으면 그 값을, 아니면 그리드 피팅의 유효 여부에 따라 반올림한 값 또는 본래의 값을 돌려준다."
+["Font::fitY"]
+description.en = "Snap a baseline offset accumulated from the anchor to the pixel grid, or pass it through unchanged when grid fit does not land. Callers must accumulate first and round once: rounding the line height and stepping by it would compound into a whole-pixel layout drift."
+description.ja = "アンカーからの累積ベースラインオフセットをピクセル境界にスナップする。グリッドフィットが働かない場合はそのまま返す。呼び出し側は必ず累積してから1回だけ丸めること。行の高さを丸めてから加算すると誤差が積み上がり、レイアウトが1ピクセル分ずれてしまう。"
+description.ko = "앵커에서 누적된 베이스라인 오프셋을 픽셀 격자에 맞추고, 그리드 피팅이 유효하지 않으면 그대로 돌려준다. 호출자는 반드시 먼저 누적한 뒤 한 번만 반올림해야 한다. 줄 높이를 반올림해 더해 나가면 오차가 쌓여 레이아웃이 한 픽셀만큼 어긋난다."

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -17366,3 +17366,66 @@ hide = true
 
 ["ScrollBar::Direction"]
 hide = true
+
+["Font::setOversampling"]
+keywords = ["oversampling", "supersample", "sharpness", "quality", "atlas"]
+description.en = "Rasterize glyphs at N x N the target size and box-filter them down, trading N^2 atlas memory for sharper text under arbitrary transforms (1 = off)."
+description.ja = "グリフを N x N 倍の解像度でラスタライズしてから縮小し、アトラスのメモリを N^2 倍払う代わりに任意の変換下で文字を鮮明にする（1 = 無効）。"
+description.ko = "글리프를 N x N 배 해상도로 래스터화한 뒤 축소하여, 아틀라스 메모리를 N^2 배 쓰는 대신 임의의 변환에서도 글자를 또렷하게 만든다(1 = 끔)."
+
+["Font::getOversampling"]
+keywords = ["oversampling", "supersample", "quality"]
+description.en = "Return the oversampling factor this font rasterizes with (1 = off)."
+description.ja = "このフォントがラスタライズに使うオーバーサンプリング倍率を返す（1 = 無効）。"
+description.ko = "이 폰트가 래스터화에 사용하는 오버샘플링 배수를 반환한다(1 = 끔)."
+
+["Font::setDefaultOversampling"]
+keywords = ["oversampling", "default", "global", "quality"]
+description.en = "Set the oversampling factor newly loaded fonts start with; does not affect fonts already loaded."
+description.ja = "以降に読み込むフォントの既定のオーバーサンプリング倍率を設定する。読み込み済みのフォントには影響しない。"
+description.ko = "이후 로드하는 폰트의 기본 오버샘플링 배수를 설정한다. 이미 로드된 폰트에는 영향을 주지 않는다."
+
+["Font::getDefaultOversampling"]
+keywords = ["oversampling", "default", "global"]
+description.en = "Return the oversampling factor newly loaded fonts start with."
+description.ja = "以降に読み込むフォントの既定のオーバーサンプリング倍率を返す。"
+description.ko = "이후 로드하는 폰트의 기본 오버샘플링 배수를 반환한다."
+
+["Font::setMipmaps"]
+keywords = ["mipmap", "minification", "shimmer", "scale", "quality"]
+description.en = "Enable mipmapping of the glyph atlas so text stays stable when drawn much smaller than its loaded size (on by default; the chain is built lazily on the first minified draw)."
+description.ja = "グリフアトラスのミップマップを有効にし、読み込みサイズよりかなり小さく描画してもテキストがちらつかないようにする（既定で有効。ミップ列は最初に縮小描画された時点で生成される）。"
+description.ko = "글리프 아틀라스의 밉맵을 활성화하여 로드 크기보다 훨씬 작게 그려도 텍스트가 흔들리지 않게 한다(기본 활성화. 밉 체인은 첫 축소 렌더링 시점에 생성된다)."
+
+["Font::getMipmaps"]
+keywords = ["mipmap", "minification", "quality"]
+description.en = "Return whether the glyph atlas is allowed to build mipmaps."
+description.ja = "グリフアトラスがミップマップを生成してよいかどうかを返す。"
+description.ko = "글리프 아틀라스가 밉맵을 생성해도 되는지 여부를 반환한다."
+
+["Font::setGridFit"]
+keywords = ["grid fit", "hinting", "baseline", "pixel grid", "sharpness"]
+description.en = "Round the ascent and line height to whole pixels so every baseline lands on the pixel grid, sharpening horizontal strokes at no memory or draw cost (on by default; automatically stands down when the transform is not 1:1, where rounding in model space would hurt instead)."
+description.ja = "アセントと行の高さを整数ピクセルに丸めてベースラインをピクセル境界に乗せ、メモリも描画コストもかけずに横画を鮮明にする（既定で有効。1:1 でない変換下ではモデル空間での丸めが逆効果になるため自動的に無効化される）。"
+description.ko = "어센트와 줄 높이를 정수 픽셀로 반올림해 베이스라인을 픽셀 격자에 맞추고, 메모리와 렌더링 비용 없이 가로획을 또렷하게 만든다(기본 활성화. 1:1이 아닌 변환에서는 모델 공간 반올림이 역효과이므로 자동으로 해제된다)."
+
+["Font::getGridFit"]
+keywords = ["grid fit", "hinting", "baseline"]
+description.en = "Return whether vertical grid fit is enabled for this font."
+description.ja = "このフォントで縦方向のグリッドフィットが有効かどうかを返す。"
+description.ko = "이 폰트에 세로 그리드 피팅이 활성화되어 있는지 여부를 반환한다."
+
+["Font::gridFitLands"]
+description.en = "Report whether grid fit actually lands on the pixel grid, i.e. whether it is enabled and the current transform maps one model unit to one device pixel."
+description.ja = "グリッドフィットが実際にピクセル境界に乗るかどうかを返す。有効であり、かつ現在の変換で1モデル単位が1デバイスピクセルに対応する場合のみ真。"
+description.ko = "그리드 피팅이 실제로 픽셀 격자에 맞는지 여부를 반환한다. 활성화되어 있고 현재 변환이 1 모델 단위를 1 디바이스 픽셀로 매핑할 때만 참이다."
+
+["Font::placementAscent"]
+description.en = "Return the ascent the draw path should place the baseline with: the grid-fitted value when the fit lands, the font's own value otherwise."
+description.ja = "描画パスがベースラインの配置に使うべきアセントを返す。グリッドフィットが有効に働く場合は丸めた値、そうでなければフォント本来の値。"
+description.ko = "렌더링 경로가 베이스라인 배치에 사용해야 할 어센트를 반환한다. 그리드 피팅이 유효할 때는 반올림한 값을, 그렇지 않으면 폰트 본래의 값을 돌려준다."
+
+["Font::placementLineHeight"]
+description.en = "Return the line height the draw path should advance by: an explicit setLineHeight value if set, otherwise the grid-fitted or unfitted line height depending on whether the fit lands."
+description.ja = "描画パスが行送りに使うべき行の高さを返す。setLineHeight が明示指定されていればその値、なければグリッドフィットが有効に働くかどうかに応じて丸めた値か本来の値。"
+description.ko = "렌더링 경로가 줄 이동에 사용해야 할 줄 높이를 반환한다. setLineHeight가 명시되어 있으면 그 값을, 아니면 그리드 피팅의 유효 여부에 따라 반올림한 값 또는 본래의 값을 돌려준다."


### PR DESCRIPTION

## Summary

Seven commits from an investigation into whether TrussC text really loses
resolution to subpixel misalignment. It does: glyph advances land at
fractional pen positions whose fractional parts are uniform over [0,1), so
this is a real sampling error, not float noise.

Two commits are plain bug fixes. Two make minified text work. Two turn vertical
grid fit into something safe enough to enable by default. One adds an
oversampling knob that stays **off** until the atlas gets cheaper.

## Bug fixes

**`e5f1f69` reloading a Font at a new size leaked its old atlas.**
`SharedFontCache` is keyed on `(path, size, mipmaps, oversample, gridFit)` and
nothing ever dropped the old entry, so a Font that changed size kept every
atlas it had ever used alive for the life of the process. A rig that cycles
sizes held 6400 KB where it should hold 256 KB. `Font::load()` now releases the
previous key if that was the last reference.

Deliberately *not* done in `~Font()`: a Font constructed per frame would then
re-rasterize its whole atlas every frame.

**`747030e` the atlas was sampled from the wrong mip at normal sizes.**
The sampler had no `max_lod`, so any text drawn at or above 1:1 could still
pick a blurrier mip. Now pinned to mip 0 unless the text is actually minified.

Note for reviewers: `max_lod = 0.0f` is a silent no-op — sokol runs it through
`_sg_def_flt(def.max_lod, FLT_MAX)` and reads zero as "unset". The code uses
`0.01f` and says why.

## Minified text

**`05bf0c4` glyph atlas mipmaps are built lazily, on the first minified draw.**
Mipmaps were previously unreachable in practice. They are now built the first
time text is drawn small enough to need them, and the sampler is chosen from
the live modelview scale (`texels-per-pixel = oversample / getScale()`,
threshold 2). Both samplers are trilinear.

This is the one change that is on by default, because an app that changes no
settings gets it for free. It cannot regress normal-size text: at or above 1:1
the sampler is pinned to mip 0 by the fix above, and the mip chain is not even
built until something is minified.

## Vertical grid fit — on by default

**`47880a4` + `d6fc4c6` `Font::setGridFit()` — round the ascent to a whole
pixel**, then absorb the line-height remainder into `lineGap_` so line N is
aligned too, not just line 0. `ascent_` never reaches the rasterizer, so this
changes no glyph shape and no advance — only where the baseline lands. No
memory cost, no draw-time cost.

Measured with the subpixel phase pinned 0.0..0.9, across Hiragino Sans W3,
Helvetica, Helvetica Neue, Times New Roman, Georgia and Menlo at sizes
9/11/13/16/20/24/32: **positive at 1:1 in every single cell**, typically
+5..15% energy concentration, up to +19%, never negative.

It rounds in *model* space, though, so it only lands on the pixel grid while
one model unit is one device pixel. Under `scale(0.5)` a fitted ascent of 13
puts every baseline at 6.5 device pixels — the worst phase, every line, every
frame — where an unfitted ascent is uniformly distributed. That measured up to
**-13%** on Helvetica. Same flaw that rules out quad pixel-snapping, and it is
what made this unshippable as a default.

So the draw path now asks whether the fit actually lands and falls back to the
font's own metrics when it does not. Re-measured after the gate: the 1:1
numbers are unchanged, and `scale(2.0)` / `scale(0.5)` / `scale(0.25)` read
**0.00% on every cell** — fitted and unfitted rows come out numerically
identical, i.e. the fit is completely out of the way.

With no remaining way for it to lose, it is on by default. `getAscent()` /
`getLineHeight()` still report the *fitted* values: they describe the font as
laid out, and a metric that changed with whatever transform happened to be
current would be a much worse thing to build a layout on.

## Opt-in knob (default off)

**`c0243c1` `Font::setOversampling(n)` — NxN supersampled rasterization**
with stb's box prefilter. Worth +23..25% and, unlike the above, it holds up
under arbitrary transforms. It stays off because it costs n^2 atlas *area*: the
atlas is RGBA8 and doubles from 256² up to 4096², so `n=2` brings one extra
doubling and pushes CJK-heavy apps toward extra atlas pages, i.e. texture
switches mid-text. An R8 atlas cuts the bytes by exactly 4x and pays for `n=2`
outright, so that is the change this default should ride in with.

`6bf58d2` is a comment recording why the oversampled glyph *origin* is left off
the pixel grid — see below.

## Measurement, and a caveat about it

Scored with energy concentration (`sum(v^2)/sum(v)`) and total variation over
equal-height A/B bands of a small FBO read back at 1:1, with a null test (both
rows identical, all diffs must read 0%) run alongside.

Honest caveat: the swept-phase averaging in the rig produced one set of
numbers that could not be reproduced later, cause not identified. The
phase-pinned measurements are reproducible and are what the reject decision
below rests on. Numbers quoted in the individual commit messages came from the
sweep and should be read as indicative rather than exact.

None of that affects the two bug fixes, which are correct independently of any
sharpness metric.

## Tried and rejected

- **Quad pixel-snapping.** Good at identity, negative under fractional
  translation or any scale, because the rounding happens in model space.
- **Integer glyph origin** (cancelling the prefilter's 1/(2*os) residual).
  Built and measured: worth about +0.5% mean concentration with the phase
  pinned. It went through three sign/offset bugs on the way, two of which no
  sharpness metric could see — a glyph rendered crisply in the *wrong place*
  still scores as crisp. Reverted; the reasoning is left in a comment where
  the next person would look.

## Testing

macOS. A dedicated A/B rig renders both paths into one FBO and scores them, with
a null test to catch rig bias, subpixel phase pinnable to 0.0-0.9, and the
metrics cross-checked by eye at magnification — which is how all three of the
rejected change's bugs were actually found.
