### PR TITLE
fix: letter keycodes are uppercase-only in keyPressed(int)

### DIFF
--- a/examples/3d/easyCamExample/src/tcApp.cpp
+++ b/examples/3d/easyCamExample/src/tcApp.cpp
@@ -150,7 +150,6 @@ void tcApp::drawGrid(float size, int divisions) {
 
 void tcApp::keyPressed(int key) {
     switch (key) {
-        case 'c':
         case 'C':
             if (cam.isMouseInputEnabled()) {
                 cam.disableMouseInput();
@@ -158,20 +157,16 @@ void tcApp::keyPressed(int key) {
                 cam.enableMouseInput();
             }
             break;
-        case 'r':
         case 'R':
             cam.reset();
             cam.setDistance(600);
             break;
-        case 'f':
         case 'F':
             toggleFullscreen();
             break;
-        case 'h':
         case 'H':
             showHelp = !showHelp;
             break;
-        case 'o':
         case 'O':
             cam.setOrtho(!cam.getOrtho());
             break;

--- a/examples/3d/sunlightExample/src/tcApp.cpp
+++ b/examples/3d/sunlightExample/src/tcApp.cpp
@@ -153,7 +153,8 @@ void tcApp::draw() {
 }
 
 void tcApp::keyPressed(int key) {
-    if (key == 's') {
+    // Letter keycodes are uppercase ASCII regardless of shift.
+    if (key == 'S') {
         softnessIndex = (softnessIndex + 1) % 3;
         sunLight.setShadowSoftness(softnessPresets[softnessIndex]);
     }

--- a/examples/graphics/curvesExample/src/tcApp.cpp
+++ b/examples/graphics/curvesExample/src/tcApp.cpp
@@ -151,12 +151,18 @@ void tcApp::drawHud() {
     drawBitmapString(line3, 20, 66);
 }
 
-void tcApp::keyPressed(int key) {
-    switch (key) {
-        case 'T': tolerance_ = std::max(0.01f,  tolerance_ * 0.5f);  applyMode(); break;
-        case 't': tolerance_ = std::min(20.0f,  tolerance_ * 2.0f);  applyMode(); break;
-        case 'R': resolution_ = std::max(3,    resolution_ - 2);    applyMode(); break;
-        case 'r': resolution_ = std::min(256,  resolution_ + 2);    applyMode(); break;
-        case 'm': case 'M': tolMode_ = !tolMode_; applyMode(); break;
+void tcApp::keyPressed(const KeyEventArgs& e) {
+    switch (e.key) {
+        case 'T':
+            tolerance_ = e.shift ? std::max(0.01f, tolerance_ * 0.5f)
+                                 : std::min(20.0f, tolerance_ * 2.0f);
+            applyMode();
+            break;
+        case 'R':
+            resolution_ = e.shift ? std::max(3,   resolution_ - 2)
+                                  : std::min(256, resolution_ + 2);
+            applyMode();
+            break;
+        case 'M': tolMode_ = !tolMode_; applyMode(); break;
     }
 }

--- a/examples/graphics/curvesExample/src/tcApp.h
+++ b/examples/graphics/curvesExample/src/tcApp.h
@@ -29,7 +29,11 @@ public:
     void setup() override;
     void update() override;
     void draw() override;
-    void keyPressed(int key) override;
+    // Takes the KeyEventArgs overload because the controls are shift-modified:
+    // keyPressed(int) receives a raw sapp_keycode, whose letter values are
+    // uppercase ASCII whether or not shift is held, so shift is unreadable
+    // from the int form.
+    void keyPressed(const KeyEventArgs& e) override;
 
 private:
     bool tolMode_ = true;

--- a/examples/graphics/polylinesExample/src/tcApp.cpp
+++ b/examples/graphics/polylinesExample/src/tcApp.cpp
@@ -221,7 +221,6 @@ void tcApp::keyPressed(int key) {
         case '1': mode = 0; break;
         case '2': mode = 1; break;
         case '3': mode = 2; break;
-        case 'c':
         case 'C':
             mousePolyline.clear();
             break;

--- a/examples/input_output/asyncDialogExample/src/tcApp.cpp
+++ b/examples/input_output/asyncDialogExample/src/tcApp.cpp
@@ -159,10 +159,10 @@ void tcApp::triggerAction(int index) {
 
 void tcApp::keyPressed(int key) {
     switch (key) {
-        case 'A': case 'a': triggerAction(0); break;
-        case 'C': case 'c': triggerAction(1); break;
-        case 'O': case 'o': triggerAction(2); break;
-        case 'S': case 's': triggerAction(3); break;
+        case 'A': triggerAction(0); break;
+        case 'C': triggerAction(1); break;
+        case 'O': triggerAction(2); break;
+        case 'S': triggerAction(3); break;
     }
 }
 

--- a/examples/input_output/fileDialogExample/src/tcApp.cpp
+++ b/examples/input_output/fileDialogExample/src/tcApp.cpp
@@ -74,8 +74,7 @@ void tcApp::draw() {
 
 void tcApp::keyPressed(int key) {
     switch (key) {
-        case 'O':
-        case 'o': {
+        case 'O': {
             // File selection dialog
             statusMessage = "Opening file dialog...";
             lastResult = loadDialog("Select a file", "");
@@ -104,8 +103,7 @@ void tcApp::keyPressed(int key) {
             break;
         }
 
-        case 'F':
-        case 'f': {
+        case 'F': {
             // Folder selection dialog
             statusMessage = "Opening folder dialog...";
             lastResult = loadDialog("Select a folder", "", "", true);
@@ -120,8 +118,7 @@ void tcApp::keyPressed(int key) {
             break;
         }
 
-        case 'S':
-        case 's': {
+        case 'S': {
             // Save dialog
             statusMessage = "Opening save dialog...";
             lastResult = saveDialog("Save File", "Save your file", "", "untitled.txt");
@@ -136,8 +133,7 @@ void tcApp::keyPressed(int key) {
             break;
         }
 
-        case 'A':
-        case 'a': {
+        case 'A': {
             // Alert dialog
             statusMessage = "Showing alert...";
             alertDialog("Alert", "This is a test alert from TrussC!");

--- a/examples/math/noiseField2dExample/src/tcApp.cpp
+++ b/examples/math/noiseField2dExample/src/tcApp.cpp
@@ -158,7 +158,6 @@ void tcApp::keyPressed(int key) {
         case '4': mode = 3; break;
 
         case '=':
-        case '+':
             noiseScale *= 1.1f;
             break;
         case '-':
@@ -174,7 +173,6 @@ void tcApp::keyPressed(int key) {
             if (timeSpeed < 0.01f) timeSpeed = 0.01f;
             break;
 
-        case 'r':
         case 'R':
             resetParticles();
             break;

--- a/examples/node/layoutModExample/src/tcApp.cpp
+++ b/examples/node/layoutModExample/src/tcApp.cpp
@@ -108,19 +108,15 @@ void tcApp::draw() {
 
 void tcApp::keyPressed(int key) {
     switch (key) {
-        case 'v':
         case 'V':
             addBoxToVStack();
             break;
-        case 'h':
         case 'H':
             addBoxToHStack();
             break;
-        case 'd':
         case 'D':
             removeLastFromVStack();
             break;
-        case 'f':
         case 'F':
             removeLastFromHStack();
             break;

--- a/examples/node/scrollContainerExample/src/tcApp.cpp
+++ b/examples/node/scrollContainerExample/src/tcApp.cpp
@@ -142,19 +142,15 @@ void tcApp::draw() {
 
 void tcApp::keyPressed(int key) {
     switch (key) {
-        case 'a':
         case 'A':
             addItem();
             break;
-        case 'd':
         case 'D':
             removeItem();
             break;
-        case 'h':
         case 'H':
             addHItem();
             break;
-        case 'j':
         case 'J':
             removeHItem();
             break;

--- a/examples/sound/audioRecorderExample/src/tcApp.cpp
+++ b/examples/sound/audioRecorderExample/src/tcApp.cpp
@@ -87,7 +87,7 @@ void tcApp::draw() {
 }
 
 void tcApp::keyPressed(int key) {
-    if (key == 'r' || key == 'R') {
+    if (key == 'R') {
         if (recorder.isRecording()) recorder.stop();
         else recorder.start("recorded.wav");
     }

--- a/examples/video/videoRecordAudioExample/src/tcApp.cpp
+++ b/examples/video/videoRecordAudioExample/src/tcApp.cpp
@@ -70,7 +70,7 @@ void tcApp::draw() {
 }
 
 void tcApp::keyPressed(int key) {
-    if (key == 'r' || key == 'R') {
+    if (key == 'R') {
         VideoRecordSettings s;
         s.fps = 60.0f;
         s.audio = true;


### PR DESCRIPTION

In TrussC, `keyPressed(int key)` always reports letter keys as uppercase
regardless of shift, so `if (key == 'A')` is the form to write. A few examples
tested lowercase by mistake, which never fires. Fixed.

Two were actually broken by it:

- **sunlightExample** — `key == 's'` was the only test, so cycling the shadow
  softness did nothing.
- **curvesExample** — `case 'T'` / `case 't'` were written as if shift picked
  between them, so tolerance and resolution could only ever go one way. The HUD
  advertises `[T / Shift+T]`, so it now takes the `KeyEventArgs` overload and
  reads `e.shift`.

The rest just carried a dead lowercase label next to a live uppercase one:
easyCam, fileDialog, noiseField2d, layoutMod, scrollContainer, polylines,
asyncDialog, audioRecorder, videoRecordAudio. Also drops `case '+'` from
noiseField2d, unreachable for the same reason (shift+= still reports `'='`).

Checked on a real keyboard: unshifted T and Shift+T both arrive as 84, and
curvesExample now raises on T and lowers on Shift+T. All 11 examples build.
