### PR TITLE
fix: MCP key injection + fboBlendMode example wording

### DIFF
--- a/core/include/tc/utils/tcStandardTools.h
+++ b/core/include/tc/utils/tcStandardTools.h
@@ -612,6 +612,67 @@ inline void registerInspectionTools() {
 }
 
 // ---------------------------------------------------------------------------
+// Key injection helpers (shared by tc_key_press / tc_key_release)
+//
+// These mirror the real SAPP_EVENTTYPE_KEY_DOWN / KEY_UP path in TrussC.h
+// step for step, including the ordering: notify listeners, update the
+// held-key set, then call the app/Node-tree callback. Modifier flags are
+// DERIVED from the held-key set, the way sokol gets ev->modifiers from the
+// keys the OS reports as down — so an injected modifier hold (tc_key_press
+// with the modifier keycode) shows up on every event that follows it, and
+// e.shift agrees with what isShiftPressed() reports.
+// ---------------------------------------------------------------------------
+namespace detail {
+
+// Modifier flags for the event carrying `key`, as of AFTER this event's own
+// state change — which is what the OS reports: a Shift key-down already has
+// the Shift flag set, its key-up already has it cleared. Every other key is
+// read straight from the held-key set.
+inline void fillKeyModifiers(KeyEventArgs& args, int key, bool down) {
+    auto heldAfter = [key, down](int code) {
+        return code == key ? down : isKeyPressed(code);
+    };
+    args.shift = heldAfter(SAPP_KEYCODE_LEFT_SHIFT)   || heldAfter(SAPP_KEYCODE_RIGHT_SHIFT);
+    args.ctrl  = heldAfter(SAPP_KEYCODE_LEFT_CONTROL) || heldAfter(SAPP_KEYCODE_RIGHT_CONTROL);
+    args.alt   = heldAfter(SAPP_KEYCODE_LEFT_ALT)     || heldAfter(SAPP_KEYCODE_RIGHT_ALT);
+    args.super = heldAfter(SAPP_KEYCODE_LEFT_SUPER)   || heldAfter(SAPP_KEYCODE_RIGHT_SUPER);
+}
+
+inline void injectKeyDown(int key) {
+    KeyEventArgs args;
+    args.key = key;
+    fillKeyModifiers(args, key, true);
+    events().keyPressed.notify(args);
+
+    ::trussc::internal::currentWindowContext().keysPressed.insert(key);
+
+    if (::trussc::internal::appKeyPressedFunc)
+        ::trussc::internal::appKeyPressedFunc(args);
+}
+
+inline void injectKeyUp(int key) {
+    KeyEventArgs args;
+    args.key = key;
+    fillKeyModifiers(args, key, false);
+    events().keyReleased.notify(args);
+
+    ::trussc::internal::currentWindowContext().keysPressed.erase(key);
+
+    if (::trussc::internal::appKeyReleasedFunc)
+        ::trussc::internal::appKeyReleasedFunc(args);
+}
+
+// Currently held keycodes, for the tool reply (handy when scripting chords).
+inline json heldKeysJson() {
+    std::vector<int> held(::trussc::internal::currentWindowContext().keysPressed.begin(),
+                          ::trussc::internal::currentWindowContext().keysPressed.end());
+    std::sort(held.begin(), held.end());
+    return json(held);
+}
+
+} // namespace detail
+
+// ---------------------------------------------------------------------------
 // Control Tools (opt-in via mcp::registerControlTools())
 //
 // The always-on standard set is strictly read-only; everything that lets the
@@ -765,26 +826,78 @@ inline void registerControlTools() {
 
     // --- Key Tools ---
 
-    tool("tc_key_press", "Press a key")
-        .arg<int>("key", "Key code (sokol_app keycode)")
-        .bind<int>([](int key) {
-            KeyEventArgs args;
-            args.key = key;
-            events().keyPressed.notify(args);
-            if (::trussc::internal::appKeyPressedFunc)
-                ::trussc::internal::appKeyPressedFunc(args);
-            return json{{"status", "ok"}};
+    // The modifier flags are shorthand for pressing/releasing the modifier
+    // KEY ITSELF (the LEFT_* keycode), like a real keyboard does — so both
+    // e.shift on the callback and isShiftPressed() in update() see it. Hold a
+    // modifier across several keys by pressing its keycode explicitly
+    // (tc_key_press 340), then plain presses inherit it.
+    tool("tc_key_press",
+         "Press a key (updates the held-key set that isKeyPressed() reads). "
+         "A modifier flag also presses that modifier's own key first (shift -> keycode 340, "
+         "ctrl -> 341, alt -> 342, super -> 343) and reports it in modifiersPressed; "
+         "pair it with the same flag on tc_key_release, or hold a modifier across several "
+         "keys by pressing/releasing its keycode explicitly")
+        .arg<int>("key", "Key code (sokol_app keycode; letters are uppercase ASCII: 'A'=65..'Z'=90)")
+        .arg<bool>("shift", "Hold Shift for this press", false)
+        .arg<bool>("ctrl", "Hold Ctrl for this press", false)
+        .arg<bool>("alt", "Hold Alt for this press", false)
+        .arg<bool>("super", "Hold Super/Command for this press", false)
+        .bind([](const json& a) -> json {
+            const int key = a.at("key").get<int>();
+
+            // Press the requested modifiers first (skip any already held —
+            // whichever side, so an explicit RIGHT_SHIFT hold is respected).
+            json pressedMods = json::array();
+            auto holdMod = [&](const char* flag, bool alreadyHeld, int code) {
+                if (a.value(flag, false) && !alreadyHeld) {
+                    detail::injectKeyDown(code);
+                    pressedMods.push_back(code);
+                }
+            };
+            holdMod("shift", isShiftPressed(),   SAPP_KEYCODE_LEFT_SHIFT);
+            holdMod("ctrl",  isControlPressed(), SAPP_KEYCODE_LEFT_CONTROL);
+            holdMod("alt",   isAltPressed(),     SAPP_KEYCODE_LEFT_ALT);
+            holdMod("super", isSuperPressed(),   SAPP_KEYCODE_LEFT_SUPER);
+
+            detail::injectKeyDown(key);
+
+            return json{{"status", "ok"},
+                        {"modifiersPressed", pressedMods},
+                        {"heldKeys", detail::heldKeysJson()}};
         });
 
-    tool("tc_key_release", "Release a key")
-        .arg<int>("key", "Key code (sokol_app keycode)")
-        .bind<int>([](int key) {
-            KeyEventArgs args;
-            args.key = key;
-            events().keyReleased.notify(args);
-            if (::trussc::internal::appKeyReleasedFunc)
-                ::trussc::internal::appKeyReleasedFunc(args);
-            return json{{"status", "ok"}};
+    tool("tc_key_release",
+         "Release a key (updates the held-key set that isKeyPressed() reads). "
+         "A modifier flag also releases that modifier's own key afterwards "
+         "(shift -> keycode 340, ctrl -> 341, alt -> 342, super -> 343), "
+         "mirroring tc_key_press")
+        .arg<int>("key", "Key code (sokol_app keycode; letters are uppercase ASCII: 'A'=65..'Z'=90)")
+        .arg<bool>("shift", "Also release Shift after this key", false)
+        .arg<bool>("ctrl", "Also release Ctrl after this key", false)
+        .arg<bool>("alt", "Also release Alt after this key", false)
+        .arg<bool>("super", "Also release Super/Command after this key", false)
+        .bind([](const json& a) -> json {
+            const int key = a.at("key").get<int>();
+
+            // The key goes up first — while the modifiers are still held, so
+            // this event still carries them (as it does on a real keyboard).
+            detail::injectKeyUp(key);
+
+            json releasedMods = json::array();
+            auto dropMod = [&](const char* flag, int code) {
+                if (a.value(flag, false) && isKeyPressed(code)) {
+                    detail::injectKeyUp(code);
+                    releasedMods.push_back(code);
+                }
+            };
+            dropMod("shift", SAPP_KEYCODE_LEFT_SHIFT);
+            dropMod("ctrl",  SAPP_KEYCODE_LEFT_CONTROL);
+            dropMod("alt",   SAPP_KEYCODE_LEFT_ALT);
+            dropMod("super", SAPP_KEYCODE_LEFT_SUPER);
+
+            return json{{"status", "ok"},
+                        {"modifiersReleased", releasedMods},
+                        {"heldKeys", detail::heldKeysJson()}};
         });
 
     // --- Node Tools ---

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -92,10 +92,30 @@ works, deprecated until v1.0.0.)
 | `tc_mouse_release` | `x`, `y`, `button` | Release — end of a drag gesture |
 | `tc_mouse_click` | `x`, `y`, `button`, `shift`/`ctrl`/`alt`/`super` (optional) | Click mouse button (0:left, 1:right), optionally with modifier keys held — e.g. `super: true` Cmd+clicks |
 | `tc_mouse_scroll` | `dx`, `dy` | Scroll mouse wheel |
-| `tc_key_press` | `key` | Press a key (sokol_app keycode) |
-| `tc_key_release` | `key` | Release a key |
+| `tc_key_press` | `key`, `shift`/`ctrl`/`alt`/`super` (optional) | Press a key (sokol_app keycode; letters are uppercase ASCII, `'A'`=65). A modifier flag presses that modifier's own key first, so both `e.shift` and `isShiftPressed()` see it |
+| `tc_key_release` | `key`, `shift`/`ctrl`/`alt`/`super` (optional) | Release a key; a modifier flag releases that modifier's own key afterwards |
 | `tc_select_node` | `id` | Select a node by instance id (0 clears); drives the same selection an inspector shows |
 | `tc_set_node_members` | `id`, `members`, `mod` (optional) | Set reflected members from a JSON object (same encoding as `tc_get_node_tree`; enums accept label string or int). Pass `mod` (a Mod's short type name, e.g. `"LayoutMod"`) to target a mod attached to the node instead of the node itself. Reports `applied` / `skipped` (type mismatch) / `readOnly` / `unknown` keys |
+
+Injected key events go through the same two channels a real key does: the
+`keyPressed` / `keyReleased` callbacks **and** the held-key set that
+`isKeyPressed()` / `isShiftPressed()` read — so an app that polls in `update()`
+reacts to injection just like it does to the keyboard. `tc_key_press` /
+`tc_key_release` reply with the resulting `heldKeys`, which is the quickest way
+to see the state an app is actually looking at.
+
+The modifier flags are shorthand for pressing that modifier's **own key**
+(`shift` → keycode 340, `ctrl` → 341, `alt` → 342, `super` → 343), the way a
+real keyboard does it — pair the same flag on press and release. To hold a
+modifier across several keys, press and release its keycode explicitly; the
+presses in between inherit it:
+
+```
+tc_key_press   {"key": 340}          # Shift down
+tc_key_press   {"key": 65}           # 'A' arrives with shift = true
+tc_key_release {"key": 65}
+tc_key_release {"key": 340}          # Shift up
+```
 
 The node tools make a scene **round-trippable for agents**: arrange things in a
 GUI (e.g. with the `tcxNodeInspector` addon's gizmo), then `tc_get_node_tree` to

--- a/examples/graphics/fboBlendModeExample/src/tcApp.cpp
+++ b/examples/graphics/fboBlendModeExample/src/tcApp.cpp
@@ -7,11 +7,11 @@ void tcApp::setup() {
     fbo_.allocate(kPane, kPane);
 }
 
-// Two half-gray rects; the second is drawn with BlendMode::Add. Where they
-// overlap the result should read 0.5 + 0.5 = 1.0 (white) if Add is honored.
-// A bitmap-string draw sits between the two: it swaps in its own alpha
-// pipeline temporarily, so the second rect also proves the restore path
-// brings the Add pipeline back (not just setBlendMode itself).
+// Two half-gray rects; the second is drawn with BlendMode::Add, so where they
+// overlap the result reads 0.5 + 0.5 = 1.0 (white). A bitmap-string draw sits
+// between the two: it swaps in its own alpha pipeline temporarily, so the
+// second rect also covers the restore path bringing the Add pipeline back
+// (not just setBlendMode itself).
 void tcApp::drawScene() {
     setColor(0.5f, 0.5f, 0.5f);
     drawRect(40, 40, 220, 220);
@@ -25,7 +25,7 @@ void tcApp::drawScene() {
 void tcApp::draw() {
     clear(0, 0, 0);
 
-    // Left: straight to the swapchain (reference — Add works here)
+    // Left: straight to the swapchain (the reference rendering)
     drawScene();
 
     // Right: the identical scene inside an Fbo pass
@@ -36,6 +36,6 @@ void tcApp::draw() {
     fbo_.draw(480, 0);
 
     setColor(1.0f);
-    drawBitmapString("swapchain: overlap should be WHITE (0.5+0.5)", 40, 490);
-    drawBitmapString("fbo: same scene - overlap gray = setBlendMode ignored", 520, 490);
+    drawBitmapString("swapchain: overlap is WHITE (0.5+0.5)", 40, 490);
+    drawBitmapString("fbo: same scene - overlap is WHITE too", 520, 490);
 }

--- a/examples/graphics/fboBlendModeExample/src/tcApp.h
+++ b/examples/graphics/fboBlendModeExample/src/tcApp.h
@@ -7,13 +7,13 @@ using namespace tc;
 // =============================================================================
 // fboBlendModeExample - setBlendMode() inside an Fbo pass
 //
+// Blend modes apply inside an Fbo pass exactly as they do on the screen.
 // The SAME scene is drawn twice: two half-gray rects overlapping, with
 // BlendMode::Add active while the second one is drawn.
 //   - Left:  directly to the swapchain
 //   - Right: into an Fbo, then the Fbo is composited to the screen
-// If blend modes work inside Fbo passes, both overlap regions read 1.0
-// (0.5 + 0.5, full white). If setBlendMode is ignored in the Fbo, the right
-// overlap stays 0.5 — the visual proof of the bug this example pins down.
+// Both overlap regions read 1.0 (0.5 + 0.5, full white), so the two panes
+// are pixel-identical — a visual check that the Fbo pass honors the mode.
 // =============================================================================
 class tcApp : public App {
 public:


### PR DESCRIPTION
Two unrelated fixes that accumulated on `dev`, integrated for one CI run.

## MCP key injection now matches the real key event path

`tc_key_press` / `tc_key_release` only fired the `keyPressed` / `keyReleased`
callbacks. They never touched the held-key set behind `isKeyPressed()`, and never
filled the modifier flags on `KeyEventArgs`, so two things silently did nothing
from MCP:

- apps that poll `isKeyPressed()` / `isShiftPressed()` in `update()` were
  completely deaf to injected keys
- apps that branch on `e.shift` could not be driven at all

Both tools now go through shared inject helpers that mirror the real
`SAPP_EVENTTYPE_KEY_DOWN` / `KEY_UP` path step for step: derive modifiers, notify
listeners, update `keysPressed`, then call the app callback — the same shape the
mouse tools already have with `mouseX` / `mouseY`.

Modifier flags are shorthand for pressing that modifier's **own** key (340–343),
the way a real keyboard does, so `e.shift` and `isShiftPressed()` always agree.
Holding a modifier across several keys is still expressed by pressing and
releasing its keycode explicitly; the presses in between inherit it, because the
flags are derived from the set. Both tools reply with the resulting `heldKeys`,
so a caller can see the state the app is actually reading. `docs/AI_AUTOMATION.md`
documents both, with a worked Shift+A example.

## fboBlendModeExample describes working behavior

The example was written while `setBlendMode()` inside an Fbo pass was broken
(fixed in v0.7.1), so its on-screen captions and comments described the bug
("overlap gray = setBlendMode ignored") rather than the behavior. That reads as a
live limitation to anyone — human or AI — finding the example now, and the site
thumbnail contradicted its own caption.

Reworded to describe what actually happens: both panes render an identical white
overlap, and the example is a visual check that an Fbo pass honors the blend mode.
No code changes. Rebuilt on macOS against current main and re-captured the site
thumbnail.
