### PR TITLE
Unpin Windows CI from 2022, and fix the two problems the pin was hiding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,16 +97,21 @@ jobs:
           - os: macos-latest
             preset: macos
             launcher: ccache
-          # Pinned to 2022: windows-latest now redirects to a VS2026 runner,
-          # where projectGenerator's VS-project generation falls back to the
-          # "Visual Studio 17 2022" generator and fails (VS2022 absent). Revert
-          # to windows-latest once projectGenerator supports VS2026.
+          # Unpinned back to windows-latest (a VS2026 runner). The previous
+          # windows-2022 pin blamed projectGenerator's VS-project generation,
+          # but that reason does not hold: this job never runs that path (it
+          # builds via tools/build_win.bat, which forces -G Ninja, plus
+          # examples/build_all.py -- `trusscli update` is never invoked with the
+          # Visual Studio IDE type), and VsDetector has mapped VS18 -> "2026"
+          # since f7810df0 (2026-04-17), two months BEFORE the pin was added.
+          # The real VS2026 breakage at the time was build_win.bat defaulting to
+          # the VS generator, which was fixed in the same batch.
           #
           # CI builds examples with the Ninja generator (TRUSSC_CMAKE_GENERATOR)
           # instead of the Visual Studio generator: the compiler-launcher hook
           # sccache relies on is ignored by the VS generator, and Ninja + cl.exe
           # (from vcvars) is version-agnostic anyway. Local dev is unchanged.
-          - os: windows-2022
+          - os: windows-latest
             preset: windows
             launcher: sccache
             cmake_gen: Ninja

--- a/addons/tcxOsc/tests/src/main.cpp
+++ b/addons/tcxOsc/tests/src/main.cpp
@@ -67,11 +67,35 @@ static Recv sendAndExpectNone(OscReceiver& rx, OscSender& tx,
     return anySent ? Recv::NotReceived : Recv::Unroutable;
 }
 
+// Bind a receiver to the first candidate port that actually takes it, and
+// return that port (0 if none did).
+//
+// The candidates all sit BELOW 49152 on purpose. At or above that Windows hands
+// out dynamic ports, and Hyper-V / WSL / Docker reserve blocks inside that
+// range; a bind landing in a reserved block fails with WSAEACCES (10013). A
+// hardcoded 57110 did exactly that on the windows-latest CI runner while
+// passing everywhere else. Trying several ports also survives an ordinary
+// collision with whatever else happens to be listening, so the test never
+// depends on one number being free.
+//
+// They avoid 9000/9001 as well: the tcxOsc examples bind those, and 9000 is
+// about the most common OSC port in the wild, so it is the LEAST safe choice
+// on a machine that does OSC work.
+static int bindFirstFree(OscReceiver& rx, const int (&candidates)[4]) {
+    for (int port : candidates) {
+        if (rx.setup(port)) return port;
+        // setup() creates the socket and registers its listeners even when the
+        // bind fails; close() undoes both so the next attempt starts clean.
+        rx.close();
+    }
+    return 0;
+}
+
 int main() {
     const std::string GROUP_A = "239.77.0.1";
     const std::string GROUP_B = "239.77.0.2";
-    const int PORT_UNI  = 57110;
-    const int PORT_MC   = 57111;  // joined receiver
+    static const int UNI_PORTS[4] = { 17110, 18110, 19110, 27110 };
+    static const int MC_PORTS[4]  = { 17111, 18111, 19111, 27111 };  // joined receiver
 
     // Outgoing multicast interface. macOS CI runners have no multicast route on
     // the default NIC (send -> EHOSTUNREACH), but lo0 is multicast-capable, so
@@ -91,13 +115,14 @@ int main() {
     // ----- 1. unicast loopback (baseline) ------------------------------------
     {
         OscReceiver rx;
-        bool bound = rx.setup(PORT_UNI);
-        check("unicast: receiver bound", bound);
+        const int portUni = bindFirstFree(rx, UNI_PORTS);
+        check("unicast: receiver bound", portUni != 0);
+        if (portUni) std::printf("  (unicast port %d)\n", portUni);
 
         OscMessage m("/uni");
         m.addInt(42);
         OscMessage got;
-        bool ok = sendAndRecv(rx, tx, "127.0.0.1", PORT_UNI, m, got) == Recv::Received;
+        bool ok = sendAndRecv(rx, tx, "127.0.0.1", portUni, m, got) == Recv::Received;
         check("unicast: message received", ok);
         check("unicast: address == /uni", ok && got.getAddress() == "/uni");
         check("unicast: arg == 42", ok && got.getArgCount() == 1 && got.getArgAsInt(0) == 42);
@@ -110,14 +135,16 @@ int main() {
     // IS routable (Linux/Windows CI, local macOS), which is the real coverage.
     {
         OscReceiver rx;
-        check("multicast: receiver bound", rx.setup(PORT_MC));
+        const int portMc = bindFirstFree(rx, MC_PORTS);
+        check("multicast: receiver bound", portMc != 0);
+        if (portMc) std::printf("  (multicast port %d)\n", portMc);
         check("multicast: joinMulticast(A)", rx.joinMulticast(GROUP_A, MIF));
         sleepMs(100);  // let the join settle
 
         OscMessage m("/mc");
         m.addInt(7);
         OscMessage got;
-        Recv r = sendAndRecv(rx, tx, GROUP_A, PORT_MC, m, got);
+        Recv r = sendAndRecv(rx, tx, GROUP_A, portMc, m, got);
         if (r == Recv::Unroutable) {
             std::printf("%-56s %s\n", "multicast: SKIPPED (no multicast route on this host)", "SKIP");
             std::fflush(stdout);
@@ -136,7 +163,7 @@ int main() {
             OscMessage mb("/other");
             mb.addInt(99);
             check("scoping: unjoined group's traffic does not reach the receiver",
-                  sendAndExpectNone(rx, tx, GROUP_B, PORT_MC, mb) == Recv::NotReceived);
+                  sendAndExpectNone(rx, tx, GROUP_B, portMc, mb) == Recv::NotReceived);
         }
         rx.close();
     }

--- a/tools/build_win.bat
+++ b/tools/build_win.bat
@@ -30,17 +30,36 @@ REM Setup Visual Studio environment
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set VS_PATH=%%i
 if defined VS_PATH call "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
 
-REM A leftover CMakeCache.txt from a previous run with a different generator
-REM (e.g. a Visual Studio generator from before this Ninja switch, or a CI
-REM cache) makes -G Ninja abort with a generator-mismatch error. Wipe the
-REM cache when it doesn't already record Ninja so the switch is seamless.
-if exist "CMakeCache.txt" (
-    findstr /C:"CMAKE_GENERATOR:INTERNAL=Ninja" "CMakeCache.txt" >nul 2>&1
-    if errorlevel 1 (
-        echo Different CMake generator found in cache, cleaning...
-        del /q "CMakeCache.txt"
-        if exist "CMakeFiles" rmdir /s /q "CMakeFiles"
-    )
+REM A leftover CMakeCache.txt can be stale in two different ways, and BOTH
+REM abort the configure below with an error that never names the cache:
+REM
+REM  1. It records a different generator (e.g. a Visual Studio generator from
+REM     before this Ninja switch) -> -G Ninja fails on a generator mismatch.
+REM  2. It records an absolute compiler path that no longer exists. This is
+REM     what upgrading Visual Studio does: the cache still points at, say,
+REM     .../Visual Studio/2022/.../cl.exe while only VS2026 is installed, and
+REM     CMake fails with "is not a full path to an existing compiler tool".
+REM     CI hits the same thing whenever the hosted runner image moves to a
+REM     newer VS while the restored build-directory cache does not.
+REM
+REM Wipe the cache in either case so the switch is seamless. Written without
+REM delayed expansion: every value is read on a later line than it is set.
+set "CACHE_CLEAN_REASON="
+if not exist "CMakeCache.txt" goto cache_checked
+
+findstr /C:"CMAKE_GENERATOR:INTERNAL=Ninja" "CMakeCache.txt" >nul 2>&1
+if errorlevel 1 set "CACHE_CLEAN_REASON=generator changed"
+
+set "CACHED_CXX="
+for /f "usebackq tokens=1,* delims==" %%i in (`findstr /b /c:"CMAKE_CXX_COMPILER:FILEPATH=" "CMakeCache.txt"`) do set "CACHED_CXX=%%j"
+if defined CACHED_CXX set "CACHED_CXX=%CACHED_CXX:/=\%"
+if defined CACHED_CXX if not exist "%CACHED_CXX%" set "CACHE_CLEAN_REASON=recorded compiler no longer exists"
+
+:cache_checked
+if defined CACHE_CLEAN_REASON (
+    echo Stale CMake cache ^(%CACHE_CLEAN_REASON%^), cleaning...
+    del /q "CMakeCache.txt"
+    if exist "CMakeFiles" rmdir /s /q "CMakeFiles"
 )
 
 REM CMake configuration. Force the Ninja generator: without -G, CMake defaults


### PR DESCRIPTION

## Why

Windows CI has been pinned to `windows-2022` since June. The pin's comment said
`projectGenerator`'s VS-project generation falls back to the "Visual Studio 17
2022" generator and fails on a VS2026 runner, and to revert "once
projectGenerator supports VS2026".

That reason does not hold, on two counts:

- **This job never runs that code path.** Windows builds go through
  `tools/build_win.bat` (which forces `-G Ninja`) and `examples/build_all.py`.
  `generateVisualStudioProject()` is only called when the project's IDE type is
  Visual Studio, which CI never selects.
- **VsDetector has mapped VS18 to "2026" since `f7810df0` (2026-04-17)** — two
  months *before* the pin was added. The generator name was never the problem.

So the pin was reverted and CI was run to find out what actually breaks. It
found two real bugs, one of which is not a CI problem at all.

## 1. A stale CMake cache is not detected when only the compiler moved

`build_win.bat` wiped a leftover `CMakeCache.txt` only when it recorded a
different *generator*. A cache also goes stale when it records an absolute
compiler path that has since disappeared — which is exactly what **upgrading
Visual Studio** does. The cache still points at
`.../Visual Studio/2022/.../cl.exe` while only VS2026 is installed, the
generator still reads `Ninja` so the old guard kept the cache, and configure
dies with:

```
The CMAKE_CXX_COMPILER:
    C:/Program Files/Microsoft Visual Studio/2022/Enterprise/.../cl.exe
  is not a full path to an existing compiler tool.
```

which names the compiler but never the cache. The only cure was deleting the
build directory by hand.

CI hit the identical failure from the other direction: the build-directory
cache is keyed on `runner.os` — `"Windows"` for both `windows-2022` and
`windows-latest` — so a cache saved on a VS2022 image is restored onto a VS2026
runner. **This is very likely what the June pin was actually working around.**

The guard now also wipes when the recorded `CMAKE_CXX_COMPILER` no longer
exists. The local Visual Studio upgrade case is the reason this is worth
fixing; CI is the reason it was found.

## 2. The tcxOsc test hardcoded ports inside the Windows dynamic range

The OSC test bound `57110` / `57111` unconditionally. Those sit inside the
Windows dynamic port range (49152+), where Hyper-V / WSL / Docker reserve
blocks; a bind landing in a reserved block fails with `WSAEACCES` (10013). That
took out 8 of the test's 10 assertions on `windows-latest` while every other
platform passed.

The receiver now takes the first of four candidate ports that actually binds.
The candidates sit below 49152, outside the dynamic range entirely, and trying
several also survives an ordinary collision. They deliberately avoid 9000/9001:
the tcxOsc examples bind those, and 9000 is about the most common OSC port
there is — the least safe number to pick on a machine that does OSC work.

## Verification

CI is green on macOS, Linux, Windows, iOS, Android and Web.

The Windows work was also checked on real hardware with VS2026 (18.3.2 RTW) and
VS2022 installed side by side:

- plain `build_win.bat` under VS2026 builds trusscli 36/36, `trusscli doctor`
  clean — VS2026 itself was never the problem
- the patched script run against a **valid** cache leaves `CMakeCache.txt`
  byte-identical (same md5) and builds in 25s, so incremental builds are not
  silently destroyed by a false positive
- eight synthetic caches in an isolated directory: valid kept (including paths
  with spaces and parentheses), missing-compiler wiped, changed generator wiped,
  absent cache a no-op, `CMAKE_CXX_COMPILER_AR`/`_RANLIB` decoys ignored, CRLF
  parsed correctly (a stray `\r` would have made every build reconfigure)
- a `.bat` keeps running past a syntax error and still exits 0, so the keep path
  was verified positively: the guard's echo does not appear, `-- Configuring
  done (0.1s)`, and none of the compiler-redetection lines print — proving the
  cache was really reused rather than the guard being skipped

The OSC change was verified on macOS: 10/10 on the first candidate, and with
17110 held by an exclusive binder it falls through to 18110 and still passes
10/10 — so the retry is live, not dead code.

## Not included

- The generator check uses `findstr /C:` without `/b`, so `Ninja Multi-Config`
  substring-matches `Ninja` and is kept. Harmless (CMake catches the mismatch)
  but asymmetric with the `/b` compiler check.
- CI's Windows branch calls `./tools/build_win.bat` raw, while mac/linux `sed`
  out their GUI-launch line first. `start "" trusscli.exe` holds the inherited
  stdout handle, so a caller capturing output never sees EOF. Benign on the
  runner today (no desktop session), but a latent hang.
- The cache key could use `matrix.os` instead of `runner.os` so a runner-image
  change gets a fresh cache. An optimization now that the guard handles the
  correctness side.
