### PR TITLE
AudioSettings defaults to the engine's sample rate instead of 96 kHz

### DIFF
--- a/core/include/tc/sound/tcSound.h
+++ b/core/include/tc/sound/tcSound.h
@@ -600,7 +600,8 @@ struct PlayingSound {
 // Use AudioEngine::listDevices() to enumerate available device names.
 // ---------------------------------------------------------------------------
 struct AudioSettings {
-    int sampleRate   = 96000;   // engine output sample rate (Hz)
+    int sampleRate   = 0;       // engine output sample rate (Hz);
+                                // 0 = AudioEngine::DEFAULT_SAMPLE_RATE (48 kHz)
     int channels     = 2;       // engine output channel count (1 = mono, 2 = stereo)
     int bufferSize   = 0;       // requested device buffer size in frames; 0 = let miniaudio choose
     int maxPolyphony = 32;      // max simultaneously-playing Sound voices
@@ -1432,7 +1433,7 @@ inline size_t getAudioAnalysisBuffer(float* outBuffer, size_t numSamples) {
 class MicInput {
 public:
     static constexpr int BUFFER_SIZE = 4096;  // Ring buffer size
-    static constexpr int DEFAULT_SAMPLE_RATE = 44100;
+    static constexpr int DEFAULT_SAMPLE_RATE = 48000;  // match AudioEngine::DEFAULT_SAMPLE_RATE
 
     MicInput() = default;
     ~MicInput();

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -471,9 +471,9 @@ description.ja = "同時再生可能な Sound ボイスの最大数 (デフォ�
 description.ko = "동시 재생 가능한 Sound 보이스 최대 수 (기본값 32)"
 
 ["AudioSettings::sampleRate"]
-description.en = "Engine output sample rate in Hz (default 96000)"
-description.ja = "エンジン出力サンプルレート (Hz、デフォルト 96000)"
-description.ko = "엔진 출력 샘플레이트 (Hz, 기본값 96000)"
+description.en = "Engine output sample rate in Hz (0 = the engine default, 48000)"
+description.ja = "エンジン出力サンプルレート (Hz、0 = エンジンのデフォルト 48000)"
+description.ko = "엔진 출력 샘플레이트 (Hz, 0 = 엔진 기본값 48000)"
 
 ["AxisMode"]
 description.en = "Layout axis sizing: None (fixed), Fill (expand to the parent), Content (fit children)."


### PR DESCRIPTION
## What

`AudioEngine::DEFAULT_SAMPLE_RATE` has been 48000 since v0.6.0, and that
release announced the change:

> オーディオのデフォルトサンプルレートが **96kHz → 48kHz** に変わりました。
> 今まで通り96kにしたい場合は `AudioEngine::init(AudioSettings{ .sampleRate = 96000 })`
> で指定してください。

But `AudioSettings::sampleRate` itself still defaulted to `96000`, so the two
entry points disagreed:

```cpp
engine.init();                 // -> 48000  (runtime field, DEFAULT_SAMPLE_RATE)
engine.init(AudioSettings{});  // -> 96000  (struct member default)
```

Anyone who passed an explicit `AudioSettings` — to select a device or a channel
count, say — silently got 96 kHz, which is the opposite of what v0.6.0 said. The
comment sitting directly above `DEFAULT_SAMPLE_RATE` ("Use
`init({.sampleRate = 96000})` to opt into a higher rate when needed") only reads
correctly once this is fixed.

## The fix

`AudioSettings::sampleRate` now defaults to `0`, meaning "use the engine
default". That is:

- the idiom `AudioSettings::bufferSize` already uses in the same struct
  (`0 = let miniaudio choose`), and
- what `init()` already resolved anyway
  (`settings.sampleRate > 0 ? settings.sampleRate : DEFAULT_SAMPLE_RATE`).

Writing `48000` in the struct would have worked too, but keeping the number in
one place is the point here — two copies of the same constant are exactly what
drifted apart.

`MicInput::DEFAULT_SAMPLE_RATE` follows the engine at 48000 as well. It was
still 44100 — a third value for the same concept in one header. Mic capture
opens its own device, so nothing else depended on the old number.

## Compatibility

This changes behavior, and the compiler will not tell anyone:

- `init()` — unchanged, still 48 kHz.
- `init(AudioSettings{...})` **without** an explicit `sampleRate` — was 96 kHz,
  now 48 kHz. This is the bug being fixed, but an app that had adapted to the
  96 kHz it was actually getting will now run at 48 kHz.
- `init({.sampleRate = 96000})` — unchanged, still 96 kHz. This is the
  documented way to ask for it, and it keeps working.
- `MicInput::start()` with no argument — was 44.1 kHz, now 48 kHz. Pass an
  explicit rate to keep 44100.

Worth a line in the release notes: anyone who followed the v0.6.0 guidance and
wrote an explicit `AudioSettings` was on 96 kHz without knowing it, so "why did
my sample rate change?" has a real answer rather than looking like a regression.

## Verification

- `soundPlayerExample` on macOS logs
  `AudioEngine: initialized (48000 Hz, 2 ch, 32 voices)` — previously 96000 via
  the same path.
- `docs/reference/check.js --strict` clean; the en/ja/ko prose for
  `AudioSettings::sampleRate` was updated to describe `0` rather than 96000.
- CI green on macOS, Linux, Windows, iOS, Android and Web.
