### PR TITLE
fix(docs): index templated members, which the AST walk was skipping

### DIFF
--- a/core/include/tc/graphics/tcFont.h
+++ b/core/include/tc/graphics/tcFont.h
@@ -1112,6 +1112,7 @@ public:
     }
     bool getMipmaps() const { return mipmaps_; }
 
+private:
     // Apply an atlas-option change to the cache key and swap in the atlas it
     // now names. Called from the option setters so they are order-independent:
     // a setter that only takes effect when it precedes load() is the kind of

--- a/docs/FOR_AI_ASSISTANT.md
+++ b/docs/FOR_AI_ASSISTANT.md
@@ -2661,6 +2661,7 @@ std::string Font::wrapTextVertical(const std::string & text) const  // Insert ha
 sg_pipeline_desc FullscreenShader::createPipelineDesc()  // Build the fullscreen-quad pipeline descriptor (overrides Shader's).
 void FullscreenShader::createVertexBuffer()  // Create the fullscreen-quad vertex/index buffers (overrides Shader's).
 void FullscreenShader::draw()  // Draw a fullscreen quad with this shader applied
+void FullscreenShader::setParams(const T & params)  // Set the uniform block for the fullscreen pass; call before draw (C++ only)
 ```
 
 ### GrabberFrame — One captured camera frame with its capture-time timestamp: Pixels (RGBA8) plus timestampUs (monotonic steady_clock microseconds, stamped on the capture thread). Returned by VideoGrabber::getQueuedFrames(). Pixels and timestamp travel together so there is no race between reading the pixels and reading the time
@@ -3129,6 +3130,7 @@ Node * Node::findByInstanceId(uint64_t id)  // Find a node in this subtree (self
 HitResult Node::findHitNode(const Ray & globalRay)  // Hit test the whole tree with a global ray, returning the frontmost node (C++ only)
 HitResult Node::findHitNodeFromScreen(float screenX, float screenY)  // Hit test the whole tree from a screen point, using each node's own camera context (C++ only)
 HitResult Node::findHitNodeRecursive(internal::PickRaySource & pick, const CameraContext * inheritedCtx, Ray globalRay, const Mat4 & parentInverseMatrix)  // Recursive hit test in reverse draw order; override for clipping-aware picking.
+T * Node::addMod(Args &&... args)  // Attach a mod of type T to this node, forwarding any arguments to its constructor; returns the mod for chaining (C++ only)
 bool Node::getActive() const ⚠️deprecated  // Deprecated alias for isActive()
 std::shared_ptr<const CameraContext> Node::getCameraContext() const  // Return the camera context this node was last drawn under (null if never drawn).
 size_t Node::getChildCount() const  // Get the number of child nodes (C++ only)
@@ -3143,6 +3145,7 @@ Vec3 Node::getGlobalPos() const  // Get the node's origin in global (world) spac
 uint64_t Node::getInstanceId() const  // Per-process unique id, assigned once at construction and stable across reparenting (C++ only)
 const Mat4 & Node::getLocalMatrix() const  // Get this node's local transform matrix (cached) (C++ only)
 Mod * Node::getModByTypeName(const std::string & name) const  // Find an attached mod by its short type name, e.g. "LayoutMod" (null if not attached) (C++ only) 
+T * Node::getMod()  // Get the attached mod of type T, or nullptr if this node has none (C++ only)
 std::vector<Mod *> Node::getMods() const  // Get all attached mods (pointers stay owned by this node) (C++ only)
 std::vector<std::string> Node::getModTypeNames() const  // Get the short (unqualified) type names of the attached mods (C++ only)
 float Node::getMouseX() const  // Get mouse X in this node's local coordinate system (C++ only)
@@ -3165,6 +3168,7 @@ float Node::getX() const  // Get local X position (C++ only)
 float Node::getY() const  // Get local Y position (C++ only)
 float Node::getZ() const  // Get local Z position (C++ only)
 Vec3 Node::globalToLocal(const Vec3 & global) const [+1] ⚠️deprecated  // Convert a global coordinate to this node's local space (C++ only)
+bool Node::hasMod() const  // Whether a mod of type T is attached to this node (C++ only)
 bool Node::hasName() const  // Whether an instance name has been set (C++ only)
 bool Node::hitTest(const Ray & localRay, float & outDistance) [+1]  // Geometric hit-test predicate in local space; override to make a node pickable.
 int Node::indexOfChild(const Node * child) const  // Index of the given child among this node's children (-1 if not a child) (C++ only)
@@ -3192,6 +3196,7 @@ bool Node::onMouseRelease(const MouseEventArgs & e) [+1]  // Handle a mouse rele
 bool Node::onMouseScroll(const ScrollEventArgs & e) [+1]  // Handle a scroll event (event localized to this node); return true to consume.
 void Node::onVisibleChanged(bool visible)  // Callback invoked when the node's visible state changes.
 void Node::processTimers()  // Process due timers (callAfter / callEvery), invoked within the update pass.
+void Node::removeMod()  // Remove the attached mod of type T, calling its onDestroy() before it is freed (C++ only)
 void Node::removeAllChildren()  // Remove all child nodes (C++ only)
 void Node::removeChild(Ptr child)  // Remove a child node (C++ only)
 std::pair<const CameraContext *, Ray> Node::resolvePickRay(internal::PickRaySource & pick, const CameraContext * inheritedCtx, const Ray & globalRay) const  // Resolve this node's effective camera context and the global ray to hit-test it with.

--- a/docs/reference/api-reference.toml
+++ b/docs/reference/api-reference.toml
@@ -2595,6 +2595,13 @@ description.en = "Draw a fullscreen quad with this shader applied"
 description.ja = "この Shader を適用してフルスクリーンクアッドを描画"
 description.ko = "이 Shader를 적용하여 전체 화면 쿼드를 그리기"
 
+["FullscreenShader::setParams"]
+keywords = ["uniform", "params", "postprocess", "shader"]
+description.en = "Set the uniform block for the fullscreen pass; call before draw (C++ only)"
+description.ja = "フルスクリーンパスの uniform ブロックを設定する。draw の前に呼ぶ（C++のみ）"
+description.ko = "전체 화면 패스의 uniform 블록을 설정. draw 전에 호출 (C++ 전용)"
+related = ["FullscreenShader", "FullscreenShader::draw", "Shader::setUniform"]
+
 ["GraphicsBackend"]
 keywords = ["renderer", "metal", "opengl", "d3d11", "webgpu", "gpu api"]
 description.en = "Runtime sokol_gfx backend query. Values are meaningful only after sg_setup() has completed (i.e. after the first setup() call)."
@@ -5329,6 +5336,15 @@ description.ja = "スクリーン座標からツリー全体をヒットテス�
 description.ko = "스크린 좌표에서 트리 전체를 히트 테스트 (각 노드 자신의 카메라 컨텍스트 사용) (C++ 전용)"
 related = ["Node::findHitNode"]
 
+["Node::addMod"]
+category = "scene_graph"
+keywords = ["behaviors", "components", "attach", "mod"]
+description.en = "Attach a mod of type T to this node, forwarding any arguments to its constructor; returns the mod for chaining (C++ only)"
+description.ja = "型 T の Mod をこのノードにアタッチする。引数はコンストラクタにそのまま渡され、Mod のポインタを返すので続けて設定できる（C++のみ）"
+description.ko = "타입 T의 모드를 이 노드에 부착하고 인자를 생성자로 전달. 모드 포인터를 반환하므로 체이닝 가능 (C++ 전용)"
+related = ["Node::getMod", "Node::hasMod", "Node::removeMod", "Mod"]
+details = "setup() runs after the mod is attached and its owner is set, so a mod may call getMod() / addChild() on its owner from inside setup(). Main thread only."
+
 ["Node::getActive"]
 category = "scene_graph"
 keywords = ["deprecated", "alias", "state"]
@@ -5452,6 +5468,14 @@ description.en = "Get the short (unqualified) type names of the attached mods (C
 description.ja = "アタッチされたModの短い（非修飾）型名を取得（C++のみ）"
 description.ko = "부착된 모드의 짧은(비수식) 타입 이름을 얻음 (C++ 전용)"
 related = ["Node::getMods", "Node::getModByTypeName"]
+
+["Node::getMod"]
+category = "scene_graph"
+keywords = ["behaviors", "components", "find", "mod"]
+description.en = "Get the attached mod of type T, or nullptr if this node has none (C++ only)"
+description.ja = "型 T のアタッチ済み Mod を取得する。無ければ nullptr（C++のみ）"
+description.ko = "타입 T의 부착된 모드를 얻음. 없으면 nullptr (C++ 전용)"
+related = ["Node::addMod", "Node::hasMod", "Node::getModByTypeName"]
 
 ["Node::getMods"]
 category = "scene_graph"
@@ -5629,6 +5653,14 @@ description.ko = "글로벌 좌표를 이 노드의 로컬 공간으로 변환 (
 details = "The out-parameter overload; new code should use `globalToLocal(Vec3)`. Scheduled for removal in v1.0.0."
 related = ["Node::localToGlobal", "Node::getGlobalMatrixInverse"]
 
+["Node::hasMod"]
+category = "scene_graph"
+keywords = ["behaviors", "components", "query", "mod"]
+description.en = "Whether a mod of type T is attached to this node (C++ only)"
+description.ja = "型 T の Mod がこのノードにアタッチされているか（C++のみ）"
+description.ko = "타입 T의 모드가 이 노드에 부착되어 있는지 여부 (C++ 전용)"
+related = ["Node::addMod", "Node::getMod", "Node::removeMod"]
+
 ["Node::hasName"]
 category = "scene_graph"
 keywords = ["named", "identity"]
@@ -5730,6 +5762,15 @@ description.en = "Callback fired when a child is removed (overridable) (C++ only
 description.ja = "子が削除されたときに呼ばれるコールバック（オーバーライド可能）（C++のみ）"
 description.ko = "자식이 제거될 때 호출되는 콜백 (오버라이드 가능) (C++ 전용)"
 related = ["Node::removeChild", "Node::onChildAdded"]
+
+["Node::removeMod"]
+category = "scene_graph"
+keywords = ["behaviors", "components", "detach", "mod"]
+description.en = "Remove the attached mod of type T, calling its onDestroy() before it is freed (C++ only)"
+description.ja = "型 T の Mod を取り外す。解放前に onDestroy() が呼ばれる（C++のみ）"
+description.ko = "타입 T의 모드를 제거. 해제 전에 onDestroy()가 호출됨 (C++ 전용)"
+related = ["Node::addMod", "Node::hasMod", "Mod"]
+details = "Removing a mod during a dispatch or update defers the destruction until iteration finishes, so the call in flight cannot dangle. A mod can remove itself without naming its type via Mod::removeSelf()."
 
 ["Node::removeAllChildren"]
 category = "scene_graph"

--- a/docs/reference/structure.js
+++ b/docs/reference/structure.js
@@ -227,6 +227,16 @@ function enumerate(objs) {
                 const flags = [/operator/.test(m.name || '') ? 'operator' : null, m.storageClass === 'static' ? 'static' : null,
                     m.isImplicit ? 'implicit' : null, m.explicitlyDeleted ? 'deleted' : null, m.explicitlyDefaulted ? 'defaulted' : null].filter(Boolean);
                 syms.push({ kind: 'method', ns: nsPath, owner: qn, name: m.name, sig: m.type && m.type.qualType, params: paramsOf(m), args: argsOf(m), file: fileOf(m), access, flags: [...(extraFlags || []), ...flags], ann: annotationsOf(m, fileOf(m)), deprecated: deprecatedOf(m) });
+            } else if (m.kind === 'FunctionTemplateDecl' && m.name) {
+                // A templated member (ToolBuilder::arg<T>, Node::getMod<T>) is a
+                // FunctionTemplateDecl wrapping the method, so the CXXMethodDecl
+                // branch above never sees it. Read the wrapped decl the way the
+                // namespace-level branch below does, and flag it 'template' so
+                // the binders skip it — every consumer already filters sig.tmpl.
+                const fn = (m.inner || []).find(x => x.kind === 'CXXMethodDecl' || x.kind === 'FunctionDecl');
+                if (fn) syms.push({ kind: 'method', ns: nsPath, owner: qn, name: m.name, sig: fn.type && fn.type.qualType, params: paramsOf(fn), args: argsOf(fn), file: fileOf(m), access,
+                    flags: [...(extraFlags || []), 'template', /operator/.test(m.name) ? 'operator' : null, fn.storageClass === 'static' ? 'static' : null].filter(Boolean),
+                    ann: annotationsOf(fn, fileOf(m)), deprecated: deprecatedOf(fn) });
             } else if (m.kind === 'FieldDecl') {
                 syms.push({ kind: 'field', ns: nsPath, owner: qn, name: m.name, ftype: m.type && m.type.qualType, file: fileOf(m), access, flags: [], deprecated: deprecatedOf(m) });
             } else if (m.kind === 'EnumDecl' && m.name) {
@@ -275,9 +285,14 @@ const noise = (s) => (s.flags || []).some(f => ['implicit', 'defaulted', 'delete
 function symbolId(s) {
     const pre = nsPrefix(s); const q = (n) => pre ? pre + '::' + n : n;
     switch (s.kind) {
-        case 'method': case 'field': return s.owner + '::' + s.name;
-        case 'enum': return s.owner ? s.owner + '::' + s.name : q(s.name);
-        case 'type': { const b = s.owner ? s.owner + '::' + s.name : q(s.name); return s.tparams && s.tparams.length ? `${b}<${s.tparams.join(', ')}>` : b; }
+        // Members are qualified like everything else: a type in a sub-namespace
+        // would otherwise be `mcp::ToolBuilder` while its own method is a bare
+        // `ToolBuilder::arg`, and generic member names (`Tool::name`) would read
+        // as top-level ids. No visible symbol sits in a sub-namespace today, so
+        // this leaves every current id byte-identical.
+        case 'method': case 'field': return q(s.owner + '::' + s.name);
+        case 'enum': return s.owner ? q(s.owner + '::' + s.name) : q(s.name);
+        case 'type': { const b = s.owner ? q(s.owner + '::' + s.name) : q(s.name); return s.tparams && s.tparams.length ? `${b}<${s.tparams.join(', ')}>` : b; }
         case 'func': case 'var': case 'typedef': return q(s.name);
         default: return null;
     }


### PR DESCRIPTION
## What

`docs/reference/structure.js` walks a record's members looking for `CXXMethodDecl`. A templated member is a `FunctionTemplateDecl` wrapping the method, so the walk saw none of them — and every derived artifact inherited the gap.

The most visible casualty: **Node's entire Mod API has never appeared in the reference.**

```cpp
node->addMod<DraggableMod>();      // the documented way to attach behaviour
node->getMod<LayoutMod>();
node->hasMod<TweenMod>();
node->removeMod<LayoutMod>();
```

Not on trussc.org, not in `FOR_AI_ASSISTANT.md`, despite being used throughout the examples and addons.

## How

Read the wrapped decl the way the namespace-level branch already does, and flag it `'template'` so `tmpl` is set on the signature.

Seven symbols surface:

| symbol | disposition |
|---|---|
| `Node::addMod` / `getMod` / `hasMod` / `removeMod` | documented (public API that was missing) |
| `FullscreenShader::setParams` | documented |
| `FileWriter::operator<<` | exempt from the undocumented gate as an operator |
| `Font::reresolveAtlas` | **not API** — moved to `private:` |

`Font::reresolveAtlas` sat between two `public:` markers and was public by accident. It is a helper the option setters call so they are order-independent; nothing outside `Font` references it.

## Member ids now carry their namespace

`symbolId()` did not qualify `method` / `field`. A type in a sub-namespace would be `mcp::ToolBuilder` while its own method was a bare `ToolBuilder::arg`, and generic member names like `Tool::name` would read as top-level ids.

**This is a no-op today.** No visible symbol sits in a sub-namespace, so the id set is unchanged — verified by diffing `structure.js --ids` before and after: the only differences are the seven additions above, and nothing was removed. It is fixed here because it belongs to the id grammar, and because the alternative is discovering it later while changing something else.

## No bindings change

Every downstream consumer already filters on `tmpl` — `luagen`, `luagen-types`, `emit-sketch-api`, `emit-sketch-reference`, `implicit-conv-audit`. Regenerating the Lua bindings against the new data produces an **identical binding set** (compared as whole assignment statements, type qualification included). `addons/tcxLua/src/generated/` is therefore untouched.

## Verification

```
node docs/reference/check.js --strict
  AST symbols  : 2481
  dup          : OK
  undocumented : 0 / 2481  ✓
```

Built and ran the core test suite (7/7 project + 1/1 unit) after the `Font` change.

Two orphans (`VideoWriter::lockFrame` / `submitFrame`) appear when the check runs on Linux and not on macOS — they live inside `#if TC_ASYNC_SCREEN_CAPTURE`. Pre-existing on `main` and unrelated to this change.

`FOR_AI_ASSISTANT.md` was hand-edited rather than regenerated, for the same reason: regenerating it on Linux would drop those two macOS-only symbols from the index. The five added lines match what `emit-forai.js` renders (signature taken from the generated `reference-data.json`, alphabetical position preserved).

## Not in this PR

The `emit-web.js` / `emit-forai.js` changes needed to *display* sub-namespaced symbols. They are dead code until something actually lives in a sub-namespace, so they belong with the change that puts something there — exposing `mcp::`, which is the follow-up.
