### PR TITLE
fix: stop six log lines garbling paths on Windows

### DIFF
--- a/core/include/tc/sound/tcAudio_impl.cpp
+++ b/core/include/tc/sound/tcAudio_impl.cpp
@@ -375,7 +375,7 @@ std::shared_ptr<PlayingSound> AudioEngine::play(std::shared_ptr<SoundSource> sou
             // behavior.
             printf("SoundStream: maxPolyphony=%d reached for %s — "
                    "stop a previous instance or raise maxPolyphony\n",
-                   s->getMaxPolyphony(), s->getPath().c_str());
+                   s->getMaxPolyphony(), internal::pathToUtf8(s->getPath()).c_str());
             return nullptr;
         }
 
@@ -387,7 +387,7 @@ std::shared_ptr<PlayingSound> AudioEngine::play(std::shared_ptr<SoundSource> sou
         ma_result r = maDecoderInitPathA(s->path_, &cfg, &stream->decoder);
         if (r != MA_SUCCESS) {
             printf("SoundStream: per-voice decoder init failed for %s (result=%d)\n",
-                   s->getPath().c_str(), (int)r);
+                   internal::pathToUtf8(s->getPath()).c_str(), (int)r);
             return nullptr;
         }
         stream->decoderInitialized = true;
@@ -826,7 +826,7 @@ void AudioEngine::migrateVoicesToNewRate(int oldRate, int newRate) {
             ma_result r = maDecoderInitPathA(src->path_, &cfg, &newStream->decoder);
             if (r != MA_SUCCESS) {
                 printf("AudioEngine: stream voice migration failed for %s (result=%d) — stopping voice\n",
-                       src->getPath().c_str(), (int)r);
+                       internal::pathToUtf8(src->getPath()).c_str(), (int)r);
                 slot->playing = false;
                 // Drop the stale stream so its old decoder is destroyed.
                 slot->stream.reset();

--- a/core/platform/win/tcSound_win.cpp
+++ b/core/platform/win/tcSound_win.cpp
@@ -148,7 +148,8 @@ LoadResult SoundBuffer::loadAac(const fs::path& path) {
     HRESULT hr = MFCreateSourceReaderFromURL(wpath.c_str(), NULL, &pReader);
 
     if (FAILED(hr)) {
-        printf("SoundBuffer: loadAac failed to open %s (0x%08X)\n", path.c_str(), hr);
+        printf("SoundBuffer: loadAac failed to open %s (0x%08X)\n",
+               internal::pathToUtf8(path).c_str(), hr);
         char hrBuf[16];
         snprintf(hrBuf, sizeof(hrBuf), "0x%08X", (unsigned)hr);
         return LoadResult::fail(LoadError::DecodeFailed,
@@ -161,9 +162,10 @@ LoadResult SoundBuffer::loadAac(const fs::path& path) {
 
     if (result) {
         printf("SoundBuffer: loaded AAC %s (%d ch, %d Hz, %zu samples)\n",
-               path.c_str(), (int)channels, (int)sampleRate, (size_t)numSamples);
+               internal::pathToUtf8(path).c_str(), (int)channels, (int)sampleRate,
+               (size_t)numSamples);
     } else {
-        printf("SoundBuffer: failed to decode AAC %s\n", path.c_str());
+        printf("SoundBuffer: failed to decode AAC %s\n", internal::pathToUtf8(path).c_str());
     }
 
     return result ? LoadResult::success()


### PR DESCRIPTION
Six log lines format an `fs::path` through `printf`'s `%s`. On Windows
`path::value_type` is `wchar_t`, so `c_str()` hands a wide string to a
conversion expecting narrow — the path prints as mojibake, and any argument
after it in the same call is read off the wrong stack offset.

MSVC has been saying so all along: these six sites are the *only* source of
C4477 in the build.

## The fix

Route them through `internal::pathToUtf8()`, the boundary helper in
`tc/utils/tcFileIO.h`. This is not a new convention — both files already use
it at six *other* call sites; these are the ones that were missed. No include
had to be added to either file.

Nothing changes on macOS or Linux, where the helper is `p.string()` and
`value_type` is `char` already.

## Verification

C4477 occurrences in the Windows CI log:

| run | commit | C4477 |
|---|---|---|
| 33832776033 | before | 156 |
| 33849546270 | before | 156 |
| 33872598552 | this branch | **0** |

Counted with `grep -ac C4477` over the downloaded log, so the "0" is measured
against a known-non-zero baseline rather than asserted. (156 rather than 6
because the header sites expand into several translation units.)

All 9 CI jobs green.

## Not in scope

Three more `printf("%s", path.c_str())` sites exist on the non-Windows
backends — `tcSound_web.cpp:123`, `tcSound_ios.mm:75`, `tcSound_mac.mm:74`.
They are not bugs there (`value_type` is `char`), so they are left alone, but
they are the copy-paste source this class of bug keeps coming from.

Closes #216.
